### PR TITLE
refine crm client table presentation

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/crm/BookingCalendar.tsx
+++ b/src/components/crm/BookingCalendar.tsx
@@ -1,0 +1,80 @@
+import { Fragment, useMemo } from 'react';
+import type { Booking } from '../../lib/mock-data';
+
+function formatDate(date: string) {
+    return new Intl.DateTimeFormat('en-US', { weekday: 'short', month: 'short', day: 'numeric' }).format(new Date(date));
+}
+
+type BookingCalendarProps = {
+    bookings: Booking[];
+};
+
+export function BookingCalendar({ bookings }: BookingCalendarProps) {
+    const grouped = useMemo(() => {
+        return bookings
+            .slice()
+            .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+            .reduce<Record<string, Booking[]>>((acc, booking) => {
+                const key = booking.date;
+                if (!acc[key]) {
+                    acc[key] = [];
+                }
+                acc[key].push(booking);
+                return acc;
+            }, {});
+    }, [bookings]);
+
+    const upcoming = Object.entries(grouped).slice(0, 8);
+
+    return (
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6 text-sm text-slate-200">
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-white">Booking Calendar</h2>
+                <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-emerald-300">
+                    {bookings.length} scheduled
+                </span>
+            </div>
+            <p className="mt-2 text-xs uppercase tracking-[0.3em] text-slate-400">Next eight shoots</p>
+            <div className="mt-6 space-y-6">
+                {upcoming.map(([date, items]) => (
+                    <Fragment key={date}>
+                        <div className="flex items-start gap-4">
+                            <div className="min-w-[120px] rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-2 text-center text-xs font-semibold uppercase tracking-wider text-emerald-200">
+                                {formatDate(date)}
+                            </div>
+                            <div className="flex-1 space-y-4">
+                                {items.map((booking) => (
+                                    <div
+                                        key={booking.id}
+                                        className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 shadow-lg shadow-slate-950/40"
+                                    >
+                                        <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+                                            <div>
+                                                <p className="text-sm font-semibold text-white">{booking.shootType}</p>
+                                                <p className="text-xs text-slate-400">{booking.location}</p>
+                                            </div>
+                                            <div className="text-right text-xs text-slate-400">
+                                                <p>
+                                                    {booking.startTime} – {booking.endTime}
+                                                </p>
+                                                <p className="mt-1 capitalize">{booking.status}</p>
+                                            </div>
+                                        </div>
+                                        {booking.deliverables && (
+                                            <p className="mt-3 text-xs leading-relaxed text-slate-300">{booking.deliverables}</p>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </Fragment>
+                ))}
+                {upcoming.length === 0 && (
+                    <p className="rounded-xl border border-dashed border-slate-800/80 bg-slate-950/40 p-6 text-center text-sm text-slate-400">
+                        No upcoming bookings scheduled.
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/crm/CRMLayout.tsx
+++ b/src/components/crm/CRMLayout.tsx
@@ -1,0 +1,90 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import type { ReactNode } from 'react';
+import { getCurrentUser } from '../../lib/auth';
+
+const navigation = [
+    { label: 'Dashboard', href: '/' },
+    { label: 'Clients', href: '/clients' },
+    { label: 'Bookings', href: '/bookings' },
+    { label: 'Invoices', href: '/invoices' },
+    { label: 'Galleries', href: '/gallery' },
+    { label: 'Settings', href: '/settings' }
+];
+
+type CRMLayoutProps = {
+    title: string;
+    description?: string;
+    actions?: ReactNode;
+    children: ReactNode;
+};
+
+export function CRMLayout({ title, description, actions, children }: CRMLayoutProps) {
+    const router = useRouter();
+    const user = getCurrentUser();
+
+    return (
+        <div className="min-h-screen bg-slate-950 text-slate-100">
+            <div className="border-b border-slate-900 bg-slate-950/60 backdrop-blur">
+                <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-6">
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Photographers CRM</p>
+                        <h1 className="text-2xl font-semibold text-white">{user.brandName ?? 'Studio Dashboard'}</h1>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <div className="text-right">
+                            <p className="text-sm font-medium text-white">{user.name}</p>
+                            <p className="text-xs text-slate-400">{user.role}</p>
+                        </div>
+                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-300">
+                            {user.name
+                                .split(' ')
+                                .map((segment) => segment[0])
+                                .join('')
+                                .slice(0, 2)}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className="mx-auto flex max-w-7xl flex-col gap-8 px-6 py-10 lg:flex-row">
+                <nav className="w-full max-w-xs space-y-1 text-sm text-slate-300">
+                    {navigation.map((item) => {
+                        const isActive = router.pathname === item.href;
+                        return (
+                            <Link
+                                key={item.href}
+                                href={item.href}
+                                className={`flex items-center justify-between rounded-lg px-4 py-3 transition ${
+                                    isActive
+                                        ? 'bg-emerald-500/10 text-emerald-200 ring-1 ring-emerald-500/40'
+                                        : 'hover:bg-slate-900 hover:text-white'
+                                }`}
+                            >
+                                <span>{item.label}</span>
+                                {isActive && (
+                                    <span className="text-xs font-semibold uppercase tracking-wide text-emerald-300">
+                                        Active
+                                    </span>
+                                )}
+                            </Link>
+                        );
+                    })}
+                </nav>
+
+                <main className="flex-1">
+                    <header className="mb-8 space-y-3">
+                        <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{title}</p>
+                                {description && <p className="mt-2 max-w-2xl text-sm text-slate-300">{description}</p>}
+                            </div>
+                            {actions && <div className="flex items-center gap-3">{actions}</div>}
+                        </div>
+                    </header>
+                    <div className="space-y-8">{children}</div>
+                </main>
+            </div>
+        </div>
+    );
+}

--- a/src/components/crm/ClientTable.tsx
+++ b/src/components/crm/ClientTable.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+
+import StatusPill, { StatusTone } from './StatusPill';
+import type { Client } from '../../lib/mock-data';
+
+export type ClientTableProps = {
+    clients: Client[];
+};
+
+const statusToneMap: Record<Client['status'], StatusTone> = {
+    Active: 'success',
+    Lead: 'info',
+    Archived: 'neutral'
+};
+
+const formatDate = (value?: string) => (value ? dayjs(value).format('MMM D, YYYY') : '—');
+
+const ClientTable: React.FC<ClientTableProps> = ({ clients }) => {
+    return (
+        <div className="overflow-hidden rounded-2xl border border-slate-200">
+            <table className="min-w-full divide-y divide-slate-200 text-left">
+                <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    <tr>
+                        <th scope="col" className="px-5 py-3">
+                            Client
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Shoots
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Last Session
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Upcoming
+                        </th>
+                        <th scope="col" className="px-5 py-3">
+                            Status
+                        </th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 text-sm">
+                    {clients.map((client) => (
+                        <tr key={client.id} className="hover:bg-slate-50">
+                            <td className="px-5 py-4">
+                                <div className="font-medium text-slate-900">{client.name}</div>
+                                <div className="text-sm text-slate-500">
+                                    {client.company ? `${client.company} · ${client.email}` : client.email}
+                                </div>
+                            </td>
+                            <td className="px-5 py-4">
+                                <div className="text-sm font-medium text-slate-900">{client.shoots}</div>
+                                {client.phone && <div className="text-xs text-slate-500">{client.phone}</div>}
+                            </td>
+                            <td className="px-5 py-4 text-slate-600">{formatDate(client.lastShootDate)}</td>
+                            <td className="px-5 py-4 text-slate-600">{formatDate(client.upcomingShootDate)}</td>
+                            <td className="px-5 py-4">
+                                <StatusPill tone={statusToneMap[client.status]}>{client.status}</StatusPill>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default ClientTable;

--- a/src/components/crm/DashboardCard.tsx
+++ b/src/components/crm/DashboardCard.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+type DashboardCardProps = {
+    title: string;
+    value: string;
+    accent?: string;
+    description?: string;
+    icon?: ReactNode;
+};
+
+export function DashboardCard({ title, value, accent, description, icon }: DashboardCardProps) {
+    return (
+        <div className="group relative overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 transition hover:-translate-y-1 hover:border-emerald-500/40 hover:bg-slate-900">
+            <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/5 via-transparent to-slate-900 opacity-0 transition duration-300 group-hover:opacity-100" />
+            <div className="relative flex items-start justify-between">
+                <div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{title}</p>
+                    <p className="mt-3 text-3xl font-semibold text-white">{value}</p>
+                    {accent && <p className="mt-1 text-xs font-medium text-emerald-300">{accent}</p>}
+                </div>
+                {icon && <div className="text-emerald-300">{icon}</div>}
+            </div>
+            {description && <p className="relative mt-6 text-sm leading-relaxed text-slate-300">{description}</p>}
+        </div>
+    );
+}

--- a/src/components/crm/GalleryUploader.tsx
+++ b/src/components/crm/GalleryUploader.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import type { Client, Gallery } from '../../lib/mock-data';
+import type { CreateGalleryInput } from '../../lib/api';
+
+function formatDate(date: string) {
+    return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(date));
+}
+
+type GalleryUploaderProps = {
+    clients: Client[];
+    galleries: Gallery[];
+    onCreate: (input: CreateGalleryInput) => Promise<void> | void;
+};
+
+export function GalleryUploader({ clients, galleries, onCreate }: GalleryUploaderProps) {
+    const [formState, setFormState] = useState<CreateGalleryInput>({
+        clientId: clients[0]?.id ?? '',
+        project: '',
+        title: '',
+        deliveryDate: new Date().toISOString().slice(0, 10),
+        photoFilenames: []
+    });
+
+    const [uploadList, setUploadList] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setIsSubmitting(true);
+        try {
+            await onCreate({
+                ...formState,
+                photoFilenames: uploadList
+                    .split('\n')
+                    .map((item) => item.trim())
+                    .filter(Boolean)
+            });
+            setFormState((prev) => ({
+                ...prev,
+                project: '',
+                title: ''
+            }));
+            setUploadList('');
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <div className="grid gap-8 lg:grid-cols-2">
+            <form onSubmit={handleSubmit} className="space-y-6 rounded-2xl border border-slate-800 bg-slate-900/50 p-6 text-sm">
+                <h2 className="text-lg font-semibold text-white">Create gallery</h2>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Client
+                    <select
+                        className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.clientId}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                clientId: event.target.value
+                            }))
+                        }
+                        required
+                    >
+                        {clients.map((client) => (
+                            <option key={client.id} value={client.id}>
+                                {client.name}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Project
+                    <input
+                        type="text"
+                        className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.project}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                project: event.target.value
+                            }))
+                        }
+                        placeholder="E.g., Rivera Wedding or Spring Mini Sessions"
+                        required
+                    />
+                </label>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Title
+                    <input
+                        type="text"
+                        className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.title}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                title: event.target.value
+                            }))
+                        }
+                        required
+                    />
+                </label>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Delivery Date
+                    <input
+                        type="date"
+                        className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.deliveryDate}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                deliveryDate: event.target.value
+                            }))
+                        }
+                    />
+                </label>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Photo filenames
+                    <textarea
+                        className="h-24 rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={uploadList}
+                        onChange={(event) => setUploadList(event.target.value)}
+                        placeholder={'hero.jpg\nhighlight-01.jpg\nfamily-portrait.png'}
+                    />
+                </label>
+                <button
+                    type="submit"
+                    className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-600/40"
+                    disabled={isSubmitting}
+                >
+                    {isSubmitting ? 'Saving...' : 'Generate gallery'}
+                </button>
+            </form>
+
+            <section className="space-y-6">
+                <h2 className="text-lg font-semibold text-white">Recent deliveries</h2>
+                <div className="space-y-4">
+                    {galleries.map((gallery) => (
+                        <article
+                            key={gallery.id}
+                            className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-6 shadow-lg shadow-slate-950/40"
+                        >
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div>
+                                    <p className="text-sm font-semibold text-white">{gallery.title}</p>
+                                    <p className="text-xs text-slate-400">{gallery.project}</p>
+                                    <p className="mt-2 text-xs uppercase tracking-[0.3em] text-emerald-300">{gallery.status}</p>
+                                </div>
+                                <div className="text-right text-xs text-slate-400">
+                                    <p>Delivery {formatDate(gallery.deliveryDate)}</p>
+                                    <p className="mt-1">{gallery.photos.length} photos</p>
+                                </div>
+                            </div>
+                        </article>
+                    ))}
+                    {galleries.length === 0 && (
+                        <p className="rounded-xl border border-dashed border-slate-800/80 bg-slate-950/40 p-6 text-center text-sm text-slate-400">
+                            No galleries created yet.
+                        </p>
+                    )}
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/src/components/crm/InvoiceForm.tsx
+++ b/src/components/crm/InvoiceForm.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import type { Client } from '../../lib/mock-data';
+import type { CreateInvoiceInput } from '../../lib/api';
+
+type InvoiceFormProps = {
+    clients: Client[];
+    onSubmit: (invoice: CreateInvoiceInput) => Promise<void> | void;
+};
+
+export function InvoiceForm({ clients, onSubmit }: InvoiceFormProps) {
+    const [formState, setFormState] = useState<CreateInvoiceInput>({
+        clientId: clients[0]?.id ?? '',
+        amount: 0,
+        dueDate: new Date().toISOString().slice(0, 10),
+        description: ''
+    });
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setIsSubmitting(true);
+        try {
+            await onSubmit(formState);
+            setFormState((prev) => ({ ...prev, amount: 0, description: '' }));
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-6 rounded-2xl border border-slate-800 bg-slate-900/50 p-6 text-sm">
+            <div className="grid gap-4 sm:grid-cols-2">
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Client
+                    <select
+                        className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.clientId}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                clientId: event.target.value
+                            }))
+                        }
+                        required
+                    >
+                        {clients.map((client) => (
+                            <option key={client.id} value={client.id}>
+                                {client.name}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Amount
+                    <input
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.amount}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                amount: Number(event.target.value)
+                            }))
+                        }
+                        required
+                    />
+                </label>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Due Date
+                    <input
+                        type="date"
+                        className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.dueDate}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                dueDate: event.target.value
+                            }))
+                        }
+                        required
+                    />
+                </label>
+                <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400 sm:col-span-2">
+                    Description
+                    <textarea
+                        className="h-24 rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        value={formState.description}
+                        onChange={(event) =>
+                            setFormState((prev) => ({
+                                ...prev,
+                                description: event.target.value
+                            }))
+                        }
+                        placeholder="Describe deliverables, payment schedule or notes"
+                    />
+                </label>
+            </div>
+            <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-600/40"
+                disabled={isSubmitting}
+            >
+                {isSubmitting ? 'Creating invoice...' : 'Create invoice'}
+            </button>
+        </form>
+    );
+}

