### PR TITLE
feat: redesign CRM dashboard analytics layout

### DIFF
--- a/src/components/crm/OverviewChart.tsx
+++ b/src/components/crm/OverviewChart.tsx
@@ -1,0 +1,185 @@
+import * as React from 'react';
+
+export type Timeframe = 'weekly' | 'monthly' | 'yearly';
+
+export type ChartPoint = {
+    label: string;
+    shoots: number;
+    revenue: number;
+};
+
+type OverviewChartProps = {
+    data: Record<Timeframe, ChartPoint[]>;
+};
+
+const timeframeOptions: Array<{ id: Timeframe; label: string }> = [
+    { id: 'weekly', label: 'Weekly' },
+    { id: 'monthly', label: 'Monthly' },
+    { id: 'yearly', label: 'Yearly' }
+];
+
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
+
+export function OverviewChart({ data }: OverviewChartProps) {
+    const [timeframe, setTimeframe] = React.useState<Timeframe>('monthly');
+
+    const activeData = data[timeframe] ?? [];
+    const maxRevenue = Math.max(0, ...activeData.map((item) => item.revenue));
+    const maxShoots = Math.max(0, ...activeData.map((item) => item.shoots));
+
+    const chartHeight = 220;
+    const chartPadding = 24;
+    const barWidth = 28;
+    const gap = 32;
+    const datasetLength = activeData.length;
+    const svgWidth =
+        datasetLength > 0
+            ? chartPadding * 2 + datasetLength * barWidth + Math.max(datasetLength - 1, 0) * gap
+            : chartPadding * 2 + barWidth;
+    const svgHeight = chartHeight + chartPadding * 2;
+    const baselineY = svgHeight - chartPadding;
+
+    const revenuePoints = activeData.map((point, index) => {
+        const x = chartPadding + index * (barWidth + gap) + barWidth / 2;
+        const ratio = maxRevenue > 0 ? point.revenue / maxRevenue : 0;
+        const y = baselineY - ratio * chartHeight;
+        return { x, y };
+    });
+
+    const revenuePath = revenuePoints
+        .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x} ${point.y}`)
+        .join(' ');
+
+    const totalShoots = activeData.reduce((total, point) => total + point.shoots, 0);
+    const totalRevenue = activeData.reduce((total, point) => total + point.revenue, 0);
+
+    return (
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Studio overview</h2>
+                    <p className="mt-1 text-sm text-slate-500 dark:text-slate-300">
+                        Shoots scheduled and revenue performance across time horizons.
+                    </p>
+                </div>
+                <div className="inline-flex shrink-0 rounded-full border border-slate-200 bg-slate-50 p-1 text-sm font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                    {timeframeOptions.map((option) => {
+                        const isActive = option.id === timeframe;
+                        return (
+                            <button
+                                key={option.id}
+                                type="button"
+                                onClick={() => setTimeframe(option.id)}
+                                className={[
+                                    'rounded-full px-3 py-1 transition',
+                                    isActive
+                                        ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
+                                        : 'hover:text-slate-900 dark:hover:text-white'
+                                ].join(' ')}
+                            >
+                                {option.label}
+                            </button>
+                        );
+                    })}
+                </div>
+            </div>
+            <div className="mt-6 space-y-6">
+                <div className="flex flex-wrap items-center gap-4 text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
+                    <div className="flex items-center gap-2">
+                        <span className="inline-flex h-2.5 w-2.5 rounded-full bg-indigo-500" aria-hidden="true" />
+                        Shoots
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full border-2 border-emerald-400" aria-hidden="true" />
+                        Revenue
+                    </div>
+                </div>
+                <div className="overflow-x-auto">
+                    {datasetLength === 0 ? (
+                        <p className="rounded-xl bg-slate-50 p-6 text-sm text-slate-500 dark:bg-slate-800/40 dark:text-slate-400">
+                            No analytics available for this timeframe yet.
+                        </p>
+                    ) : (
+                        <svg viewBox={`0 0 ${svgWidth} ${svgHeight}`} className="h-64 w-full min-w-[540px]" role="img">
+                            <title>Chart showing booked shoots and revenue performance</title>
+                            <defs>
+                                <linearGradient id="chartBarGradient" x1="0" x2="0" y1="0" y2="1">
+                                    <stop offset="0%" stopColor="rgba(99, 102, 241, 0.55)" />
+                                    <stop offset="100%" stopColor="rgba(99, 102, 241, 0.15)" />
+                                </linearGradient>
+                            </defs>
+                            {Array.from({ length: 5 }).map((_, index) => {
+                                const y = chartPadding + (chartHeight / 4) * index;
+                                return (
+                                    <line
+                                        key={`grid-${index}`}
+                                        x1={chartPadding - 12}
+                                        x2={svgWidth - chartPadding + 12}
+                                        y1={y}
+                                        y2={y}
+                                        stroke="currentColor"
+                                        strokeWidth={1}
+                                        className="text-slate-100 dark:text-slate-800"
+                                    />
+                                );
+                            })}
+                            {activeData.map((point, index) => {
+                                const barHeight = maxShoots > 0 ? (point.shoots / maxShoots) * chartHeight : 0;
+                                const x = chartPadding + index * (barWidth + gap);
+                                const y = baselineY - barHeight;
+
+                                return (
+                                    <g key={point.label}>
+                                        <rect x={x} y={y} width={barWidth} height={barHeight} rx={8} fill="url(#chartBarGradient)" />
+                                        <text
+                                            x={x + barWidth / 2}
+                                            y={baselineY + 20}
+                                            textAnchor="middle"
+                                            className="fill-slate-500 text-xs dark:fill-slate-400"
+                                        >
+                                            {point.label}
+                                        </text>
+                                    </g>
+                                );
+                            })}
+                            {revenuePath && (
+                                <path
+                                    d={revenuePath}
+                                    fill="none"
+                                    stroke="rgba(16, 185, 129, 0.85)"
+                                    strokeWidth={3}
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                />
+                            )}
+                            {revenuePoints.map((point, index) => (
+                                <circle
+                                    key={`point-${index}`}
+                                    cx={point.x}
+                                    cy={point.y}
+                                    r={5}
+                                    fill="#0f172a"
+                                    stroke="rgba(16, 185, 129, 0.95)"
+                                    strokeWidth={3}
+                                />
+                            ))}
+                        </svg>
+                    )}
+                </div>
+                <dl className="grid gap-4 sm:grid-cols-2">
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/40">
+                        <dt className="font-medium text-slate-500 dark:text-slate-400">Total shoots</dt>
+                        <dd className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">{totalShoots}</dd>
+                    </div>
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/40">
+                        <dt className="font-medium text-slate-500 dark:text-slate-400">Revenue booked</dt>
+                        <dd className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">{formatCurrency(totalRevenue)}</dd>
+                    </div>
+                </dl>
+            </div>
+        </section>
+    );
+}
+
+export default OverviewChart;

--- a/src/components/crm/StatCard.tsx
+++ b/src/components/crm/StatCard.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+
+type StatCardProps = {
+    title: string;
+    value: string;
+    change: number;
+    changeLabel: string;
+    icon: React.ReactNode;
+};
+
+const formatChange = (change: number) => {
+    const rounded = Number.isFinite(change) ? Math.abs(change).toFixed(1) : '0.0';
+    const sign = change >= 0 ? '+' : '-';
+    return `${sign}${rounded}%`;
+};
+
+export function StatCard({ title, value, change, changeLabel, icon }: StatCardProps) {
+    const isPositive = change >= 0;
+    const TrendIcon = isPositive ? TrendUpIcon : TrendDownIcon;
+
+    return (
+        <article className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
+            <div className="flex items-center justify-between">
+                <div className="rounded-full bg-indigo-50 p-3 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
+                    <span className="block h-5 w-5" aria-hidden="true">
+                        {icon}
+                    </span>
+                </div>
+            </div>
+            <div className="mt-10">
+                <p className="text-sm font-medium text-slate-500 dark:text-slate-300">{title}</p>
+                <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-900 dark:text-white">{value}</p>
+                <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                    <span
+                        className={[
+                            'inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide',
+                            isPositive
+                                ? 'bg-emerald-100 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300'
+                                : 'bg-rose-100 text-rose-600 dark:bg-rose-500/10 dark:text-rose-300'
+                        ].join(' ')}
+                    >
+                        <TrendIcon className="h-3.5 w-3.5" />
+                        {formatChange(change)}
+                    </span>
+                    <span className="ml-2">{changeLabel}</span>
+                </p>
+            </div>
+        </article>
+    );
+}
+
+type IconProps = React.SVGProps<SVGSVGElement>;
+
+function TrendUpIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M4 14 10 8 14 12 20 6" />
+            <path d="M20 10V6h-4" />
+        </svg>
+    );
+}
+
+function TrendDownIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M20 10 14 16 10 12 4 18" />
+            <path d="M4 14v4h4" />
+        </svg>
+    );
+}
+
+export default StatCard;

--- a/src/components/crm/index.ts
+++ b/src/components/crm/index.ts
@@ -10,3 +10,6 @@ export { InvoiceTable } from './InvoiceTable';
 export type { InvoiceRecord, InvoiceStatus } from './InvoiceTable';
 export { TaskList } from './TaskList';
 export type { TaskRecord } from './TaskList';
+export { StatCard } from './StatCard';
+export { OverviewChart } from './OverviewChart';
+export type { ChartPoint, Timeframe } from './OverviewChart';

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -1,64 +1,41 @@
 import * as React from 'react';
 import Head from 'next/head';
+import Image from 'next/image';
 import Link from 'next/link';
+import dayjs from 'dayjs';
 
 import {
     BookingList,
     ClientTable,
-    DashboardCard,
     InvoiceTable,
+    OverviewChart,
     SectionCard,
+    StatCard,
     TaskList,
     type BookingRecord,
+    type BookingStatus,
     type ClientRecord,
     type InvoiceRecord,
-    type TaskRecord
+    type TaskRecord,
+    type ChartPoint
 } from '../../components/crm';
 
-const metrics = [
-    {
-        id: 'revenue',
-        title: 'Monthly Revenue',
-        value: '$18,450',
-        trend: {
-            value: '+12%',
-            label: 'vs last month'
-        }
-    },
-    {
-        id: 'bookings',
-        title: 'Upcoming Shoots',
-        value: '14',
-        trend: {
-            value: '6 confirmed',
-            label: 'next 30 days'
-        }
-    },
-    {
-        id: 'galleries',
-        title: 'Galleries to Deliver',
-        value: '5',
-        trend: {
-            value: '3 due this week'
-        }
-    },
-    {
-        id: 'invoices',
-        title: 'Outstanding Invoices',
-        value: '$4,300',
-        trend: {
-            value: '2 overdue',
-            isPositive: false
-        }
-    }
-];
+type GalleryStatus = 'Delivered' | 'Pending';
 
-const bookings: BookingRecord[] = [
+type GalleryRecord = {
+    id: string;
+    client: string;
+    shootType: string;
+    deliveredAt?: string;
+    status: GalleryStatus;
+};
+
+const bookingCollection: BookingRecord[] = [
     {
         id: 'bk-01',
         client: 'Evelyn Sanders',
         shootType: 'Engagement Session',
-        date: '2024-05-11',
+        date: '2025-05-11',
         startTime: '3:00 PM',
         endTime: '5:00 PM',
         location: 'Golden Gate Park',
@@ -67,8 +44,8 @@ const bookings: BookingRecord[] = [
     {
         id: 'bk-02',
         client: 'Harrison & June',
-        shootType: 'Wedding',
-        date: '2024-05-18',
+        shootType: 'Wedding Weekend',
+        date: '2025-05-18',
         startTime: '11:00 AM',
         endTime: '8:00 PM',
         location: 'Terranea Resort',
@@ -78,11 +55,101 @@ const bookings: BookingRecord[] = [
         id: 'bk-03',
         client: 'Sona Patel',
         shootType: 'Brand Lifestyle',
-        date: '2024-05-21',
+        date: '2025-05-21',
         startTime: '9:00 AM',
         endTime: '12:00 PM',
         location: 'Downtown Studio',
         status: 'Editing'
+    },
+    {
+        id: 'bk-04',
+        client: 'Fern & Pine Studio',
+        shootType: 'Lookbook Launch',
+        date: '2025-06-08',
+        startTime: '10:00 AM',
+        endTime: '2:00 PM',
+        location: 'Mission District Loft',
+        status: 'Pending'
+    },
+    {
+        id: 'bk-05',
+        client: 'Evergreen Architects',
+        shootType: 'Team Headshots',
+        date: '2025-05-29',
+        startTime: '1:00 PM',
+        endTime: '4:00 PM',
+        location: 'Financial District HQ',
+        status: 'Confirmed'
+    },
+    {
+        id: 'bk-06',
+        client: 'Evergreen Architects',
+        shootType: 'Site Progress',
+        date: '2025-03-16',
+        startTime: '8:00 AM',
+        endTime: '11:00 AM',
+        location: 'Oakland Waterfront',
+        status: 'Confirmed'
+    },
+    {
+        id: 'bk-07',
+        client: 'Atlas Fitness',
+        shootType: 'Campaign Refresh',
+        date: '2025-02-19',
+        startTime: '7:00 AM',
+        endTime: '10:00 AM',
+        location: 'SOMA Studio',
+        status: 'Editing'
+    },
+    {
+        id: 'bk-08',
+        client: 'Violet & Thread',
+        shootType: 'Spring Collection',
+        date: '2025-01-27',
+        startTime: '9:00 AM',
+        endTime: '1:00 PM',
+        location: 'Dogpatch Warehouse',
+        status: 'Confirmed'
+    },
+    {
+        id: 'bk-09',
+        client: 'Harbor & Co',
+        shootType: 'Product Launch',
+        date: '2024-12-03',
+        startTime: '10:00 AM',
+        endTime: '12:00 PM',
+        location: 'Sausalito Studio',
+        status: 'Confirmed'
+    },
+    {
+        id: 'bk-10',
+        client: 'Lumen Studio',
+        shootType: 'Agency Portfolio',
+        date: '2024-11-18',
+        startTime: '1:00 PM',
+        endTime: '5:00 PM',
+        location: 'North Beach Loft',
+        status: 'Editing'
+    },
+    {
+        id: 'bk-11',
+        client: 'Beacon Realty',
+        shootType: 'Property Showcase',
+        date: '2024-10-09',
+        startTime: '9:30 AM',
+        endTime: '12:30 PM',
+        location: 'Pacific Heights Residence',
+        status: 'Confirmed'
+    },
+    {
+        id: 'bk-12',
+        client: 'Sona Patel',
+        shootType: 'Holiday Campaign',
+        date: '2024-09-14',
+        startTime: '2:00 PM',
+        endTime: '6:00 PM',
+        location: 'Marin Headlands',
+        status: 'Confirmed'
     }
 ];
 
@@ -92,9 +159,9 @@ const clients: ClientRecord[] = [
         name: 'Evelyn Sanders',
         email: 'evelyn@wanderlust.com',
         phone: '(415) 555-0108',
-        shoots: 6,
-        lastShoot: '2024-04-22',
-        upcomingShoot: '2024-05-11',
+        shoots: 7,
+        lastShoot: '2025-03-29',
+        upcomingShoot: '2025-05-11',
         status: 'Active'
     },
     {
@@ -102,9 +169,9 @@ const clients: ClientRecord[] = [
         name: 'Harrison & June',
         email: 'hello@harrisonandjune.com',
         phone: '(424) 555-0145',
-        shoots: 2,
-        lastShoot: '2023-11-18',
-        upcomingShoot: '2024-05-18',
+        shoots: 3,
+        lastShoot: '2024-11-18',
+        upcomingShoot: '2025-05-18',
         status: 'Lead'
     },
     {
@@ -112,9 +179,9 @@ const clients: ClientRecord[] = [
         name: 'Sona Patel',
         email: 'sona@patelcreative.co',
         phone: '(415) 555-0121',
-        shoots: 3,
-        lastShoot: '2024-04-02',
-        upcomingShoot: '2024-05-21',
+        shoots: 4,
+        lastShoot: '2025-04-02',
+        upcomingShoot: '2025-05-21',
         status: 'Active'
     },
     {
@@ -122,36 +189,183 @@ const clients: ClientRecord[] = [
         name: 'Fern & Pine Studio',
         email: 'contact@fernandpine.com',
         phone: '(510) 555-0186',
-        shoots: 4,
-        lastShoot: '2023-12-14',
-        status: 'Archived'
+        shoots: 5,
+        lastShoot: '2025-04-04',
+        upcomingShoot: '2025-06-08',
+        status: 'Active'
+    },
+    {
+        id: 'cl-05',
+        name: 'Evergreen Architects',
+        email: 'team@evergreenarchitects.com',
+        phone: '(628) 555-0163',
+        shoots: 2,
+        lastShoot: '2025-03-18',
+        upcomingShoot: '2025-05-29',
+        status: 'Lead'
+    },
+    {
+        id: 'cl-06',
+        name: 'Atlas Fitness',
+        email: 'hello@atlasfitness.co',
+        phone: '(415) 555-0194',
+        shoots: 3,
+        lastShoot: '2025-01-22',
+        status: 'Active'
     }
 ];
 
-const invoices: InvoiceRecord[] = [
+const invoiceCollection: InvoiceRecord[] = [
     {
-        id: '1024',
+        id: '1031',
         client: 'Evelyn Sanders',
         project: 'Engagement Session',
-        amount: 1150,
-        dueDate: '2024-05-05',
+        amount: 1850,
+        dueDate: '2025-05-06',
         status: 'Sent'
     },
     {
-        id: '1023',
+        id: '1030',
         client: 'Harrison & June',
         project: 'Wedding Collection',
-        amount: 3800,
-        dueDate: '2024-04-28',
+        amount: 5200,
+        dueDate: '2025-05-18',
         status: 'Overdue'
     },
     {
-        id: '1022',
+        id: '1029',
         client: 'Sona Patel',
-        project: 'Brand Lifestyle',
-        amount: 1450,
-        dueDate: '2024-04-15',
+        project: 'Brand Lifestyle Campaign',
+        amount: 2400,
+        dueDate: '2025-04-25',
         status: 'Paid'
+    },
+    {
+        id: '1028',
+        client: 'Fern & Pine Studio',
+        project: 'Lookbook Launch',
+        amount: 1950,
+        dueDate: '2025-04-08',
+        status: 'Paid'
+    },
+    {
+        id: '1027',
+        client: 'Evergreen Architects',
+        project: 'Team Headshots',
+        amount: 1650,
+        dueDate: '2025-03-19',
+        status: 'Paid'
+    },
+    {
+        id: '1026',
+        client: 'Violet & Thread',
+        project: 'Spring Collection',
+        amount: 2100,
+        dueDate: '2025-02-21',
+        status: 'Paid'
+    },
+    {
+        id: '1025',
+        client: 'Atlas Fitness',
+        project: 'Brand Campaign',
+        amount: 2850,
+        dueDate: '2025-01-29',
+        status: 'Paid'
+    },
+    {
+        id: '1024',
+        client: 'Harbor & Co',
+        project: 'Product Launch',
+        amount: 2600,
+        dueDate: '2024-12-12',
+        status: 'Paid'
+    },
+    {
+        id: '1023',
+        client: 'Lumen Studio',
+        project: 'Agency Portfolio',
+        amount: 3400,
+        dueDate: '2024-11-16',
+        status: 'Paid'
+    },
+    {
+        id: '1022',
+        client: 'Beacon Realty',
+        project: 'Property Showcase',
+        amount: 1750,
+        dueDate: '2024-10-05',
+        status: 'Paid'
+    }
+];
+
+const galleryCollection: GalleryRecord[] = [
+    {
+        id: 'gal-01',
+        client: 'Evelyn Sanders',
+        shootType: 'Engagement Session',
+        status: 'Pending'
+    },
+    {
+        id: 'gal-02',
+        client: 'Harrison & June',
+        shootType: 'Wedding Weekend',
+        status: 'Pending'
+    },
+    {
+        id: 'gal-03',
+        client: 'Sona Patel',
+        shootType: 'Brand Lifestyle Campaign',
+        deliveredAt: '2025-04-28',
+        status: 'Delivered'
+    },
+    {
+        id: 'gal-04',
+        client: 'Fern & Pine Studio',
+        shootType: 'Lookbook Launch',
+        deliveredAt: '2025-04-10',
+        status: 'Delivered'
+    },
+    {
+        id: 'gal-05',
+        client: 'Evergreen Architects',
+        shootType: 'Team Headshots',
+        deliveredAt: '2025-03-23',
+        status: 'Delivered'
+    },
+    {
+        id: 'gal-06',
+        client: 'Violet & Thread',
+        shootType: 'Spring Collection',
+        deliveredAt: '2025-02-24',
+        status: 'Delivered'
+    },
+    {
+        id: 'gal-07',
+        client: 'Atlas Fitness',
+        shootType: 'Brand Campaign',
+        deliveredAt: '2025-02-02',
+        status: 'Delivered'
+    },
+    {
+        id: 'gal-08',
+        client: 'Harbor & Co',
+        shootType: 'Product Launch',
+        deliveredAt: '2024-12-18',
+        status: 'Delivered'
+    },
+    {
+        id: 'gal-09',
+        client: 'Lumen Studio',
+        shootType: 'Agency Portfolio',
+        deliveredAt: '2024-11-23',
+        status: 'Delivered'
+    },
+    {
+        id: 'gal-10',
+        client: 'Beacon Realty',
+        shootType: 'Property Showcase',
+        deliveredAt: '2024-10-12',
+        status: 'Delivered'
     }
 ];
 
@@ -159,21 +373,21 @@ const tasks: TaskRecord[] = [
     {
         id: 'task-01',
         title: 'Send Harrison & June final timeline',
-        dueDate: '2024-05-07',
+        dueDate: '2025-05-07',
         assignee: 'You',
         completed: false
     },
     {
         id: 'task-02',
         title: 'Cull and edit Sona Patel preview set',
-        dueDate: '2024-05-06',
+        dueDate: '2025-05-06',
         assignee: 'Retouch Team',
         completed: false
     },
     {
         id: 'task-03',
         title: 'Email Evelyn gallery delivery details',
-        dueDate: '2024-05-03',
+        dueDate: '2025-05-03',
         assignee: 'You',
         completed: true
     }
@@ -241,6 +455,121 @@ export default function PhotographyCrmDashboard() {
     const toggleDarkMode = () => {
         setIsDarkMode((previous) => (previous === null ? true : !previous));
     };
+
+    const sortedInvoices = React.useMemo(
+        () =>
+            invoiceCollection
+                .slice()
+                .sort((first, second) => dayjs(first.dueDate).valueOf() - dayjs(second.dueDate).valueOf()),
+        []
+    );
+
+    const currentMonth = sortedInvoices.length
+        ? dayjs(sortedInvoices[sortedInvoices.length - 1].dueDate).startOf('month')
+        : dayjs().startOf('month');
+    const previousMonth = currentMonth.subtract(1, 'month');
+
+    const revenueThisMonth = sumInvoicesForMonth(invoiceCollection, currentMonth);
+    const revenuePreviousMonth = sumInvoicesForMonth(invoiceCollection, previousMonth);
+    const revenueChange = calculatePercentChange(revenueThisMonth, revenuePreviousMonth);
+
+    const activeBookingStatuses: BookingStatus[] = ['Confirmed', 'Pending'];
+
+    const upcomingShootsCurrent = bookingCollection.filter(
+        (booking) => activeBookingStatuses.includes(booking.status) && dayjs(booking.date).isSame(currentMonth, 'month')
+    ).length;
+    const upcomingShootsPrevious = bookingCollection.filter(
+        (booking) => activeBookingStatuses.includes(booking.status) && dayjs(booking.date).isSame(previousMonth, 'month')
+    ).length;
+    const upcomingChange = calculatePercentChange(upcomingShootsCurrent, upcomingShootsPrevious);
+
+    const outstandingAmountCurrent = invoiceCollection
+        .filter((invoice) => invoice.status !== 'Paid' && dayjs(invoice.dueDate).isSame(currentMonth, 'month'))
+        .reduce((total, invoice) => total + invoice.amount, 0);
+    const outstandingAmountPrevious = invoiceCollection
+        .filter((invoice) => invoice.status !== 'Paid' && dayjs(invoice.dueDate).isSame(previousMonth, 'month'))
+        .reduce((total, invoice) => total + invoice.amount, 0);
+    const outstandingChange = calculatePercentChange(outstandingAmountCurrent, outstandingAmountPrevious);
+
+    const statCards = [
+        {
+            id: 'revenue',
+            title: 'Revenue This Month',
+            value: formatCurrency(revenueThisMonth),
+            change: revenueChange,
+            changeLabel: 'vs previous month',
+            icon: <InvoiceIcon className="h-5 w-5" />
+        },
+        {
+            id: 'shoots',
+            title: 'Upcoming Shoots',
+            value: `${upcomingShootsCurrent}`,
+            change: upcomingChange,
+            changeLabel: 'vs previous month',
+            icon: <CalendarIcon className="h-5 w-5" />
+        },
+        {
+            id: 'outstanding',
+            title: 'Outstanding Invoices',
+            value: formatCurrency(outstandingAmountCurrent),
+            change: outstandingChange,
+            changeLabel: 'vs previous month',
+            icon: <GalleryIcon className="h-5 w-5" />
+        }
+    ];
+
+    const upcomingBookings = React.useMemo(
+        () =>
+            bookingCollection
+                .filter(
+                    (booking) =>
+                        activeBookingStatuses.includes(booking.status) &&
+                        (dayjs(booking.date).isSame(currentMonth, 'month') || dayjs(booking.date).isAfter(currentMonth))
+                )
+                .sort((first, second) => dayjs(first.date).valueOf() - dayjs(second.date).valueOf())
+                .slice(0, 5),
+        [currentMonth]
+    );
+
+    const openInvoices = React.useMemo(
+        () =>
+            invoiceCollection
+                .filter((invoice) => invoice.status !== 'Paid')
+                .sort((first, second) => dayjs(first.dueDate).valueOf() - dayjs(second.dueDate).valueOf()),
+        []
+    );
+
+    const analyticsData = React.useMemo(
+        () => buildAnalytics(currentMonth, bookingCollection, invoiceCollection),
+        [currentMonth]
+    );
+
+    const deliveredGalleries = galleryCollection.filter((gallery) => gallery.status === 'Delivered').length;
+    const pendingGalleries = galleryCollection.length - deliveredGalleries;
+    const galleryCompletion = galleryCollection.length
+        ? Math.round((deliveredGalleries / galleryCollection.length) * 100)
+        : 0;
+    const pendingGalleryClients = galleryCollection
+        .filter((gallery) => gallery.status === 'Pending')
+        .map((gallery) => gallery.client);
+
+    const totalClients = clients.filter((client) => client.status !== 'Archived').length;
+    const shootsThisYear = bookingCollection.filter((booking) => dayjs(booking.date).year() === currentMonth.year()).length;
+    const outstandingInvoiceCount = openInvoices.length;
+
+    const paidRevenue = invoiceCollection
+        .filter((invoice) => invoice.status === 'Paid')
+        .reduce((total, invoice) => total + invoice.amount, 0);
+    const earningsGoal = 85000;
+    const earningsProgress = Math.min(paidRevenue / earningsGoal, 1);
+    const earningsPercentage = Math.round(earningsProgress * 100);
+    const earningsRemaining = Math.max(earningsGoal - paidRevenue, 0);
+
+    const profileStats = [
+        { id: 'clients', label: 'Active clients', value: totalClients.toString() },
+        { id: 'shoots', label: 'Shoots this year', value: shootsThisYear.toString() },
+        { id: 'invoices', label: 'Outstanding invoices', value: outstandingInvoiceCount.toString() }
+    ];
 
     return (
         <>
@@ -363,11 +692,85 @@ export default function PhotographyCrmDashboard() {
                                     </div>
                                 </header>
 
-                                <section className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-                                    {metrics.map((metric) => (
-                                        <DashboardCard key={metric.id} title={metric.title} value={metric.value} trend={metric.trend} />
+                                <section className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                                    {statCards.map((card) => (
+                                        <StatCard
+                                            key={card.id}
+                                            title={card.title}
+                                            value={card.value}
+                                            change={card.change}
+                                            changeLabel={card.changeLabel}
+                                            icon={card.icon}
+                                        />
                                     ))}
                                 </section>
+
+                                <div className="grid gap-6 xl:grid-cols-[2fr_minmax(0,1fr)]">
+                                    <OverviewChart data={analyticsData} />
+                                    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
+                                        <div className="flex items-center gap-4">
+                                            <Image
+                                                src="/images/avatar4.svg"
+                                                alt="Avery Logan"
+                                                width={64}
+                                                height={64}
+                                                className="h-16 w-16 rounded-full border border-slate-200 bg-white p-1 dark:border-slate-700"
+                                            />
+                                            <div>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-indigo-600 dark:text-indigo-400">
+                                                    Lead Photographer
+                                                </p>
+                                                <h2 className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">Avery Logan</h2>
+                                                <p className="text-sm text-slate-500 dark:text-slate-400">San Francisco Bay Area</p>
+                                            </div>
+                                        </div>
+                                        <dl className="mt-6 grid gap-4 sm:grid-cols-3">
+                                            {profileStats.map((stat) => (
+                                                <div
+                                                    key={stat.id}
+                                                    className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/40"
+                                                >
+                                                    <dt className="font-medium text-slate-500 dark:text-slate-400">{stat.label}</dt>
+                                                    <dd className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">{stat.value}</dd>
+                                                </div>
+                                            ))}
+                                        </dl>
+                                        <div className="mt-8 rounded-2xl bg-slate-50 p-5 dark:bg-slate-800/40">
+                                            <div className="flex flex-col gap-6 sm:flex-row sm:items-center">
+                                                <EarningsProgress percentage={earningsPercentage} />
+                                                <div>
+                                                    <p className="text-sm font-medium text-slate-500 dark:text-slate-300">Earnings goal</p>
+                                                    <p className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">
+                                                        {formatCurrency(paidRevenue)}
+                                                    </p>
+                                                    <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                                        Target {formatCurrency(earningsGoal)} · {formatCurrency(earningsRemaining)} to go
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div className="mt-6 border-t border-slate-200 pt-6 dark:border-slate-800">
+                                            <h3 className="text-xs font-semibold uppercase tracking-[0.32em] text-indigo-600 dark:text-indigo-400">Galleries</h3>
+                                            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                                                {deliveredGalleries} delivered · {pendingGalleries} pending ({galleryCompletion}% complete)
+                                            </p>
+                                            <div className="mt-4 flex items-center gap-3">
+                                                <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+                                                    <div
+                                                        className="h-full rounded-full bg-indigo-500"
+                                                        style={{ width: `${galleryCompletion}%` }}
+                                                    />
+                                                </div>
+                                                <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">{galleryCompletion}%</span>
+                                            </div>
+                                            {pendingGalleryClients.length > 0 && (
+                                                <p className="mt-3 text-xs uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
+                                                    Pending: {pendingGalleryClients.join(' · ')}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </section>
+                                </div>
 
                                 <div className="grid gap-6 lg:grid-cols-3">
                                     <div className="space-y-6 lg:col-span-2">
@@ -380,7 +783,7 @@ export default function PhotographyCrmDashboard() {
                                                 </button>
                                             }
                                         >
-                                            <BookingList bookings={bookings} />
+                                            <BookingList bookings={upcomingBookings} />
                                         </SectionCard>
 
                                         <SectionCard
@@ -400,7 +803,7 @@ export default function PhotographyCrmDashboard() {
                                             title="Open Invoices"
                                             description="Collect payments faster with a focused list of outstanding balances."
                                         >
-                                            <InvoiceTable invoices={invoices} />
+                                            <InvoiceTable invoices={openInvoices} />
                                         </SectionCard>
 
                                         <SectionCard
@@ -425,7 +828,200 @@ export default function PhotographyCrmDashboard() {
     );
 }
 
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+});
+
+function formatCurrency(value: number): string {
+    return currencyFormatter.format(value);
+}
+
+function calculatePercentChange(current: number, previous: number): number {
+    if (previous === 0) {
+        return current === 0 ? 0 : 100;
+    }
+    return ((current - previous) / Math.abs(previous)) * 100;
+}
+
+function sumInvoicesForMonth(invoices: InvoiceRecord[], month: dayjs.Dayjs): number {
+    return invoices
+        .filter((invoice) => dayjs(invoice.dueDate).isSame(month, 'month'))
+        .reduce((total, invoice) => total + invoice.amount, 0);
+}
+
+function startOfWeek(value: dayjs.Dayjs): dayjs.Dayjs {
+    return value.subtract(value.day(), 'day').startOf('day');
+}
+
+function endOfWeek(value: dayjs.Dayjs): dayjs.Dayjs {
+    return startOfWeek(value).add(6, 'day').endOf('day');
+}
+
+function isWithinRange(value: dayjs.Dayjs, start: dayjs.Dayjs, end: dayjs.Dayjs): boolean {
+    return (value.isAfter(start) || value.isSame(start)) && (value.isBefore(end) || value.isSame(end));
+}
+
+function buildAnalytics(
+    referenceMonth: dayjs.Dayjs,
+    bookings: BookingRecord[],
+    invoices: InvoiceRecord[]
+): Record<'weekly' | 'monthly' | 'yearly', ChartPoint[]> {
+    return {
+        weekly: buildWeeklyAnalytics(referenceMonth, bookings, invoices),
+        monthly: buildMonthlyAnalytics(referenceMonth, bookings, invoices),
+        yearly: buildYearlyAnalytics(referenceMonth, bookings, invoices)
+    };
+}
+
+function buildWeeklyAnalytics(
+    referenceMonth: dayjs.Dayjs,
+    bookings: BookingRecord[],
+    invoices: InvoiceRecord[]
+): ChartPoint[] {
+    const weeksToDisplay = 6;
+    const result: ChartPoint[] = [];
+    const referenceEnd = referenceMonth.endOf('month');
+
+    for (let offset = weeksToDisplay - 1; offset >= 0; offset -= 1) {
+        const anchor = referenceEnd.subtract(offset, 'week');
+        const weekStart = startOfWeek(anchor);
+        const weekEnd = endOfWeek(anchor);
+
+        const shoots = bookings.filter((booking) => isWithinRange(dayjs(booking.date), weekStart, weekEnd)).length;
+        const revenue = invoices
+            .filter((invoice) => isWithinRange(dayjs(invoice.dueDate), weekStart, weekEnd))
+            .reduce((total, invoice) => total + invoice.amount, 0);
+
+        result.push({
+            label: weekStart.format('MMM D'),
+            shoots,
+            revenue
+        });
+    }
+
+    return result;
+}
+
+function buildMonthlyAnalytics(
+    referenceMonth: dayjs.Dayjs,
+    bookings: BookingRecord[],
+    invoices: InvoiceRecord[]
+): ChartPoint[] {
+    const monthsToDisplay = 6;
+    const result: ChartPoint[] = [];
+
+    for (let offset = monthsToDisplay - 1; offset >= 0; offset -= 1) {
+        const month = referenceMonth.subtract(offset, 'month');
+        const shoots = bookings.filter((booking) => dayjs(booking.date).isSame(month, 'month')).length;
+        const revenue = invoices
+            .filter((invoice) => dayjs(invoice.dueDate).isSame(month, 'month'))
+            .reduce((total, invoice) => total + invoice.amount, 0);
+
+        result.push({
+            label: month.format('MMM'),
+            shoots,
+            revenue
+        });
+    }
+
+    return result;
+}
+
+function buildYearlyAnalytics(
+    referenceMonth: dayjs.Dayjs,
+    bookings: BookingRecord[],
+    invoices: InvoiceRecord[]
+): ChartPoint[] {
+    const yearsToDisplay = 3;
+    const result: ChartPoint[] = [];
+    const latestYear = referenceMonth.year();
+
+    for (let offset = yearsToDisplay - 1; offset >= 0; offset -= 1) {
+        const year = latestYear - offset;
+        const shoots = bookings.filter((booking) => dayjs(booking.date).year() === year).length;
+        const revenue = invoices
+            .filter((invoice) => dayjs(invoice.dueDate).year() === year)
+            .reduce((total, invoice) => total + invoice.amount, 0);
+
+        result.push({
+            label: year.toString(),
+            shoots,
+            revenue
+        });
+    }
+
+    return result;
+}
+
+type EarningsProgressProps = {
+    percentage: number;
+};
+
+function EarningsProgress({ percentage }: EarningsProgressProps) {
+    const radius = 56;
+    const circumference = 2 * Math.PI * radius;
+    const clamped = Math.min(Math.max(percentage, 0), 100);
+    const offset = circumference * (1 - clamped / 100);
+
+    return (
+        <div className="relative h-32 w-32">
+            <svg viewBox="0 0 140 140" className="h-full w-full" aria-hidden="true">
+                <circle cx="70" cy="70" r={radius} stroke="rgba(148, 163, 184, 0.35)" strokeWidth="12" fill="none" />
+                <circle
+                    cx="70"
+                    cy="70"
+                    r={radius}
+                    stroke="#6366F1"
+                    strokeWidth="12"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeDasharray={`${circumference} ${circumference}`}
+                    strokeDashoffset={offset}
+                    transform="rotate(-90 70 70)"
+                />
+            </svg>
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+                <span className="text-2xl font-semibold text-slate-900 dark:text-white">{clamped}%</span>
+                <span className="text-xs font-medium uppercase tracking-[0.32em] text-slate-500 dark:text-slate-400">to goal</span>
+            </div>
+        </div>
+    );
+}
+
 type IconProps = React.SVGProps<SVGSVGElement>;
+
+function CalendarIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+            <line x1="16" y1="2" x2="16" y2="6" />
+            <line x1="8" y1="2" x2="8" y2="6" />
+            <line x1="3" y1="10" x2="21" y2="10" />
+        </svg>
+    );
+}
+
+function InvoiceIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M6 2h12a2 2 0 0 1 2 2v16l-3-2-3 2-3-2-3 2-2-2V4a2 2 0 0 1 2-2z" />
+            <line x1="8" y1="8" x2="16" y2="8" />
+            <line x1="8" y1="12" x2="16" y2="12" />
+        </svg>
+    );
+}
+
+function GalleryIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <rect x="3" y="5" width="18" height="14" rx="2" ry="2" />
+            <circle cx="9" cy="11" r="2" />
+            <path d="M3 17.5 7.5 13l3 3 3.5-4.5 5 5.5" />
+        </svg>
+    );
+}
 
 function MoonIcon(props: IconProps) {
     return (


### PR DESCRIPTION
## Summary
- populate the CRM dashboard with richer booking, invoice, and gallery collections that power runtime analytics
- replace the legacy metric row with reusable StatCard tiles, an overview chart, and a photographer profile sidebar
- add reusable StatCard and OverviewChart components and expose them through the CRM component index for other modules

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9813eaf5883299c3c83967df2853d