### PR TITLE
Add Supabase-backed CRM API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Netlify starter that's made for customization with a flexible content model, com
 - [Develop with Netlify Visual Editor Locally](#develop-with-netlify-visual-editor-locally)
 - [Building for production](#building-for-production)
 - [Setting Up Algolia Search](#setting-up-algolia-search)
+- [Configuring Supabase Storage](#configuring-supabase-storage)
 - [Next Steps](#next-steps)
 - [Support](#support)
 
@@ -61,6 +62,19 @@ This starter includes Algolia search integration. To set it up:
    - `NEXT_PUBLIC_ALGOLIA_APP_ID` - Your Algolia application ID
    - `NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY` - Your Algolia search-only API key
    - `NEXT_PUBLIC_ALGOLIA_INDEX_NAME` - Your index name
+
+## Configuring Supabase Storage
+
+The CRM API routes under `src/pages/api/` rely on [Supabase](https://supabase.com/) for persistence. To connect your project:
+
+1. Create a Supabase project and note the project URL and service role key from the dashboard.
+2. Create `clients` and `projects` tables with the columns your application needs (for example: `id`, `name`, `email`, `notes`, timestamps, etc.).
+3. Add the following environment variables (for local development use `.env.local`):
+   - `SUPABASE_URL` – Your Supabase project URL.
+   - `SUPABASE_SERVICE_ROLE_KEY` – Service role key for server-side CRUD operations (alternatively use `SUPABASE_ANON_KEY` with adequate Row Level Security policies).
+4. Redeploy or restart the Next.js server so the API routes can pick up the new variables.
+
+These API routes return JSON responses for GET, POST, PUT, and DELETE requests, so they can be consumed directly from front-end forms or integrations.
 
 ## Next Steps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@algolia/autocomplete-js": "^1.17.1",
                 "@algolia/autocomplete-theme-classic": "^1.17.1",
+                "@supabase/supabase-js": "^2.57.4",
                 "algoliasearch": "^4.24.0",
                 "classnames": "^2.5.1",
                 "dayjs": "^1.11.11",
@@ -2271,6 +2272,80 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/@supabase/auth-js": {
+            "version": "2.71.1",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+            "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/functions-js": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+            "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/node-fetch": {
+            "version": "2.6.15",
+            "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+            "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/@supabase/postgrest-js": {
+            "version": "1.21.4",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+            "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/realtime-js": {
+            "version": "2.15.5",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+            "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.13",
+                "@types/phoenix": "^1.6.6",
+                "@types/ws": "^8.18.1",
+                "ws": "^8.18.2"
+            }
+        },
+        "node_modules/@supabase/storage-js": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+            "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/supabase-js": {
+            "version": "2.57.4",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+            "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/auth-js": "2.71.1",
+                "@supabase/functions-js": "2.4.6",
+                "@supabase/node-fetch": "2.6.15",
+                "@supabase/postgrest-js": "1.21.4",
+                "@supabase/realtime-js": "2.15.5",
+                "@supabase/storage-js": "2.12.1"
+            }
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2386,8 +2461,7 @@
         "node_modules/@types/node": {
             "version": "18.8.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-            "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
-            "dev": true
+            "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q=="
         },
         "node_modules/@types/node-fetch": {
             "version": "2.6.12",
@@ -2398,6 +2472,12 @@
                 "@types/node": "*",
                 "form-data": "^4.0.0"
             }
+        },
+        "node_modules/@types/phoenix": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+            "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+            "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "19.1.11",
@@ -2441,6 +2521,15 @@
             "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ==",
             "dev": true
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -8143,8 +8232,7 @@
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "node_modules/truncate-utf8-bytes": {
             "version": "1.0.2",
@@ -8355,14 +8443,12 @@
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -8494,6 +8580,27 @@
                 "is-typedarray": "^1.0.0",
                 "signal-exit": "^3.0.2",
                 "typedarray-to-buffer": "^3.1.5"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/xdg-basedir": {
@@ -10113,6 +10220,70 @@
                 }
             }
         },
+        "@supabase/auth-js": {
+            "version": "2.71.1",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+            "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/functions-js": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+            "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/node-fetch": {
+            "version": "2.6.15",
+            "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+            "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
+        "@supabase/postgrest-js": {
+            "version": "1.21.4",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+            "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/realtime-js": {
+            "version": "2.15.5",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+            "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.13",
+                "@types/phoenix": "^1.6.6",
+                "@types/ws": "^8.18.1",
+                "ws": "^8.18.2"
+            }
+        },
+        "@supabase/storage-js": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+            "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/supabase-js": {
+            "version": "2.57.4",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+            "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+            "requires": {
+                "@supabase/auth-js": "2.71.1",
+                "@supabase/functions-js": "2.4.6",
+                "@supabase/node-fetch": "2.6.15",
+                "@supabase/postgrest-js": "1.21.4",
+                "@supabase/realtime-js": "2.15.5",
+                "@supabase/storage-js": "2.12.1"
+            }
+        },
         "@swc/helpers": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -10222,8 +10393,7 @@
         "@types/node": {
             "version": "18.8.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-            "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
-            "dev": true
+            "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q=="
         },
         "@types/node-fetch": {
             "version": "2.6.12",
@@ -10234,6 +10404,11 @@
                 "@types/node": "*",
                 "form-data": "^4.0.0"
             }
+        },
+        "@types/phoenix": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+            "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
         },
         "@types/react": {
             "version": "19.1.11",
@@ -10275,6 +10450,14 @@
             "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ==",
             "dev": true
+        },
+        "@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "abort-controller": {
             "version": "3.0.0",
@@ -14478,8 +14661,7 @@
         "tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "truncate-utf8-bytes": {
             "version": "1.0.2",
@@ -14632,14 +14814,12 @@
         "webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
             "requires": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -14728,6 +14908,12 @@
                 "signal-exit": "^3.0.2",
                 "typedarray-to-buffer": "^3.1.5"
             }
+        },
+        "ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "requires": {}
         },
         "xdg-basedir": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "@algolia/autocomplete-js": "^1.17.1",
         "@algolia/autocomplete-theme-classic": "^1.17.1",
