### PR TITLE
Add photography CRM dashboard scaffolding

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/crm/BookingList.tsx
+++ b/src/components/crm/BookingList.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+
+import StatusPill, { StatusTone } from './StatusPill';
+
+export type BookingStatus = 'Confirmed' | 'Pending' | 'Editing';
+
+export type BookingRecord = {
+    id: string;
+    client: string;
+    shootType: string;
+    date: string;
+    startTime: string;
+    endTime?: string;
+    location: string;
+    status: BookingStatus;
+};
+
+const statusToneMap: Record<BookingStatus, StatusTone> = {
+    Confirmed: 'success',
+    Pending: 'warning',
+    Editing: 'info'
+};
+
+const formatDate = (value: string) => dayjs(value).format('ddd, MMM D');
+
+export function BookingList({ bookings }: { bookings: BookingRecord[] }) {
+    return (
+        <ol className="relative space-y-6 border-l border-slate-200 pl-6">
+            {bookings.map((booking) => (
+                <li key={booking.id} className="relative">
+                    <span className="absolute -left-3 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-indigo-500">
+                        •
+                    </span>
+                    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <p className="text-sm font-medium text-indigo-600">{formatDate(booking.date)}</p>
+                                <h3 className="text-lg font-semibold text-slate-900">{booking.client}</h3>
+                                <p className="text-sm text-slate-500">{booking.shootType}</p>
+                            </div>
+                            <div className="text-right text-sm text-slate-500">
+                                <p>
+                                    {booking.startTime}
+                                    {booking.endTime ? ` – ${booking.endTime}` : ''}
+                                </p>
+                                <p>{booking.location}</p>
+                            </div>
+                        </div>
+                        <div className="mt-3">
+                            <StatusPill tone={statusToneMap[booking.status]}>{booking.status}</StatusPill>
+                        </div>
+                    </div>
+                </li>
+            ))}
+        </ol>
+    );
+}
+
+export default BookingList;