--- a/src/components/crm/StatusPill.tsx
+++ b/src/components/crm/StatusPill.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+export type StatusTone = 'success' | 'info' | 'neutral';
+
+type StatusPillProps = React.PropsWithChildren<{
+    tone: StatusTone;
+}>;
+
+const toneStyles: Record<StatusTone, string> = {
+    success: 'bg-emerald-100 text-emerald-700',
+    info: 'bg-sky-100 text-sky-700',
+    neutral: 'bg-slate-200 text-slate-600'
+};
+
+function StatusPill({ tone, children }: StatusPillProps) {
+    return (
+        <span
+            className={classNames(
+                'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium',
+                toneStyles[tone]
+            )}
+        >
+            {children}
+        </span>
+    );
+}
+
+export default StatusPill;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,86 @@
+import { bookings, clients, galleries, invoices } from './mock-data';
+import type {
+    Booking,
+    Client,
+    Gallery,
+    GalleryPhoto,
+    Invoice,
+    InvoiceStatus
+} from './mock-data';
+
+export type CreateInvoiceInput = {
+    clientId: string;
+    amount: number;
+    dueDate: string;
+    description?: string;
+};
+
+export type CreateGalleryInput = {
+    clientId: string;
+    project: string;
+    title: string;
+    deliveryDate: string;
+    photoFilenames: string[];
+};
+
+export async function getClients(): Promise<Client[]> {
+    return clients;
+}
+
+export async function getClientById(id: string): Promise<Client | undefined> {
+    return clients.find((client) => client.id === id);
+}
+
+export async function getBookings(): Promise<Booking[]> {
+    return bookings;
+}
+
+export async function getInvoices(): Promise<Invoice[]> {
+    return invoices;
+}
+
+export async function getGalleries(): Promise<Gallery[]> {
+    return galleries;
+}
+
+export async function createInvoice(input: CreateInvoiceInput): Promise<Invoice> {
+    const nextSequence = invoices.length + 1;
+    const paddedSequence = String(nextSequence).padStart(3, '0');
+    const newInvoice: Invoice = {
+        id: `invoice-2024-${paddedSequence}`,
+        clientId: input.clientId,
+        amount: input.amount,
+        dueDate: input.dueDate,
+        status: deriveInvoiceStatus(input.dueDate),
+        description: input.description
+    };
+    return newInvoice;
+}
+
+function deriveInvoiceStatus(dueDate: string): InvoiceStatus {
+    const now = new Date();
+    const due = new Date(dueDate);
+    if (due < now) {
+        return 'overdue';
+    }
+    return 'sent';
+}
+
+export async function createGallery(input: CreateGalleryInput): Promise<Gallery> {
+    const photoEntries: GalleryPhoto[] = input.photoFilenames.map((filename, index) => ({
+        id: `${input.title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${index + 1}`,
+        filename,
+        url: `/uploads/${filename}`
+    }));
+    const newGallery: Gallery = {
+        id: `${input.title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${Date.now()}`,
+        clientId: input.clientId,
+        project: input.project,
+        title: input.title,
+        status: 'draft',
+        deliveryDate: input.deliveryDate,
+        coverImage: photoEntries[0]?.url || '/images/gallery/placeholder.jpg',
+        photos: photoEntries
+    };
+    return newGallery;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,33 @@
+export type CRMUserRole = 'photographer' | 'studio-manager' | 'assistant';
+
+export type CRMUser = {
+    id: string;
+    name: string;
+    email: string;
+    role: CRMUserRole;
+    avatarUrl?: string;
+    brandName?: string;
+};
+
+const demoUser: CRMUser = {
+    id: 'user-demo-photographer',
+    name: 'Harper Sloan',
+    email: 'harper@lumina-studios.com',
+    role: 'photographer',
+    avatarUrl: '/images/avatars/harper-sloan.png',
+    brandName: 'Lumina Studios'
+};
+
+export function getCurrentUser(): CRMUser {
+    return demoUser;
+}
+
+export async function signInWithEmail(email: string, password: string): Promise<CRMUser> {
+    // Placeholder implementation that mimics a network delay.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    return { ...demoUser, email };
+}
+
+export async function signOut(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 150));
+}

