### PR TITLE
fix: disable git push during netlify builds

### DIFF
--- a/sources/local/local-git-content-source.ts
+++ b/sources/local/local-git-content-source.ts
@@ -1,0 +1,29 @@
+import type { InitOptions } from '@stackbit/types';
+import { GitContentSource, type GitContentSourceOptions } from '@stackbit/cms-git';
+import type { DocumentContext, AssetContext } from '@stackbit/cms-git/dist/content-converter';
+
+/**
+ * Custom Git content source that disables remote syncing during Netlify builds.
+ *
+ * The default GitContentSource will push commits back to the repository when
+ * running in a non-local environment. When Netlify clones the site from the
+ * starter template, those pushes fail if the remote already contains
+ * additional commits (for example, project-specific customizations).
+ *
+ * By overriding `init` and forcing `syncRemote` to false, we ensure Netlify
+ * treats the content source as read-only during builds so it no longer
+ * attempts to push to the remote repository.
+ */
+export class LocalOnlyGitContentSource extends GitContentSource {
+    constructor(options: GitContentSourceOptions) {
+        super(options);
+    }
+
+    async init(options: InitOptions<unknown, DocumentContext, AssetContext>): Promise<void> {
+        await super.init(options);
+        // Disable remote sync to avoid git push attempts in the build environment.
+        (this as unknown as { syncRemote: boolean }).syncRemote = false;
+    }
+}
+
+export type { GitContentSourceOptions };

--- a/stackbit.config.ts
+++ b/stackbit.config.ts
@@ -1,8 +1,8 @@
 import { defineStackbitConfig, DocumentStringLikeFieldNonLocalized, SiteMapEntry } from '@stackbit/types';
-import { GitContentSource } from '@stackbit/cms-git';
+import { LocalOnlyGitContentSource, type GitContentSourceOptions } from './sources/local/local-git-content-source';
 import { allModels } from 'sources/local/models';
 
-const gitContentSource = new GitContentSource({
+const gitContentSource = new LocalOnlyGitContentSource({
     rootPath: __dirname,
     contentDirs: ['content'],
     models: Object.values(allModels),


### PR DESCRIPTION
## Summary
- add a custom Stackbit Git content source that turns off remote syncing during builds
- wire the Netlify configuration to use the local-only content source so deploys stop trying to push upstream

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8f493ea688329929c32a2b4564282