+        "@supabase/supabase-js": "^2.57.4",
         "algoliasearch": "^4.24.0",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.11",

--- a/src/pages/api/clients.js
+++ b/src/pages/api/clients.js
@@ -1,0 +1,3 @@
+import { createCrudHandler } from '../../utils/create-crud-handler';
+
+export default createCrudHandler('clients');

--- a/src/pages/api/projects.js
+++ b/src/pages/api/projects.js
@@ -1,0 +1,3 @@
+import { createCrudHandler } from '../../utils/create-crud-handler';
+
+export default createCrudHandler('projects');

--- a/src/utils/create-crud-handler.js
+++ b/src/utils/create-crud-handler.js
@@ -1,0 +1,194 @@
+import { getSupabaseClient } from './supabase-client';
+
+const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'DELETE'];
+
+const parseId = (value) => {
+    if (Array.isArray(value)) {
+        return parseId(value[0]);
+    }
+
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed === '' ? undefined : trimmed;
+    }
+
+    return value;
+};
+
+const parseBody = (body) => {
+    if (body == null) {
+        return null;
+    }
+
+    if (typeof body === 'string') {
+        const trimmed = body.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        try {
+            return JSON.parse(trimmed);
+        } catch (err) {
+            console.error('Failed to parse request body as JSON', err);
+            return null;
+        }
+    }
+
+    return body;
+};
+
+const ensureObject = (value) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    return value;
+};
+
+const handleSupabaseError = (res, error) => {
+    console.error('Supabase error', error);
+    const status = error && typeof error.status === 'number' ? error.status : 400;
+    return res.status(status).json({ error: error?.message || 'Database error' });
+};
+
+async function handleGet(req, res, supabase, tableName) {
+    const id = parseId(req.query.id);
+
+    if (id) {
+        const { data, error } = await supabase.from(tableName).select('*').eq('id', id).maybeSingle();
+
+        if (error) {
+            return handleSupabaseError(res, error);
+        }
+
+        if (!data) {
+            return res.status(404).json({ error: 'Record not found' });
+        }
+
+        return res.status(200).json({ data });
+    }
+
+    const { data, error } = await supabase.from(tableName).select('*');
+
+    if (error) {
+        return handleSupabaseError(res, error);
+    }
+
+    return res.status(200).json({ data: data || [] });
+}
+
+async function handlePost(req, res, supabase, tableName) {
+    const payload = ensureObject(parseBody(req.body));
+
+    if (!payload) {
+        return res.status(400).json({ error: 'Request body must be a JSON object' });
+    }
+
+    const { data, error } = await supabase.from(tableName).insert([payload]).select().single();
+
+    if (error) {
+        return handleSupabaseError(res, error);
+    }
+
+    return res.status(201).json({ data });
+}
+
+async function handlePut(req, res, supabase, tableName) {
+    const payload = ensureObject(parseBody(req.body));
+
+    if (!payload) {
+        return res.status(400).json({ error: 'Request body must be a JSON object' });
+    }
+
+    const id = parseId(req.query.id) || parseId(payload.id);
+
+    if (!id) {
+        return res.status(400).json({ error: 'Record id is required' });
+    }
+
+    const update = { ...payload };
+    delete update.id;
+
+    if (Object.keys(update).length === 0) {
+        return res.status(400).json({ error: 'No fields provided for update' });
+    }
+
+    const { data, error } = await supabase
+        .from(tableName)
+        .update(update)
+        .eq('id', id)
+        .select()
+        .maybeSingle();
+
+    if (error) {
+        return handleSupabaseError(res, error);
+    }
+
+    if (!data) {
+        return res.status(404).json({ error: 'Record not found' });
+    }
+
+    return res.status(200).json({ data });
+}
+
+async function handleDelete(req, res, supabase, tableName) {
+    const payload = ensureObject(parseBody(req.body));
+    const id = parseId(req.query.id) || parseId(payload?.id);
+
+    if (!id) {
+        return res.status(400).json({ error: 'Record id is required' });
+    }
+
+    const { data, error } = await supabase
+        .from(tableName)
+        .delete()
+        .eq('id', id)
+        .select()
+        .maybeSingle();
+
+    if (error) {
+        return handleSupabaseError(res, error);
+    }
+
+    if (!data) {
+        return res.status(404).json({ error: 'Record not found' });
+    }
+
+    return res.status(200).json({ data });
+}
+
+export function createCrudHandler(tableName) {
+    return async function crudHandler(req, res) {
+        res.setHeader('Content-Type', 'application/json');
+
+        if (!ALLOWED_METHODS.includes(req.method)) {
+            res.setHeader('Allow', ALLOWED_METHODS);
+            return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
+        }
+
+        try {
+            const supabase = getSupabaseClient();
+
+            switch (req.method) {
+                case 'GET':
+                    return await handleGet(req, res, supabase, tableName);
+                case 'POST':
+                    return await handlePost(req, res, supabase, tableName);
+                case 'PUT':
+                    return await handlePut(req, res, supabase, tableName);
+                case 'DELETE':
+                    return await handleDelete(req, res, supabase, tableName);
+                default:
+                    res.setHeader('Allow', ALLOWED_METHODS);
+                    return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
+            }
+        } catch (err) {
+            console.error(`Unhandled error in ${tableName} handler`, err);
+            return res.status(500).json({ error: 'Internal server error' });
+        }
+    };
+}