--- a/src/lib/cms.ts
+++ b/src/lib/cms.ts
@@ -1,0 +1,83 @@
+export type CMSField = {
+    label: string;
+    name: string;
+    widget: string;
+    hint?: string;
+    required?: boolean;
+    multiple?: boolean;
+};
+
+export type CMSCollection = {
+    name: string;
+    label: string;
+    folder: string;
+    slug: string;
+    create: boolean;
+    fields: CMSField[];
+};
+
+export const CRM_COLLECTIONS: CMSCollection[] = [
+    {
+        name: 'clients',
+        label: 'Clients',
+        folder: 'content/data/clients',
+        slug: '{{slug}}',
+        create: true,
+        fields: [
+            { label: 'Client Name', name: 'name', widget: 'string', required: true },
+            { label: 'Email', name: 'email', widget: 'string', required: true },
+            { label: 'Phone', name: 'phone', widget: 'string' },
+            { label: 'Location', name: 'location', widget: 'string' },
+            { label: 'Tags', name: 'tags', widget: 'list', hint: 'Keywords for filtering (wedding, family, etc.)' },
+            { label: 'Notes', name: 'notes', widget: 'text', hint: 'Important reminders before a shoot' }
+        ]
+    },
+    {
+        name: 'bookings',
+        label: 'Bookings',
+        folder: 'content/data/bookings',
+        slug: '{{year}}-{{month}}-{{slug}}',
+        create: true,
+        fields: [
+            { label: 'Client', name: 'client', widget: 'relation', hint: 'Reference a client record' },
+            { label: 'Date', name: 'date', widget: 'datetime', required: true },
+            { label: 'Location', name: 'location', widget: 'string' },
+            { label: 'Shoot Type', name: 'shootType', widget: 'select', multiple: false },
+            { label: 'Status', name: 'status', widget: 'select', hint: 'Proposal, scheduled, delivered, etc.' },
+            { label: 'Deliverables', name: 'deliverables', widget: 'text' }
+        ]
+    },
+    {
+        name: 'invoices',
+        label: 'Invoices',
+        folder: 'content/data/invoices',
+        slug: '{{slug}}',
+        create: true,
+        fields: [
+            { label: 'Client', name: 'client', widget: 'relation', required: true },
+            { label: 'Amount', name: 'amount', widget: 'number', required: true },
+            { label: 'Due Date', name: 'dueDate', widget: 'datetime', required: true },
+            { label: 'Status', name: 'status', widget: 'select', required: true },
+            { label: 'Description', name: 'description', widget: 'text' }
+        ]
+    },
+    {
+        name: 'galleries',
+        label: 'Galleries',
+        folder: 'content/data/galleries',
+        slug: '{{slug}}',
+        create: true,
+        fields: [
+            { label: 'Client', name: 'client', widget: 'relation', required: true },
+            { label: 'Project', name: 'project', widget: 'string', required: true },
+            { label: 'Title', name: 'title', widget: 'string', required: true },
+            { label: 'Delivery Date', name: 'deliveryDate', widget: 'datetime' },
+            { label: 'Status', name: 'status', widget: 'select' },
+            { label: 'Photos', name: 'photos', widget: 'list', hint: 'Upload or reference CDN URLs' }
+        ]
+    }
+];
+
+export function listCollections(): CMSCollection[] {
+    return CRM_COLLECTIONS;
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,0 +1,198 @@
+export type ClientStatus = 'Active' | 'Lead' | 'Archived';
+
+export type Client = {
+    id: string;
+    name: string;
+    email: string;
+    phone: string;
+    location: string;
+    company?: string;
+    shoots: number;
+    lastShootDate: string;
+    upcomingShootDate?: string;
+    status: ClientStatus;
+    tags: string[];
+    notes?: string;
+};
+
+export type BookingStatus = 'proposal' | 'scheduled' | 'completed' | 'delivered';
+
+export type Booking = {
+    id: string;
+    clientId: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    location: string;
+    shootType: string;
+    status: BookingStatus;
+    deliverables?: string;
+};
+
+export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue';
+
+export type Invoice = {
+    id: string;
+    clientId: string;
+    amount: number;
+    dueDate: string;
+    status: InvoiceStatus;
+    description?: string;
+};
+
+export type GalleryStatus = 'draft' | 'delivered' | 'archived';
+
+export type GalleryPhoto = {
+    id: string;
+    filename: string;
+    url: string;
+};
+
+export type Gallery = {
+    id: string;
+    clientId: string;
+    project: string;
+    title: string;
+    status: GalleryStatus;
+    deliveryDate: string;
+    coverImage: string;
+    photos: GalleryPhoto[];
+};
+
+export const clients: Client[] = [
+    {
+        id: 'client-olivia-rivera',
+        name: 'Olivia Rivera',
+        company: 'Rivera & Co.',
+        email: 'olivia.rivera@example.com',
+        phone: '+1 (312) 555-9023',
+        location: 'Chicago, IL',
+        shoots: 6,
+        lastShootDate: '2023-10-02',
+        upcomingShootDate: '2024-05-18',
+        status: 'Active',
+        tags: ['wedding', 'vip'],
+        notes: 'Prefers natural light and candid shots. Following up about spring engagement session.'
+    },
+    {
+        id: 'client-liam-nguyen',
+        name: 'Liam Nguyen',
+        company: 'Nguyen Creative',
+        email: 'liam.nguyen@example.com',
+        phone: '+1 (415) 555-4411',
+        location: 'San Francisco, CA',
+        shoots: 3,
+        lastShootDate: '2023-12-14',
+        upcomingShootDate: '2024-06-12',
+        status: 'Lead',
+        tags: ['branding'],
+        notes: 'Launching a new personal brand site in Q2. Needs lifestyle portraits.'
+    },
+    {
+        id: 'client-amelia-cho',
+        name: 'Amelia Cho',
+        company: 'Cho Family',
+        email: 'amelia.cho@example.com',
+        phone: '+1 (646) 555-7312',
+        location: 'New York, NY',
+        shoots: 5,
+        lastShootDate: '2024-01-09',
+        upcomingShootDate: '2024-03-24',
+        status: 'Active',
+        tags: ['family', 'repeat'],
+        notes: 'Booked annual family mini-session. Loves quick turnarounds.'
+    }
+];
+
+export const bookings: Booking[] = [
+    {
+        id: 'booking-rivera-wedding',
+        clientId: 'client-olivia-rivera',
+        date: '2024-05-18',
+        startTime: '13:00',
+        endTime: '20:00',
+        location: 'Lakeview Pavilion, Chicago',
+        shootType: 'Wedding',
+        status: 'scheduled',
+        deliverables: 'Full day coverage, highlight film, 400 edited photos'
+    },
+    {
+        id: 'booking-nguyen-branding',
+        clientId: 'client-liam-nguyen',
+        date: '2024-03-08',
+        startTime: '09:30',
+        endTime: '12:30',
+        location: 'SoMa Studio Collective, San Francisco',
+        shootType: 'Branding Portraits',
+        status: 'completed',
+        deliverables: '20 retouched images formatted for LinkedIn and website banners'
+    },
+    {
+        id: 'booking-cho-family',
+        clientId: 'client-amelia-cho',
+        date: '2024-03-24',
+        startTime: '16:00',
+        endTime: '17:00',
+        location: 'Brooklyn Bridge Park, New York',
+        shootType: 'Family Session',
+        status: 'scheduled',
+        deliverables: 'Mini session with 15 edited images'
+    }
+];
+
+export const invoices: Invoice[] = [
+    {
+        id: 'invoice-2024-001',
+        clientId: 'client-olivia-rivera',
+        amount: 4800,
+        dueDate: '2024-04-30',
+        status: 'sent',
+        description: 'Final balance for Rivera wedding coverage'
+    },
+    {
+        id: 'invoice-2024-002',
+        clientId: 'client-liam-nguyen',
+        amount: 950,
+        dueDate: '2024-02-22',
+        status: 'paid',
+        description: 'Branding portrait session with rush delivery add-on'
+    },
+    {
+        id: 'invoice-2024-003',
+        clientId: 'client-amelia-cho',
+        amount: 450,
+        dueDate: '2024-03-30',
+        status: 'draft',
+        description: 'Family mini-session with print package'
+    }
+];
+
+export const galleries: Gallery[] = [
+    {
+        id: 'gallery-rivera-proofs',
+        clientId: 'client-olivia-rivera',
+        project: 'Rivera Wedding',
+        title: 'Rivera Wedding Proofs',
+        status: 'draft',
+        deliveryDate: '2024-06-01',
+        coverImage: '/images/gallery/rivera-cover.jpg',
+        photos: [
+            { id: 'rivera-001', filename: 'rivera-001.jpg', url: '/images/gallery/rivera-001.jpg' },
+            { id: 'rivera-002', filename: 'rivera-002.jpg', url: '/images/gallery/rivera-002.jpg' }
+        ]
+    },
+    {
+        id: 'gallery-nguyen-launch',
+        clientId: 'client-liam-nguyen',
+        project: 'Liam Nguyen Branding',
+        title: 'Brand Refresh Deliverables',
+        status: 'delivered',
+        deliveryDate: '2023-12-20',
+        coverImage: '/images/gallery/nguyen-cover.jpg',
+        photos: [
+            { id: 'nguyen-001', filename: 'nguyen-001.jpg', url: '/images/gallery/nguyen-001.jpg' },
+            { id: 'nguyen-002', filename: 'nguyen-002.jpg', url: '/images/gallery/nguyen-002.jpg' },
+            { id: 'nguyen-003', filename: 'nguyen-003.jpg', url: '/images/gallery/nguyen-003.jpg' }
+        ]
+    }
+];

--- a/src/pages/[...slug].js
+++ b/src/pages/[...slug].js
@@ -41,7 +41,11 @@ function Page(props) {
 
 export function getStaticPaths() {
     const data = allContent();
-    const paths = resolveStaticPaths(data);
+    const paths = resolveStaticPaths(data)
+        .filter((path) => path && path !== '/')
+        .map((path) => ({
+            params: { slug: path.split('/').filter(Boolean) }
+        }));
     return { paths, fallback: false };
 }
 

--- a/src/pages/bookings/index.tsx
+++ b/src/pages/bookings/index.tsx
@@ -1,0 +1,68 @@
+import type { GetStaticProps } from 'next';
+import Link from 'next/link';
+import { CRMLayout } from '../../components/crm/CRMLayout';
+import { BookingCalendar } from '../../components/crm/BookingCalendar';
+import type { Booking, Client } from '../../lib/mock-data';
+import { getBookings, getClients } from '../../lib/api';
+
+interface BookingsPageProps {
+    bookings: Booking[];
+    clients: Client[];
+}
+
+export default function BookingsPage({ bookings, clients }: BookingsPageProps) {
+    return (
+        <CRMLayout
+            title="Booking Calendar"
+            description="Keep every shoot aligned—assign assistants, confirm locations and prepare shot lists in one place."
+            actions={
+                <Link
+                    href="/invoices"
+                    className="inline-flex items-center rounded-lg border border-emerald-500/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300 transition hover:border-emerald-300 hover:text-emerald-200"
+                >
+                    Send invoice
+                </Link>
+            }
+        >
+            <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+                <BookingCalendar bookings={bookings} />
+                <aside className="space-y-6 rounded-2xl border border-slate-800 bg-slate-900/50 p-6 text-sm">
+                    <h2 className="text-lg font-semibold text-white">Production checklist</h2>
+                    <ul className="space-y-3 text-slate-300">
+                        <li>• Confirm contracts and retainers are signed.</li>
+                        <li>• Share timeline and shot list with second shooters.</li>
+                        <li>• Prep gear kit and charge batteries the night before.</li>
+                        <li>• Block travel time and parking details in your calendar.</li>
+                    </ul>
+                    <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4 text-xs text-emerald-100">
+                        <p className="font-semibold uppercase tracking-[0.3em]">Pro tip</p>
+                        <p className="mt-2 text-sm text-emerald-50">
+                            Tag shoots with "editing" or "delivery" so you know which sessions still need a gallery follow up.
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Clients on deck</p>
+                        <div className="mt-3 space-y-2 text-sm text-slate-300">
+                            {clients.slice(0, 5).map((client) => (
+                                <div key={client.id} className="flex items-center justify-between">
+                                    <span>{client.name}</span>
+                                    <span className="text-xs text-slate-500">{client.location}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </aside>
+            </section>
+        </CRMLayout>
+    );
+}
+
+export const getStaticProps: GetStaticProps<BookingsPageProps> = async () => {
+    const [bookingsData, clientsData] = await Promise.all([getBookings(), getClients()]);
+    return {
+        props: {
+            bookings: bookingsData,
+            clients: clientsData
+        }
+    };
+};

--- a/src/pages/clients/[clientId].tsx
+++ b/src/pages/clients/[clientId].tsx
@@ -1,0 +1,159 @@
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import Link from 'next/link';
+import { CRMLayout } from '../../components/crm/CRMLayout';
+import type { Booking, Client, Invoice } from '../../lib/mock-data';
+import { getBookings, getClients, getInvoices } from '../../lib/api';
+
+function formatDate(date: string) {
+    return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(date));
+}
+
+type ClientProfileProps = {
+    client: Client;
+    bookings: Booking[];
+    invoices: Invoice[];
+};
+
+export default function ClientProfilePage({ client, bookings, invoices }: ClientProfileProps) {
+    const upcomingBookings = bookings.filter((booking) => new Date(booking.date) >= new Date());
+    const pastBookings = bookings.filter((booking) => new Date(booking.date) < new Date());
+
+    return (
+        <CRMLayout
+            title={`Client: ${client.name}`}
+            description="Review the full history of shoots, invoices and notes for this relationship."
+            actions={
+                <Link
+                    href="/bookings"
+                    className="inline-flex items-center rounded-lg border border-emerald-500/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300 transition hover:border-emerald-300 hover:text-emerald-200"
+                >
+                    Schedule follow-up
+                </Link>
+            }
+        >
+            <section className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+                <div className="space-y-6">
+                    <article className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                        <h2 className="text-lg font-semibold text-white">Contact</h2>
+                        <div className="mt-4 grid gap-4 text-sm text-slate-300 md:grid-cols-2">
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Email</p>
+                                <p className="mt-1 text-white">{client.email}</p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Phone</p>
+                                <p className="mt-1">{client.phone}</p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Location</p>
+                                <p className="mt-1">{client.location}</p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Last shoot</p>
+                                <p className="mt-1">{formatDate(client.lastShootDate)}</p>
+                            </div>
+                        </div>
+                        {client.notes && (
+                            <p className="mt-4 rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 text-sm text-slate-200">
+                                {client.notes}
+                            </p>
+                        )}
+                    </article>
+
+                    <article className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-lg font-semibold text-white">Upcoming bookings</h2>
+                            <span className="text-xs uppercase tracking-[0.3em] text-slate-400">{upcomingBookings.length}</span>
+                        </div>
+                        <div className="mt-4 space-y-4 text-sm">
+                            {upcomingBookings.map((booking) => (
+                                <div key={booking.id} className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4">
+                                    <p className="text-sm font-semibold text-white">{booking.shootType}</p>
+                                    <p className="text-xs text-slate-400">{booking.location}</p>
+                                    <p className="mt-2 text-xs text-slate-300">{formatDate(booking.date)}</p>
+                                </div>
+                            ))}
+                            {upcomingBookings.length === 0 && (
+                                <p className="rounded-xl border border-dashed border-slate-800/80 bg-slate-950/40 p-6 text-center text-xs text-slate-400">
+                                    No upcoming bookings scheduled.
+                                </p>
+                            )}
+                        </div>
+                    </article>
+
+                    <article className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-lg font-semibold text-white">Past sessions</h2>
+                            <span className="text-xs uppercase tracking-[0.3em] text-slate-400">{pastBookings.length}</span>
+                        </div>
+                        <div className="mt-4 space-y-4 text-sm">
+                            {pastBookings.map((booking) => (
+                                <div key={booking.id} className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4">
+                                    <p className="text-sm font-semibold text-white">{booking.shootType}</p>
+                                    <p className="text-xs text-slate-400">{booking.location}</p>
+                                    <p className="mt-2 text-xs text-slate-300">{formatDate(booking.date)}</p>
+                                </div>
+                            ))}
+                            {pastBookings.length === 0 && (
+                                <p className="rounded-xl border border-dashed border-slate-800/80 bg-slate-950/40 p-6 text-center text-xs text-slate-400">
+                                    No session history recorded yet.
+                                </p>
+                            )}
+                        </div>
+                    </article>
+                </div>
+
+                <aside className="space-y-6 rounded-2xl border border-slate-800 bg-slate-900/50 p-6 text-sm">
+                    <h2 className="text-lg font-semibold text-white">Billing timeline</h2>
+                    <div className="space-y-3">
+                        {invoices.map((invoice) => (
+                            <div key={invoice.id} className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4">
+                                <p className="text-sm font-semibold text-white">{invoice.description ?? 'Invoice'}</p>
+                                <p className="text-xs text-slate-400">{invoice.status.toUpperCase()} • Due {formatDate(invoice.dueDate)}</p>
+                            </div>
+                        ))}
+                        {invoices.length === 0 && (
+                            <p className="rounded-xl border border-dashed border-slate-800/80 bg-slate-950/40 p-6 text-center text-xs text-slate-400">
+                                No invoices yet—create one from the invoices tab.
+                            </p>
+                        )}
+                    </div>
+                    <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4 text-xs text-emerald-200">
+                        <p className="font-semibold uppercase tracking-[0.3em]">Next steps</p>
+                        <p className="mt-2 text-sm text-emerald-50">
+                            Share a client experience guide and collect testimonials after each session to strengthen retention.
+                        </p>
+                    </div>
+                </aside>
+            </section>
+        </CRMLayout>
+    );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+    const clientsData = await getClients();
+    return {
+        paths: clientsData.map((client) => ({ params: { clientId: client.id } })),
+        fallback: false
+    };
+};
+
+export const getStaticProps: GetStaticProps<ClientProfileProps> = async ({ params }) => {
+    const clientId = params?.clientId as string;
+    const [clientsData, bookingsData, invoicesData] = await Promise.all([
+        getClients(),
+        getBookings(),
+        getInvoices()
+    ]);
+    const client = clientsData.find((item) => item.id === clientId);
+    if (!client) {
+        return { notFound: true };
+    }
+    return {
+        props: {
+            client,
+            bookings: bookingsData.filter((booking) => booking.clientId === clientId),
+            invoices: invoicesData.filter((invoice) => invoice.clientId === clientId)
+        }
+    };
+};

--- a/src/pages/clients/index.tsx
+++ b/src/pages/clients/index.tsx
@@ -1,0 +1,54 @@
+import type { GetStaticProps } from 'next';
+import Link from 'next/link';
+import { CRMLayout } from '../../components/crm/CRMLayout';
+import ClientTable from '../../components/crm/ClientTable';
+import type { Client } from '../../lib/mock-data';
+import { getClients } from '../../lib/api';
+
+interface ClientsPageProps {
+    clients: Client[];
+}
+
+export default function ClientsPage({ clients }: ClientsPageProps) {
+    return (
+        <CRMLayout
+            title="Client Directory"
+            description="Manage every relationship from lead intake through gallery delivery and anniversaries."
+            actions={
+                <Link
+                    href="/bookings"
+                    className="inline-flex items-center rounded-lg border border-emerald-500/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300 transition hover:border-emerald-300 hover:text-emerald-200"
+                >
+                    New booking
+                </Link>
+            }
+        >
+            <section className="space-y-6">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div>
+                        <h2 className="text-lg font-semibold text-white">All clients</h2>
+                        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Filter by shoot type, tags or last touchpoint</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                        <button className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                            Import CSV
+                        </button>
+                        <button className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                            Add tag
+                        </button>
+                    </div>
+                </div>
+                <ClientTable clients={clients} />
+            </section>
+        </CRMLayout>
+    );
+}
+
+export const getStaticProps: GetStaticProps<ClientsPageProps> = async () => {
+    const clientsData = await getClients();
+    return {
+        props: {
+            clients: clientsData
+        }
+    };
+};

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -1,0 +1,57 @@
+import type { GetStaticProps } from 'next';
+import Link from 'next/link';
+import { useState } from 'react';
+import { CRMLayout } from '../../components/crm/CRMLayout';
+import { GalleryUploader } from '../../components/crm/GalleryUploader';
+import type { Client, Gallery } from '../../lib/mock-data';
+import { createGallery, getClients, getGalleries } from '../../lib/api';
+
+interface GalleryPageProps {
+    clients: Client[];
+    galleries: Gallery[];
+}
+
+export default function GalleryPage({ clients, galleries: initialGalleries }: GalleryPageProps) {
+    const [galleries, setGalleries] = useState(initialGalleries);
+    const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+    async function handleCreateGallery(payload: Parameters<typeof createGallery>[0]) {
+        const newGallery = await createGallery(payload);
+        setGalleries((prev) => [newGallery, ...prev]);
+        const client = clients.find((item) => item.id === newGallery.clientId);
+        setStatusMessage(`Gallery "${newGallery.title}" drafted for ${client?.name ?? 'client'}.`);
+        setTimeout(() => setStatusMessage(null), 4000);
+    }
+
+    return (
+        <CRMLayout
+            title="Gallery Delivery"
+            description="Build password protected galleries, track delivery dates and make it effortless for clients to download files."
+            actions={
+                <Link
+                    href="/settings"
+                    className="inline-flex items-center rounded-lg border border-emerald-500/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300 transition hover:border-emerald-300 hover:text-emerald-200"
+                >
+                    Configure branding
+                </Link>
+            }
+        >
+            <GalleryUploader clients={clients} galleries={galleries} onCreate={handleCreateGallery} />
+            {statusMessage && (
+                <p className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-center text-xs text-emerald-200">
+                    {statusMessage}
+                </p>
+            )}
+        </CRMLayout>
+    );
+}
+
+export const getStaticProps: GetStaticProps<GalleryPageProps> = async () => {
+    const [clientsData, galleriesData] = await Promise.all([getClients(), getGalleries()]);
+    return {
+        props: {
+            clients: clientsData,
+            galleries: galleriesData
+        }
+    };
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,197 @@
+import type { GetStaticProps } from 'next';
+import Link from 'next/link';
+import { CRMLayout } from '../components/crm/CRMLayout';
+import { DashboardCard } from '../components/crm/DashboardCard';
+import { Booking, Client, Invoice } from '../lib/mock-data';
+import { getBookings, getClients, getInvoices } from '../lib/api';
+
+function formatCurrency(amount: number) {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+}
+
+type DashboardPageProps = {
+    clients: Client[];
+    bookings: Booking[];
+    invoices: Invoice[];
+};
+
+export default function DashboardPage({ clients, bookings, invoices }: DashboardPageProps) {
+    const outstandingInvoices = invoices.filter((invoice) => invoice.status !== 'paid');
+    const outstandingTotal = outstandingInvoices.reduce((sum, invoice) => sum + invoice.amount, 0);
+    const upcomingBookings = bookings
+        .filter((booking) => new Date(booking.date) >= new Date())
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    const nextBooking = upcomingBookings[0];
+    const completedThisMonth = bookings.filter((booking) => {
+        const bookingDate = new Date(booking.date);
+        const now = new Date();
+        return (
+            booking.status === 'completed' &&
+            bookingDate.getMonth() === now.getMonth() &&
+            bookingDate.getFullYear() === now.getFullYear()
+        );
+    });
+
+    return (
+        <CRMLayout
+            title="Studio Overview"
+            description="Track clients, shoots, invoices and delivery milestones from one centralized photographer workspace."
+            actions={
+                <Link
+                    href="/bookings"
+                    className="inline-flex items-center rounded-lg border border-emerald-500/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300 transition hover:border-emerald-300 hover:text-emerald-200"
+                >
+                    View calendar
+                </Link>
+            }
+        >
+            <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                <DashboardCard
+                    title="Active clients"
+                    value={String(clients.length)}
+                    accent="Across weddings, portraits & recurring sessions"
+                    description="Add upcoming clients directly from inquiry forms or the CRM to keep your pipeline visible."
+                />
+                <DashboardCard
+                    title="Upcoming shoots"
+                    value={String(upcomingBookings.length)}
+                    accent={nextBooking ? `Next: ${nextBooking.shootType} on ${new Intl.DateTimeFormat('en-US', {
+                            month: 'short',
+                            day: 'numeric'
+                        }).format(new Date(nextBooking.date))}` : 'No shoots on the calendar'}
+                    description="Confirm shot lists, assistants and gear prep ahead of time so every production runs smoothly."
+                />
+                <DashboardCard
+                    title="Outstanding invoices"
+                    value={formatCurrency(outstandingTotal)}
+                    accent={`${outstandingInvoices.length} awaiting payment`}
+                    description="Send payment reminders or convert drafts into final invoices before the due date hits."
+                />
+                <DashboardCard
+                    title="Completed this month"
+                    value={String(completedThisMonth.length)}
+                    accent="Shoots delivered and ready for testimonials"
+                    description="Celebrate the wins—archive galleries, request reviews and update your portfolio."
+                />
+            </section>
+
+            <section className="grid gap-6 lg:grid-cols-2">
+                <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                    <div className="flex items-center justify-between">
+                        <h2 className="text-lg font-semibold text-white">Upcoming schedule</h2>
+                        <Link href="/bookings" className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                            Open calendar
+                        </Link>
+                    </div>
+                    <p className="mt-2 text-xs uppercase tracking-[0.3em] text-slate-400">Next 5 sessions</p>
+                    <div className="mt-4 space-y-4 text-sm">
+                        {upcomingBookings.slice(0, 5).map((booking) => (
+                            <div key={booking.id} className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4">
+                                <p className="text-sm font-semibold text-white">{booking.shootType}</p>
+                                <p className="text-xs text-slate-400">{booking.location}</p>
+                                <div className="mt-2 flex items-center justify-between text-xs text-slate-400">
+                                    <span>
+                                        {new Intl.DateTimeFormat('en-US', {
+                                            month: 'short',
+                                            day: 'numeric',
+                                            year: 'numeric'
+                                        }).format(new Date(booking.date))}
+                                    </span>
+                                    <span>
+                                        {booking.startTime} – {booking.endTime}
+                                    </span>
+                                    <span className="capitalize">{booking.status}</span>
+                                </div>
+                            </div>
+                        ))}
+                        {upcomingBookings.length === 0 && (
+                            <p className="rounded-xl border border-dashed border-slate-800/80 bg-slate-950/40 p-6 text-center text-xs text-slate-400">
+                                All clear! Add a shoot from the bookings page to populate your schedule.
+                            </p>
+                        )}
+                    </div>
+                </div>
+
+                <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                    <div className="flex items-center justify-between">
+                        <h2 className="text-lg font-semibold text-white">Outstanding balances</h2>
+                        <Link href="/invoices" className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                            Manage invoices
+                        </Link>
+                    </div>
+                    <p className="mt-2 text-xs uppercase tracking-[0.3em] text-slate-400">Clients to follow up</p>
+                    <div className="mt-4 space-y-4 text-sm">
+                        {outstandingInvoices.map((invoice) => {
+                            const client = clients.find((item) => item.id === invoice.clientId);
+                            return (
+                                <div key={invoice.id} className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4">
+                                    <p className="text-sm font-semibold text-white">
+                                        {client?.name ?? 'Unknown client'}
+                                    </p>
+                                    <div className="mt-1 flex items-center justify-between text-xs text-slate-400">
+                                        <span>{invoice.description ?? 'Invoice due soon'}</span>
+                                        <span className="font-semibold text-emerald-300">{formatCurrency(invoice.amount)}</span>
+                                    </div>
+                                    <p className="mt-2 text-xs text-slate-400">
+                                        Due on{' '}
+                                        {new Intl.DateTimeFormat('en-US', {
+                                            month: 'short',
+                                            day: 'numeric',
+                                            year: 'numeric'
+                                        }).format(new Date(invoice.dueDate))}
+                                    </p>
+                                </div>
+                            );
+                        })}
+                        {outstandingInvoices.length === 0 && (
+                            <p className="rounded-xl border border-dashed border-slate-800/80 bg-slate-950/40 p-6 text-center text-xs text-slate-400">
+                                All invoices paid—great job staying on top of cash flow!
+                            </p>
+                        )}
+                    </div>
+                </div>
+            </section>
+
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div>
+                        <h2 className="text-lg font-semibold text-white">Quick actions</h2>
+                        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                            Jump straight into your most common workflows
+                        </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                        <Link href="/clients" className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                            Add client
+                        </Link>
+                        <Link href="/bookings" className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                            Schedule shoot
+                        </Link>
+                        <Link href="/invoices" className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                            Send invoice
+                        </Link>
+                        <Link href="/gallery" className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                            Deliver gallery
+                        </Link>
+                    </div>
+                </div>
+            </section>
+        </CRMLayout>
+    );
+}
+
+export const getStaticProps: GetStaticProps<DashboardPageProps> = async () => {
+    const [clientsData, bookingsData, invoicesData] = await Promise.all([
+        getClients(),
+        getBookings(),
+        getInvoices()
+    ]);
+
+    return {
+        props: {
+            clients: clientsData,
+            bookings: bookingsData,
+            invoices: invoicesData
+        }
+    };
+};

--- a/src/pages/invoices/index.tsx
+++ b/src/pages/invoices/index.tsx
@@ -1,0 +1,121 @@
+import type { GetStaticProps } from 'next';
+import Link from 'next/link';
+import { useState } from 'react';
+import { CRMLayout } from '../../components/crm/CRMLayout';
+import { InvoiceForm } from '../../components/crm/InvoiceForm';
+import type { Client, Invoice } from '../../lib/mock-data';
+import { createInvoice, getClients, getInvoices } from '../../lib/api';
+
+function formatCurrency(amount: number) {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+}
+
+type InvoicesPageProps = {
+    invoices: Invoice[];
+    clients: Client[];
+};
+
+type InvoiceStatusStyle = {
+    label: string;
+    className: string;
+};
+
+const STATUS_STYLES: Record<Invoice['status'], InvoiceStatusStyle> = {
+    draft: { label: 'Draft', className: 'bg-slate-800 text-slate-200' },
+    sent: { label: 'Sent', className: 'bg-emerald-500/10 text-emerald-200' },
+    paid: { label: 'Paid', className: 'bg-emerald-500 text-slate-900' },
+    overdue: { label: 'Overdue', className: 'bg-rose-500 text-white' }
+};
+
+export default function InvoicesPage({ invoices: initialInvoices, clients }: InvoicesPageProps) {
+    const [invoices, setInvoices] = useState(initialInvoices);
+    const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+    async function handleCreateInvoice(payload: Parameters<typeof createInvoice>[0]) {
+        const newInvoice = await createInvoice(payload);
+        setInvoices((prev) => [...prev, newInvoice]);
+        const client = clients.find((item) => item.id === newInvoice.clientId);
+        setStatusMessage(`Draft invoice ${newInvoice.id} created for ${client?.name ?? 'client'}.`);
+        setTimeout(() => setStatusMessage(null), 4000);
+    }
+
+    return (
+        <CRMLayout
+            title="Invoice Management"
+            description="Send branded invoices, track payment status and keep your cash flow predictable."
+            actions={
+                <Link
+                    href="/clients"
+                    className="inline-flex items-center rounded-lg border border-emerald-500/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300 transition hover:border-emerald-300 hover:text-emerald-200"
+                >
+                    View clients
+                </Link>
+            }
+        >
+            <section className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+                <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                        <h2 className="text-lg font-semibold text-white">Invoices</h2>
+                        <span className="text-xs uppercase tracking-[0.3em] text-slate-400">{invoices.length} total</span>
+                    </div>
+                    <div className="space-y-4">
+                        {invoices.map((invoice) => {
+                            const client = clients.find((item) => item.id === invoice.clientId);
+                            const style = STATUS_STYLES[invoice.status];
+                            return (
+                                <article
+                                    key={invoice.id}
+                                    className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-lg shadow-slate-950/40"
+                                >
+                                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p className="text-sm font-semibold text-white">{client?.name ?? 'Unknown client'}</p>
+                                            <p className="text-xs text-slate-400">{invoice.description ?? 'Invoice details coming soon'}</p>
+                                        </div>
+                                        <div className="text-right text-xs text-slate-400">
+                                            <p className="text-lg font-semibold text-white">{formatCurrency(invoice.amount)}</p>
+                                            <p>Due {new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(invoice.dueDate))}</p>
+                                        </div>
+                                    </div>
+                                    <div className="mt-4 flex items-center justify-between text-xs">
+                                        <span
+                                            className={`inline-flex items-center rounded-full px-3 py-1 font-semibold uppercase tracking-[0.3em] ${style.className}`}
+                                        >
+                                            {style.label}
+                                        </span>
+                                        <div className="flex gap-2 text-emerald-300">
+                                            <button className="rounded-full border border-emerald-500/40 px-3 py-1 hover:border-emerald-300 hover:text-emerald-200">
+                                                Download PDF
+                                            </button>
+                                            <button className="rounded-full border border-emerald-500/40 px-3 py-1 hover:border-emerald-300 hover:text-emerald-200">
+                                                Send reminder
+                                            </button>
+                                        </div>
+                                    </div>
+                                </article>
+                            );
+                        })}
+                    </div>
+                </div>
+                <div className="space-y-4">
+                    <InvoiceForm clients={clients} onSubmit={handleCreateInvoice} />
+                    {statusMessage && (
+                        <p className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-center text-xs text-emerald-200">
+                            {statusMessage}
+                        </p>
+                    )}
+                </div>
+            </section>
+        </CRMLayout>
+    );
+}
+
+export const getStaticProps: GetStaticProps<InvoicesPageProps> = async () => {
+    const [invoicesData, clientsData] = await Promise.all([getInvoices(), getClients()]);
+    return {
+        props: {
+            invoices: invoicesData,
+            clients: clientsData
+        }
+    };
+};

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,0 +1,164 @@
+import type { GetStaticProps } from 'next';
+import { useState } from 'react';
+import { CRMLayout } from '../../components/crm/CRMLayout';
+import { getCurrentUser } from '../../lib/auth';
+import type { CMSCollection } from '../../lib/cms';
+import { listCollections } from '../../lib/cms';
+
+interface SettingsPageProps {
+    collections: CMSCollection[];
+}
+
+export default function SettingsPage({ collections }: SettingsPageProps) {
+    const user = getCurrentUser();
+    const [brandName, setBrandName] = useState(user.brandName ?? '');
+    const [replyToEmail, setReplyToEmail] = useState(user.email);
+    const [notifications, setNotifications] = useState({
+        bookingReminder: true,
+        invoiceReminder: true,
+        galleryExpiring: true
+    });
+
+    return (
+        <CRMLayout
+            title="Studio Settings"
+            description="Update your brand presence, automate reminders and review the data models powering the CRM."
+        >
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                <h2 className="text-lg font-semibold text-white">Brand identity</h2>
+                <p className="mt-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    These details sync to invoices, proposals and client emails
+                </p>
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                        Studio name
+                        <input
+                            type="text"
+                            className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                            value={brandName}
+                            onChange={(event) => setBrandName(event.target.value)}
+                        />
+                    </label>
+                    <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                        Reply-to email
+                        <input
+                            type="email"
+                            className="rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                            value={replyToEmail}
+                            onChange={(event) => setReplyToEmail(event.target.value)}
+                        />
+                    </label>
+                    <label className="md:col-span-2">
+                        <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Brand statement</span>
+                        <textarea
+                            className="mt-2 h-24 w-full rounded-lg border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                            placeholder="Tell clients what makes working with you unforgettable."
+                        />
+                    </label>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                    <button className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                        Upload logo
+                    </button>
+                    <button className="rounded-full border border-emerald-500/40 px-4 py-2 hover:border-emerald-300 hover:text-emerald-200">
+                        Save settings
+                    </button>
+                </div>
+            </section>
+
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                <h2 className="text-lg font-semibold text-white">Automation</h2>
+                <p className="mt-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Send timely reminders and surprise-and-delight touchpoints
+                </p>
+                <div className="mt-4 space-y-4 text-sm">
+                    <label className="flex items-center justify-between gap-4 rounded-xl border border-slate-800/80 bg-slate-950/60 px-4 py-3">
+                        <div>
+                            <p className="font-semibold text-white">Booking prep reminder</p>
+                            <p className="text-xs text-slate-400">Email clients a prep guide 3 days before their session.</p>
+                        </div>
+                        <input
+                            type="checkbox"
+                            checked={notifications.bookingReminder}
+                            onChange={(event) =>
+                                setNotifications((prev) => ({
+                                    ...prev,
+                                    bookingReminder: event.target.checked
+                                }))
+                            }
+                            className="h-5 w-5 rounded border border-emerald-500/30 bg-slate-900 text-emerald-500 focus:ring-emerald-500"
+                        />
+                    </label>
+                    <label className="flex items-center justify-between gap-4 rounded-xl border border-slate-800/80 bg-slate-950/60 px-4 py-3">
+                        <div>
+                            <p className="font-semibold text-white">Invoice reminder</p>
+                            <p className="text-xs text-slate-400">Send an automated nudge 2 days after the due date.</p>
+                        </div>
+                        <input
+                            type="checkbox"
+                            checked={notifications.invoiceReminder}
+                            onChange={(event) =>
+                                setNotifications((prev) => ({
+                                    ...prev,
+                                    invoiceReminder: event.target.checked
+                                }))
+                            }
+                            className="h-5 w-5 rounded border border-emerald-500/30 bg-slate-900 text-emerald-500 focus:ring-emerald-500"
+                        />
+                    </label>
+                    <label className="flex items-center justify-between gap-4 rounded-xl border border-slate-800/80 bg-slate-950/60 px-4 py-3">
+                        <div>
+                            <p className="font-semibold text-white">Gallery expiry</p>
+                            <p className="text-xs text-slate-400">Let clients know when galleries will archive or need renewal.</p>
+                        </div>
+                        <input
+                            type="checkbox"
+                            checked={notifications.galleryExpiring}
+                            onChange={(event) =>
+                                setNotifications((prev) => ({
+                                    ...prev,
+                                    galleryExpiring: event.target.checked
+                                }))
+                            }
+                            className="h-5 w-5 rounded border border-emerald-500/30 bg-slate-900 text-emerald-500 focus:ring-emerald-500"
+                        />
+                    </label>
+                </div>
+            </section>
+
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+                <h2 className="text-lg font-semibold text-white">Content model blueprint</h2>
+                <p className="mt-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    Collections ready to sync with Netlify (Decap) CMS or another git-based workflow
+                </p>
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    {collections.map((collection) => (
+                        <article
+                            key={collection.name}
+                            className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 text-sm text-slate-200"
+                        >
+                            <h3 className="text-base font-semibold text-white">{collection.label}</h3>
+                            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{collection.folder}</p>
+                            <ul className="mt-3 space-y-2 text-xs text-slate-300">
+                                {collection.fields.map((field) => (
+                                    <li key={field.name} className="flex items-start justify-between gap-2">
+                                        <span className="font-medium text-white">{field.label}</span>
+                                        <span className="text-slate-400">{field.widget}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </article>
+                    ))}
+                </div>
+            </section>
+        </CRMLayout>
+    );
+}
+
+export const getStaticProps: GetStaticProps<SettingsPageProps> = async () => {
+    return {
+        props: {
+            collections: listCollections()
+        }
+    };
+};


### PR DESCRIPTION
## Summary
- add CRM layout components with supporting mock data, auth helpers, and CMS collection definitions
- implement dashboard, clients, bookings, invoices, gallery, and settings pages for the photographer CRM experience
- adjust catch-all routing so legacy content continues to build alongside the new CRM homepage
- restyle the CRM client table with status pills and supporting client metadata

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ea6d7bfc8329b963f6df47f85448