### PR TITLE
Add CRM dashboard layout with navigation and dark mode

### DIFF
--- a/src/components/crm/BookingList.tsx
+++ b/src/components/crm/BookingList.tsx
@@ -26,20 +26,20 @@ const formatDate = (value: string) => dayjs(value).format('ddd, MMM D');
 
 export function BookingList({ bookings }: { bookings: BookingRecord[] }) {
     return (
-        <ol className="relative space-y-6 border-l border-slate-200 pl-6">
+        <ol className="relative space-y-6 border-l border-slate-200 pl-6 dark:border-slate-800">
             {bookings.map((booking) => (
                 <li key={booking.id} className="relative">
-                    <span className="absolute -left-3 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-indigo-500">
+                    <span className="absolute -left-3 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-indigo-500 dark:border-slate-900 dark:bg-indigo-500/20 dark:text-indigo-300">
                         •
                     </span>
-                    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
                         <div className="flex flex-wrap items-start justify-between gap-3">
                             <div>
-                                <p className="text-sm font-medium text-indigo-600">{formatDate(booking.date)}</p>
-                                <h3 className="text-lg font-semibold text-slate-900">{booking.client}</h3>
-                                <p className="text-sm text-slate-500">{booking.shootType}</p>
+                                <p className="text-sm font-medium text-indigo-600 dark:text-indigo-400">{formatDate(booking.date)}</p>
+                                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{booking.client}</h3>
+                                <p className="text-sm text-slate-500 dark:text-slate-400">{booking.shootType}</p>
                             </div>
-                            <div className="text-right text-sm text-slate-500">
+                            <div className="text-right text-sm text-slate-500 dark:text-slate-400">
                                 <p>
                                     {booking.startTime}
                                     {booking.endTime ? ` – ${booking.endTime}` : ''}

--- a/src/components/crm/ClientTable.tsx
+++ b/src/components/crm/ClientTable.tsx
@@ -27,9 +27,9 @@ const formatDate = (value?: string) => (value ? dayjs(value).format('MMM D, YYYY
 
 export function ClientTable({ clients }: { clients: ClientRecord[] }) {
     return (
-        <div className="overflow-hidden rounded-2xl border border-slate-200">
-            <table className="min-w-full divide-y divide-slate-200 text-left">
-                <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-800">
+            <table className="min-w-full divide-y divide-slate-200 text-left dark:divide-slate-800">
+                <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:text-slate-300">
                     <tr>
                         <th scope="col" className="px-5 py-3">
                             Client
@@ -48,19 +48,19 @@ export function ClientTable({ clients }: { clients: ClientRecord[] }) {
                         </th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-100 text-sm">
+                <tbody className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
                     {clients.map((client) => (
-                        <tr key={client.id} className="hover:bg-slate-50">
+                        <tr key={client.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/60">
                             <td className="px-5 py-4">
-                                <div className="font-medium text-slate-900">{client.name}</div>
-                                <div className="text-sm text-slate-500">{client.email}</div>
+                                <div className="font-medium text-slate-900 dark:text-white">{client.name}</div>
+                                <div className="text-sm text-slate-500 dark:text-slate-400">{client.email}</div>
                             </td>
                             <td className="px-5 py-4">
-                                <div className="text-sm font-medium text-slate-900">{client.shoots}</div>
-                                {client.phone && <div className="text-xs text-slate-500">{client.phone}</div>}
+                                <div className="text-sm font-medium text-slate-900 dark:text-white">{client.shoots}</div>
+                                {client.phone && <div className="text-xs text-slate-500 dark:text-slate-400">{client.phone}</div>}
                             </td>
-                            <td className="px-5 py-4 text-slate-600">{formatDate(client.lastShoot)}</td>
-                            <td className="px-5 py-4 text-slate-600">{formatDate(client.upcomingShoot)}</td>
+                            <td className="px-5 py-4 text-slate-600 dark:text-slate-400">{formatDate(client.lastShoot)}</td>
+                            <td className="px-5 py-4 text-slate-600 dark:text-slate-400">{formatDate(client.upcomingShoot)}</td>
                             <td className="px-5 py-4">
                                 <StatusPill tone={statusToneMap[client.status]}>{client.status}</StatusPill>
                             </td>

--- a/src/components/crm/DashboardCard.tsx
+++ b/src/components/crm/DashboardCard.tsx
@@ -15,27 +15,27 @@ type DashboardCardProps = {
 
 const trendClassNames = (isPositive?: boolean) =>
     classNames('text-sm font-medium', {
-        'text-emerald-600': isPositive !== false,
-        'text-rose-600': isPositive === false
+        'text-emerald-600 dark:text-emerald-400': isPositive !== false,
+        'text-rose-600 dark:text-rose-400': isPositive === false
     });
 
 export function DashboardCard({ title, value, trend, className, children }: DashboardCardProps) {
     return (
         <div
             className={classNames(
-                'flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md',
+                'flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900',
                 className
             )}
         >
-            <p className="text-sm font-medium text-slate-500">{title}</p>
-            <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-900">{value}</p>
+            <p className="text-sm font-medium text-slate-500 dark:text-slate-300">{title}</p>
+            <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 dark:text-white">{value}</p>
             {trend && (
                 <p className={classNames('mt-2 flex items-center gap-2', trendClassNames(trend.isPositive))}>
                     <span>{trend.value}</span>
-                    {trend.label && <span className="text-slate-500">{trend.label}</span>}
+                    {trend.label && <span className="text-slate-500 dark:text-slate-400">{trend.label}</span>}
                 </p>
             )}
-            {children && <div className="mt-4 flex-grow text-sm text-slate-500">{children}</div>}
+            {children && <div className="mt-4 flex-grow text-sm text-slate-500 dark:text-slate-300">{children}</div>}
         </div>
     );
 }

--- a/src/components/crm/InvoiceTable.tsx
+++ b/src/components/crm/InvoiceTable.tsx
@@ -29,21 +29,21 @@ export function InvoiceTable({ invoices }: { invoices: InvoiceRecord[] }) {
     return (
         <div className="space-y-4">
             {invoices.map((invoice) => (
-                <div key={invoice.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div key={invoice.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
                     <div className="flex items-start justify-between gap-3">
                         <div>
-                            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">Invoice {invoice.id}</p>
-                            <h3 className="text-base font-semibold text-slate-900">{invoice.client}</h3>
-                            <p className="text-sm text-slate-500">{invoice.project}</p>
+                            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Invoice {invoice.id}</p>
+                            <h3 className="text-base font-semibold text-slate-900 dark:text-white">{invoice.client}</h3>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">{invoice.project}</p>
                         </div>
                         <div className="text-right">
-                            <p className="text-lg font-semibold text-slate-900">{formatCurrency(invoice.amount)}</p>
-                            <p className="text-sm text-slate-500">Due {formatDate(invoice.dueDate)}</p>
+                            <p className="text-lg font-semibold text-slate-900 dark:text-white">{formatCurrency(invoice.amount)}</p>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">Due {formatDate(invoice.dueDate)}</p>
                         </div>
                     </div>
                     <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
                         <StatusPill tone={statusToneMap[invoice.status]}>{invoice.status}</StatusPill>
-                        <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500">View invoice</button>
+                        <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">View invoice</button>
                     </div>
                 </div>
             ))}

--- a/src/components/crm/SectionCard.tsx
+++ b/src/components/crm/SectionCard.tsx
@@ -13,16 +13,16 @@ export function SectionCard({ title, description, action, children, className }:
     return (
         <section
             className={classNames(
-                'rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md',
+                'rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900',
                 className
             )}
         >
             <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
-                    {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
+                    <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
+                    {description && <p className="mt-1 text-sm text-slate-500 dark:text-slate-300">{description}</p>}
                 </div>
-                {action && <div className="flex shrink-0 items-center gap-2 text-sm font-medium text-indigo-600">{action}</div>}
+                {action && <div className="flex shrink-0 items-center gap-2 text-sm font-medium text-indigo-600 dark:text-indigo-400">{action}</div>}
             </div>
             <div className="mt-5">{children}</div>
         </section>

--- a/src/components/crm/StatusPill.tsx
+++ b/src/components/crm/StatusPill.tsx
@@ -9,11 +9,11 @@ type StatusPillProps = {
 };
 
 const toneStyles: Record<StatusTone, string> = {
-    success: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
-    warning: 'bg-amber-50 text-amber-700 ring-amber-200',
-    danger: 'bg-rose-50 text-rose-700 ring-rose-200',
-    info: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
-    neutral: 'bg-slate-100 text-slate-700 ring-slate-200'
+    success: 'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-200 dark:ring-emerald-500/40',
+    warning: 'bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-200 dark:ring-amber-500/40',
+    danger: 'bg-rose-50 text-rose-700 ring-rose-200 dark:bg-rose-500/10 dark:text-rose-200 dark:ring-rose-500/40',
+    info: 'bg-indigo-50 text-indigo-700 ring-indigo-200 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/40',
+    neutral: 'bg-slate-100 text-slate-700 ring-slate-200 dark:bg-slate-700/40 dark:text-slate-200 dark:ring-slate-600'
 };
 
 export function StatusPill({ tone = 'neutral', children }: StatusPillProps) {

--- a/src/components/crm/TaskList.tsx
+++ b/src/components/crm/TaskList.tsx
@@ -15,22 +15,22 @@ export function TaskList({ tasks }: { tasks: TaskRecord[] }) {
     return (
         <ul className="space-y-3">
             {tasks.map((task) => (
-                <li key={task.id} className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <li key={task.id} className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
                     <input
                         type="checkbox"
                         checked={task.completed}
                         readOnly
-                        className="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                        className="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900"
                     />
                     <div className="flex-1">
-                        <p className="text-sm font-medium text-slate-900">{task.title}</p>
-                        <p className="text-xs text-slate-500">
+                        <p className="text-sm font-medium text-slate-900 dark:text-white">{task.title}</p>
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
                             Due {formatDate(task.dueDate)}
                             {task.assignee ? ` · ${task.assignee}` : ''}
                         </p>
                     </div>
                     {!task.completed && (
-                        <button className="text-xs font-semibold text-indigo-600 hover:text-indigo-500">Open</button>
+                        <button className="text-xs font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">Open</button>
                     )}
                 </li>
             ))}

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 
 import {
     BookingList,
@@ -184,81 +185,278 @@ const quickActions = [
     { id: 'upload-gallery', label: 'Upload gallery' }
 ];
 
+const navigationItems = [
+    { id: 'dashboard', label: 'Dashboard', href: '/crm', isActive: true },
+    { id: 'calendar', label: 'Calendar', href: '#' },
+    { id: 'clients', label: 'Clients', href: '#' },
+    { id: 'invoices', label: 'Invoices', href: '#' },
+    { id: 'galleries', label: 'Galleries', href: '#' },
+    { id: 'projects', label: 'Projects', href: '#' },
+    { id: 'settings', label: 'Settings', href: '#' }
+];
+
 export default function PhotographyCrmDashboard() {
+    const [isDarkMode, setIsDarkMode] = React.useState<boolean | null>(null);
+    const [isUserMenuOpen, setIsUserMenuOpen] = React.useState(false);
+    const userMenuRef = React.useRef<HTMLDivElement | null>(null);
+
+    React.useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+        const storedTheme = window.localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const shouldEnableDark = storedTheme ? storedTheme === 'dark' : prefersDark;
+        setIsDarkMode(shouldEnableDark);
+    }, []);
+
+    React.useEffect(() => {
+        if (typeof window === 'undefined' || isDarkMode === null) {
+            return;
+        }
+        const root = window.document.documentElement;
+        if (isDarkMode) {
+            root.classList.add('dark');
+            window.localStorage.setItem('theme', 'dark');
+        } else {
+            root.classList.remove('dark');
+            window.localStorage.setItem('theme', 'light');
+        }
+    }, [isDarkMode]);
+
+    React.useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+        const handleClick = (event: MouseEvent) => {
+            if (userMenuRef.current && !userMenuRef.current.contains(event.target as Node)) {
+                setIsUserMenuOpen(false);
+            }
+        };
+
+        window.document.addEventListener('mousedown', handleClick);
+        return () => window.document.removeEventListener('mousedown', handleClick);
+    }, []);
+
+    const toggleDarkMode = () => {
+        setIsDarkMode((previous) => (previous === null ? true : !previous));
+    };
+
     return (
         <>
             <Head>
                 <title>Photography CRM Dashboard</title>
                 <meta name="description" content="Command center for managing photography clients, shoots and invoices." />
             </Head>
-            <main className="min-h-screen bg-slate-50 pb-16">
-                <div className="mx-auto max-w-7xl px-6 pt-12">
-                    <header className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-                        <div>
-                            <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">Studio Command Center</p>
-                            <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-900">
-                                Photography CRM Dashboard
-                            </h1>
-                            <p className="mt-3 max-w-2xl text-base text-slate-600">
-                                Track client relationships, keep shoots on schedule, and stay ahead of deliverables—all from a
-                                single workspace designed for busy photographers.
-                            </p>
+            <div className="min-h-screen bg-slate-100 transition-colors dark:bg-slate-950">
+                <div className="flex min-h-screen">
+                    <aside className="hidden w-64 flex-col border-r border-slate-200 bg-slate-950 text-slate-100 shadow-lg lg:flex dark:border-slate-900">
+                        <div className="flex h-16 items-center px-6">
+                            <span className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-400">Navigation</span>
                         </div>
-                        <div className="flex flex-wrap gap-3">
-                            {quickActions.map((action) => (
-                                <button
-                                    key={action.id}
-                                    className="inline-flex items-center justify-center rounded-full border border-indigo-200 bg-white px-4 py-2 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50"
+                        <nav className="flex flex-1 flex-col gap-1 px-4 py-4">
+                            {navigationItems.map((item) => (
+                                <Link
+                                    key={item.id}
+                                    href={item.href}
+                                    className={[
+                                        'flex items-center gap-3 rounded-xl px-4 py-2.5 text-sm font-medium transition',
+                                        item.isActive
+                                            ? 'bg-slate-900/80 text-white shadow-inner'
+                                            : 'text-slate-300 hover:bg-slate-900/60 hover:text-white'
+                                    ].join(' ')}
                                 >
-                                    {action.label}
-                                </button>
+                                    <span className="inline-flex h-2 w-2 rounded-full bg-current" aria-hidden="true" />
+                                    {item.label}
+                                </Link>
                             ))}
+                        </nav>
+                        <div className="px-6 pb-8 text-xs text-slate-500">
+                            <p className="font-semibold text-slate-200">Codex Environment</p>
+                            <p className="mt-1 text-slate-400">Organize every shoot, deliverable, and client moment.</p>
                         </div>
-                    </header>
+                    </aside>
+                    <div className="flex min-h-screen flex-1 flex-col">
+                        <header className="sticky top-0 z-30 flex h-16 items-center justify-between border-b border-slate-200 bg-white/90 px-6 backdrop-blur transition-colors dark:border-slate-800 dark:bg-slate-900/80">
+                            <div className="flex items-center gap-3">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white shadow-sm">
+                                    CE
+                                </div>
+                                <div>
+                                    <p className="text-xs font-semibold uppercase tracking-[0.32em] text-indigo-600 dark:text-indigo-400">
+                                        Codex Environment
+                                    </p>
+                                    <p className="text-base font-semibold text-slate-900 dark:text-white">Studio CRM</p>
+                                </div>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    type="button"
+                                    onClick={toggleDarkMode}
+                                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-white"
+                                    aria-label={isDarkMode ? 'Activate light mode' : 'Activate dark mode'}
+                                >
+                                    {isDarkMode ? <SunIcon className="h-5 w-5" /> : <MoonIcon className="h-5 w-5" />}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="relative inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-white"
+                                    aria-label="Open notifications"
+                                >
+                                    <BellIcon className="h-5 w-5" />
+                                    <span className="absolute right-2 top-2 inline-flex h-2 w-2 rounded-full bg-rose-500"></span>
+                                </button>
+                                <div className="relative" ref={userMenuRef}>
+                                    <button
+                                        type="button"
+                                        onClick={() => setIsUserMenuOpen((open) => !open)}
+                                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-2 py-1 pl-1 pr-3 text-sm font-medium text-slate-700 shadow-sm transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:text-white"
+                                        aria-haspopup="menu"
+                                        aria-expanded={isUserMenuOpen}
+                                    >
+                                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-600 text-sm font-semibold text-white">
+                                            AL
+                                        </span>
+                                        <span className="hidden text-left sm:block">
+                                            <span className="block text-xs text-slate-500 dark:text-slate-400">Photographer</span>
+                                            <span className="block font-semibold">Avery Logan</span>
+                                        </span>
+                                        <ChevronDownIcon className={`h-4 w-4 transition ${isUserMenuOpen ? 'rotate-180' : ''}`} />
+                                    </button>
+                                    {isUserMenuOpen && (
+                                        <div className="absolute right-0 mt-3 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white py-2 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                                            <button className="block w-full px-4 py-2 text-left text-sm font-medium text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800">
+                                                Profile
+                                            </button>
+                                            <button className="block w-full px-4 py-2 text-left text-sm font-medium text-rose-600 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-500/10">
+                                                Logout
+                                            </button>
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </header>
+                        <main className="flex-1 bg-slate-50 pb-16 transition-colors dark:bg-slate-950">
+                            <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 pt-10">
+                                <header className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                                    <div>
+                                        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600 dark:text-indigo-400">
+                                            Studio Command Center
+                                        </p>
+                                        <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">
+                                            Photography CRM Dashboard
+                                        </h1>
+                                        <p className="mt-3 max-w-2xl text-base text-slate-600 dark:text-slate-300">
+                                            Track client relationships, keep shoots on schedule, and stay ahead of deliverables—all from a
+                                            single workspace designed for busy photographers.
+                                        </p>
+                                    </div>
+                                    <div className="flex flex-wrap gap-3">
+                                        {quickActions.map((action) => (
+                                            <button
+                                                key={action.id}
+                                                className="inline-flex items-center justify-center rounded-full border border-indigo-200 bg-white px-4 py-2 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50 dark:border-indigo-500/40 dark:bg-slate-900/60 dark:text-indigo-300 dark:hover:bg-slate-800/60"
+                                            >
+                                                {action.label}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </header>
 
-                    <section className="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-                        {metrics.map((metric) => (
-                            <DashboardCard key={metric.id} title={metric.title} value={metric.value} trend={metric.trend} />
-                        ))}
-                    </section>
+                                <section className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+                                    {metrics.map((metric) => (
+                                        <DashboardCard key={metric.id} title={metric.title} value={metric.value} trend={metric.trend} />
+                                    ))}
+                                </section>
 
-                    <div className="mt-10 grid gap-6 lg:grid-cols-3">
-                        <div className="space-y-6 lg:col-span-2">
-                            <SectionCard
-                                title="Upcoming Shoots"
-                                description="Stay ready for every session with a quick view of the week ahead."
-                                action={<button className="text-sm font-semibold text-indigo-600">Open calendar</button>}
-                            >
-                                <BookingList bookings={bookings} />
-                            </SectionCard>
+                                <div className="grid gap-6 lg:grid-cols-3">
+                                    <div className="space-y-6 lg:col-span-2">
+                                        <SectionCard
+                                            title="Upcoming Shoots"
+                                            description="Stay ready for every session with a quick view of the week ahead."
+                                            action={
+                                                <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                    Open calendar
+                                                </button>
+                                            }
+                                        >
+                                            <BookingList bookings={bookings} />
+                                        </SectionCard>
 
-                            <SectionCard
-                                title="Active Clients"
-                                description="From loyal regulars to new leads, see who needs attention next."
-                                action={<button className="text-sm font-semibold text-indigo-600">View all clients</button>}
-                            >
-                                <ClientTable clients={clients} />
-                            </SectionCard>
-                        </div>
-                        <div className="space-y-6">
-                            <SectionCard
-                                title="Open Invoices"
-                                description="Collect payments faster with a focused list of outstanding balances."
-                            >
-                                <InvoiceTable invoices={invoices} />
-                            </SectionCard>
+                                        <SectionCard
+                                            title="Active Clients"
+                                            description="From loyal regulars to new leads, see who needs attention next."
+                                            action={
+                                                <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                    View all clients
+                                                </button>
+                                            }
+                                        >
+                                            <ClientTable clients={clients} />
+                                        </SectionCard>
+                                    </div>
+                                    <div className="space-y-6">
+                                        <SectionCard
+                                            title="Open Invoices"
+                                            description="Collect payments faster with a focused list of outstanding balances."
+                                        >
+                                            <InvoiceTable invoices={invoices} />
+                                        </SectionCard>
 
-                            <SectionCard
-                                title="Studio Tasks"
-                                description="Keep production moving with next actions across your team."
-                                action={<button className="text-sm font-semibold text-indigo-600">Create task</button>}
-                            >
-                                <TaskList tasks={tasks} />
-                            </SectionCard>
-                        </div>
+                                        <SectionCard
+                                            title="Studio Tasks"
+                                            description="Keep production moving with next actions across your team."
+                                            action={
+                                                <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                    Create task
+                                                </button>
+                                            }
+                                        >
+                                            <TaskList tasks={tasks} />
+                                        </SectionCard>
+                                    </div>
+                                </div>
+                            </div>
+                        </main>
                     </div>
                 </div>
-            </main>
+            </div>
         </>
+    );
+}
+
+type IconProps = React.SVGProps<SVGSVGElement>;
+
+function MoonIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z" />
+        </svg>
+    );
+}
+
+function SunIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l1.41-1.41M16.24 7.76l1.41-1.41" />
+        </svg>
+    );
+}
+
+function BellIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+    );
+}
+
+function ChevronDownIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M6 9l6 6 6-6" />
+        </svg>
     );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ const plugin = require('tailwindcss/plugin');
 const themeStyle = require('./content/data/style.json');
 
 module.exports = {
+    darkMode: 'class',
     content: ['./src/**/*.{js,ts,jsx,tsx}', './content/**/*', './.sourcebit-nextjs-cache.json'],
     safelist: [
         'text-neutral',


### PR DESCRIPTION
## Summary
- add a global CRM shell with a sidebar navigation, top navbar branding, theme toggle, notifications, and user menu
- implement client-side dark mode toggling with persistence and class-based styling support
- refresh CRM cards, tables, and pills with dark theme styles for consistent visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9647a0a4c8329b16af1c82a0b3569