--- a/src/components/crm/ClientTable.tsx
+++ b/src/components/crm/ClientTable.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+
+import StatusPill, { StatusTone } from './StatusPill';
+
+export type ClientStatus = 'Active' | 'Lead' | 'Archived';
+
+export type ClientRecord = {
+    id: string;
+    name: string;
+    company?: string;
+    email: string;
+    phone?: string;
+    shoots: number;
+    lastShoot: string;
+    upcomingShoot?: string;
+    status: ClientStatus;
+};
+
+const statusToneMap: Record<ClientStatus, StatusTone> = {
+    Active: 'success',
+    Lead: 'info',
+    Archived: 'neutral'
+};
+
+const formatDate = (value?: string) => (value ? dayjs(value).format('MMM D, YYYY') : '—');
+
+export function ClientTable({ clients }: { clients: ClientRecord[] }) {
+    return (
+        <div className="overflow-hidden rounded-2xl border border-slate-200">
+            <table className="min-w-full divide-y divide-slate-200 text-left">
+                <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    <tr>
+                        <th scope="col" className="px-5 py-3">
+                            Client
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Shoots
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Last Session
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Upcoming
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Status
+                        </th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 text-sm">
+                    {clients.map((client) => (
+                        <tr key={client.id} className="hover:bg-slate-50">
+                            <td className="px-5 py-4">
+                                <div className="font-medium text-slate-900">{client.name}</div>
+                                <div className="text-sm text-slate-500">{client.email}</div>
+                            </td>
+                            <td className="px-5 py-4">
+                                <div className="text-sm font-medium text-slate-900">{client.shoots}</div>
+                                {client.phone && <div className="text-xs text-slate-500">{client.phone}</div>}
+                            </td>
+                            <td className="px-5 py-4 text-slate-600">{formatDate(client.lastShoot)}</td>
+                            <td className="px-5 py-4 text-slate-600">{formatDate(client.upcomingShoot)}</td>
+                            <td className="px-5 py-4">
+                                <StatusPill tone={statusToneMap[client.status]}>{client.status}</StatusPill>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export default ClientTable;

--- a/src/components/crm/DashboardCard.tsx
+++ b/src/components/crm/DashboardCard.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+type DashboardCardProps = {
+    title: string;
+    value: string;
+    trend?: {
+        value: string;
+        label?: string;
+        isPositive?: boolean;
+    };
+    className?: string;
+    children?: React.ReactNode;
+};
+
+const trendClassNames = (isPositive?: boolean) =>
+    classNames('text-sm font-medium', {
+        'text-emerald-600': isPositive !== false,
+        'text-rose-600': isPositive === false
+    });
+
+export function DashboardCard({ title, value, trend, className, children }: DashboardCardProps) {
+    return (
+        <div
+            className={classNames(
+                'flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md',
+                className
+            )}
+        >
+            <p className="text-sm font-medium text-slate-500">{title}</p>
+            <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-900">{value}</p>
+            {trend && (
+                <p className={classNames('mt-2 flex items-center gap-2', trendClassNames(trend.isPositive))}>
+                    <span>{trend.value}</span>
+                    {trend.label && <span className="text-slate-500">{trend.label}</span>}
+                </p>
+            )}
+            {children && <div className="mt-4 flex-grow text-sm text-slate-500">{children}</div>}
+        </div>
+    );
+}
+
+export default DashboardCard;

--- a/src/components/crm/InvoiceTable.tsx
+++ b/src/components/crm/InvoiceTable.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+
+import StatusPill, { StatusTone } from './StatusPill';
+
+export type InvoiceStatus = 'Sent' | 'Paid' | 'Overdue';
+
+export type InvoiceRecord = {
+    id: string;
+    client: string;
+    project: string;
+    amount: number;
+    dueDate: string;
+    status: InvoiceStatus;
+};
+
+const statusToneMap: Record<InvoiceStatus, StatusTone> = {
+    Paid: 'success',
+    Sent: 'info',
+    Overdue: 'danger'
+};
+
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
+
+const formatDate = (value: string) => dayjs(value).format('MMM D, YYYY');
+
+export function InvoiceTable({ invoices }: { invoices: InvoiceRecord[] }) {
+    return (
+        <div className="space-y-4">
+            {invoices.map((invoice) => (
+                <div key={invoice.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                    <div className="flex items-start justify-between gap-3">
+                        <div>
+                            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">Invoice {invoice.id}</p>
+                            <h3 className="text-base font-semibold text-slate-900">{invoice.client}</h3>
+                            <p className="text-sm text-slate-500">{invoice.project}</p>
+                        </div>
+                        <div className="text-right">
+                            <p className="text-lg font-semibold text-slate-900">{formatCurrency(invoice.amount)}</p>
+                            <p className="text-sm text-slate-500">Due {formatDate(invoice.dueDate)}</p>
+                        </div>
+                    </div>
+                    <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                        <StatusPill tone={statusToneMap[invoice.status]}>{invoice.status}</StatusPill>
+                        <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500">View invoice</button>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default InvoiceTable;

--- a/src/components/crm/SectionCard.tsx
+++ b/src/components/crm/SectionCard.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+type SectionCardProps = {
+    title: string;
+    description?: string;
+    action?: React.ReactNode;
+    children: React.ReactNode;
+    className?: string;
+};
+
+export function SectionCard({ title, description, action, children, className }: SectionCardProps) {
+    return (
+        <section
+            className={classNames(
+                'rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md',
+                className
+            )}
+        >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+                    {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
+                </div>
+                {action && <div className="flex shrink-0 items-center gap-2 text-sm font-medium text-indigo-600">{action}</div>}
+            </div>
+            <div className="mt-5">{children}</div>
+        </section>
+    );
+}
+
+export default SectionCard;

--- a/src/components/crm/StatusPill.tsx
+++ b/src/components/crm/StatusPill.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+export type StatusTone = 'success' | 'warning' | 'danger' | 'info' | 'neutral';
+
+type StatusPillProps = {
+    tone?: StatusTone;
+    children: React.ReactNode;
+};
+
+const toneStyles: Record<StatusTone, string> = {
+    success: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    warning: 'bg-amber-50 text-amber-700 ring-amber-200',
+    danger: 'bg-rose-50 text-rose-700 ring-rose-200',
+    info: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
+    neutral: 'bg-slate-100 text-slate-700 ring-slate-200'
+};
+
+export function StatusPill({ tone = 'neutral', children }: StatusPillProps) {
+    return (
+        <span
+            className={classNames(
+                'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset',
+                toneStyles[tone]
+            )}
+        >
+            {children}
+        </span>
+    );
+}
+
+export default StatusPill;

--- a/src/components/crm/TaskList.tsx
+++ b/src/components/crm/TaskList.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+
+export type TaskRecord = {
+    id: string;
+    title: string;
+    dueDate: string;
+    assignee?: string;
+    completed?: boolean;
+};
+
+const formatDate = (value: string) => dayjs(value).format('MMM D');
+
+export function TaskList({ tasks }: { tasks: TaskRecord[] }) {
+    return (
+        <ul className="space-y-3">
+            {tasks.map((task) => (
+                <li key={task.id} className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                    <input
+                        type="checkbox"
+                        checked={task.completed}
+                        readOnly
+                        className="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    <div className="flex-1">
+                        <p className="text-sm font-medium text-slate-900">{task.title}</p>
+                        <p className="text-xs text-slate-500">
+                            Due {formatDate(task.dueDate)}
+                            {task.assignee ? ` · ${task.assignee}` : ''}
+                        </p>
+                    </div>
+                    {!task.completed && (
+                        <button className="text-xs font-semibold text-indigo-600 hover:text-indigo-500">Open</button>
+                    )}
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+export default TaskList;

--- a/src/components/crm/index.ts
+++ b/src/components/crm/index.ts
@@ -1,0 +1,12 @@
+export { DashboardCard } from './DashboardCard';
+export { SectionCard } from './SectionCard';
+export { StatusPill } from './StatusPill';
+export type { StatusTone } from './StatusPill';
+export { ClientTable } from './ClientTable';
+export type { ClientRecord, ClientStatus } from './ClientTable';
+export { BookingList } from './BookingList';
+export type { BookingRecord, BookingStatus } from './BookingList';
+export { InvoiceTable } from './InvoiceTable';
+export type { InvoiceRecord, InvoiceStatus } from './InvoiceTable';
+export { TaskList } from './TaskList';
+export type { TaskRecord } from './TaskList';

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -1,0 +1,264 @@
+import * as React from 'react';
+import Head from 'next/head';
+
+import {
+    BookingList,
+    ClientTable,
+    DashboardCard,
+    InvoiceTable,
+    SectionCard,
+    TaskList,
+    type BookingRecord,
+    type ClientRecord,
+    type InvoiceRecord,
+    type TaskRecord
+} from '../../components/crm';
+
+const metrics = [
+    {
+        id: 'revenue',
+        title: 'Monthly Revenue',
+        value: '$18,450',
+        trend: {
+            value: '+12%',
+            label: 'vs last month'
+        }
+    },
+    {
+        id: 'bookings',
+        title: 'Upcoming Shoots',
+        value: '14',
+        trend: {
+            value: '6 confirmed',
+            label: 'next 30 days'
+        }
+    },
+    {
+        id: 'galleries',
+        title: 'Galleries to Deliver',
+        value: '5',
+        trend: {
+            value: '3 due this week'
+        }
+    },
+    {
+        id: 'invoices',
+        title: 'Outstanding Invoices',
+        value: '$4,300',
+        trend: {
+            value: '2 overdue',
+            isPositive: false
+        }
+    }
+];
+
+const bookings: BookingRecord[] = [
+    {
+        id: 'bk-01',
+        client: 'Evelyn Sanders',
+        shootType: 'Engagement Session',
+        date: '2024-05-11',
+        startTime: '3:00 PM',
+        endTime: '5:00 PM',
+        location: 'Golden Gate Park',
+        status: 'Confirmed'
+    },
+    {
+        id: 'bk-02',
+        client: 'Harrison & June',
+        shootType: 'Wedding',
+        date: '2024-05-18',
+        startTime: '11:00 AM',
+        endTime: '8:00 PM',
+        location: 'Terranea Resort',
+        status: 'Pending'
+    },
+    {
+        id: 'bk-03',
+        client: 'Sona Patel',
+        shootType: 'Brand Lifestyle',
+        date: '2024-05-21',
+        startTime: '9:00 AM',
+        endTime: '12:00 PM',
+        location: 'Downtown Studio',
+        status: 'Editing'
+    }
+];
+
+const clients: ClientRecord[] = [
+    {
+        id: 'cl-01',
+        name: 'Evelyn Sanders',
+        email: 'evelyn@wanderlust.com',
+        phone: '(415) 555-0108',
+        shoots: 6,
+        lastShoot: '2024-04-22',
+        upcomingShoot: '2024-05-11',
+        status: 'Active'
+    },
+    {
+        id: 'cl-02',
+        name: 'Harrison & June',
+        email: 'hello@harrisonandjune.com',
+        phone: '(424) 555-0145',
+        shoots: 2,
+        lastShoot: '2023-11-18',
+        upcomingShoot: '2024-05-18',
+        status: 'Lead'
+    },
+    {
+        id: 'cl-03',
+        name: 'Sona Patel',
+        email: 'sona@patelcreative.co',
+        phone: '(415) 555-0121',
+        shoots: 3,
+        lastShoot: '2024-04-02',
+        upcomingShoot: '2024-05-21',
+        status: 'Active'
+    },
+    {
+        id: 'cl-04',
+        name: 'Fern & Pine Studio',
+        email: 'contact@fernandpine.com',
+        phone: '(510) 555-0186',
+        shoots: 4,
+        lastShoot: '2023-12-14',
+        status: 'Archived'
+    }
+];
+
+const invoices: InvoiceRecord[] = [
+    {
+        id: '1024',
+        client: 'Evelyn Sanders',
+        project: 'Engagement Session',
+        amount: 1150,
+        dueDate: '2024-05-05',
+        status: 'Sent'
+    },
+    {
+        id: '1023',
+        client: 'Harrison & June',
+        project: 'Wedding Collection',
+        amount: 3800,
+        dueDate: '2024-04-28',
+        status: 'Overdue'
+    },
+    {
+        id: '1022',
+        client: 'Sona Patel',
+        project: 'Brand Lifestyle',
+        amount: 1450,
+        dueDate: '2024-04-15',
+        status: 'Paid'
+    }
+];
+
+const tasks: TaskRecord[] = [
+    {
+        id: 'task-01',
+        title: 'Send Harrison & June final timeline',
+        dueDate: '2024-05-07',
+        assignee: 'You',
+        completed: false
+    },
+    {
+        id: 'task-02',
+        title: 'Cull and edit Sona Patel preview set',
+        dueDate: '2024-05-06',
+        assignee: 'Retouch Team',
+        completed: false
+    },
+    {
+        id: 'task-03',
+        title: 'Email Evelyn gallery delivery details',
+        dueDate: '2024-05-03',
+        assignee: 'You',
+        completed: true
+    }
+];
+
+const quickActions = [
+    { id: 'new-booking', label: 'Schedule shoot' },
+    { id: 'new-invoice', label: 'Create invoice' },
+    { id: 'upload-gallery', label: 'Upload gallery' }
+];
+
+export default function PhotographyCrmDashboard() {
+    return (
+        <>
+            <Head>
+                <title>Photography CRM Dashboard</title>
+                <meta name="description" content="Command center for managing photography clients, shoots and invoices." />
+            </Head>
+            <main className="min-h-screen bg-slate-50 pb-16">
+                <div className="mx-auto max-w-7xl px-6 pt-12">
+                    <header className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                        <div>
+                            <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">Studio Command Center</p>
+                            <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-900">
+                                Photography CRM Dashboard
+                            </h1>
+                            <p className="mt-3 max-w-2xl text-base text-slate-600">
+                                Track client relationships, keep shoots on schedule, and stay ahead of deliverables—all from a
+                                single workspace designed for busy photographers.
+                            </p>
+                        </div>
+                        <div className="flex flex-wrap gap-3">
+                            {quickActions.map((action) => (
+                                <button
+                                    key={action.id}
+                                    className="inline-flex items-center justify-center rounded-full border border-indigo-200 bg-white px-4 py-2 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50"
+                                >
+                                    {action.label}
+                                </button>
+                            ))}
+                        </div>
+                    </header>
+
+                    <section className="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+                        {metrics.map((metric) => (
+                            <DashboardCard key={metric.id} title={metric.title} value={metric.value} trend={metric.trend} />
+                        ))}
+                    </section>
+
+                    <div className="mt-10 grid gap-6 lg:grid-cols-3">
+                        <div className="space-y-6 lg:col-span-2">
+                            <SectionCard
+                                title="Upcoming Shoots"
+                                description="Stay ready for every session with a quick view of the week ahead."
+                                action={<button className="text-sm font-semibold text-indigo-600">Open calendar</button>}
+                            >
+                                <BookingList bookings={bookings} />
+                            </SectionCard>
+
+                            <SectionCard
+                                title="Active Clients"
+                                description="From loyal regulars to new leads, see who needs attention next."
+                                action={<button className="text-sm font-semibold text-indigo-600">View all clients</button>}
+                            >
+                                <ClientTable clients={clients} />
+                            </SectionCard>
+                        </div>
+                        <div className="space-y-6">
+                            <SectionCard
+                                title="Open Invoices"
+                                description="Collect payments faster with a focused list of outstanding balances."
+                            >
+                                <InvoiceTable invoices={invoices} />
+                            </SectionCard>
+
+                            <SectionCard
+                                title="Studio Tasks"
+                                description="Keep production moving with next actions across your team."
+                                action={<button className="text-sm font-semibold text-indigo-600">Create task</button>}
+                            >
+                                <TaskList tasks={tasks} />
+                            </SectionCard>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- add CRM-focused UI building blocks for bookings, clients, invoices, and tasks
- create a dedicated /crm dashboard page populated with photography studio sample data
- update Next.js type references generated by the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ea6d7bfc8329b963f6df47f85448