--- a/src/utils/supabase-client.js
+++ b/src/utils/supabase-client.js
@@ -1,0 +1,42 @@
+import { createClient } from '@supabase/supabase-js';
+
+let cachedClient = null;
+
+const resolveKey = () => {
+    if (process.env.SUPABASE_SERVICE_ROLE_KEY) {
+        return process.env.SUPABASE_SERVICE_ROLE_KEY;
+    }
+
+    if (process.env.SUPABASE_ANON_KEY) {
+        return process.env.SUPABASE_ANON_KEY;
+    }
+
+    return null;
+};
+
+export function getSupabaseClient() {
+    if (cachedClient) {
+        return cachedClient;
+    }
+
+    const url = process.env.SUPABASE_URL;
+    const key = resolveKey();
+
+    if (!url || !key) {
+        throw new Error(
+            'Missing Supabase configuration. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY.'
+        );
+    }
+
+    cachedClient = createClient(url, key, {
+        auth: {
+            persistSession: false,
+        },
+    });
+
+    return cachedClient;
+}
+
+export function resetSupabaseClient() {
+    cachedClient = null;
+}


### PR DESCRIPTION
## Summary
- add a shared Supabase client helper and CRUD handler factory
- expose `/api/clients` and `/api/projects` routes that proxy to Supabase tables
- document Supabase environment variables needed for the new API endpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ed2a1e948329be61083cd946ea26