### PR TITLE
Add CRM analytics chart powered by CMS data

### DIFF
--- a/content/data/crm-bookings.json
+++ b/content/data/crm-bookings.json
@@ -1,0 +1,126 @@
+{
+    "type": "CrmBookings",
+    "items": [
+        {
+            "id": "bk-01",
+            "client": "Evelyn Sanders",
+            "shootType": "Engagement Session",
+            "date": "2025-05-11",
+            "startTime": "3:00 PM",
+            "endTime": "5:00 PM",
+            "location": "Golden Gate Park",
+            "status": "Confirmed"
+        },
+        {
+            "id": "bk-02",
+            "client": "Harrison & June",
+            "shootType": "Wedding Weekend",
+            "date": "2025-05-18",
+            "startTime": "11:00 AM",
+            "endTime": "8:00 PM",
+            "location": "Terranea Resort",
+            "status": "Pending"
+        },
+        {
+            "id": "bk-03",
+            "client": "Sona Patel",
+            "shootType": "Brand Lifestyle",
+            "date": "2025-05-21",
+            "startTime": "9:00 AM",
+            "endTime": "12:00 PM",
+            "location": "Downtown Studio",
+            "status": "Editing"
+        },
+        {
+            "id": "bk-04",
+            "client": "Fern & Pine Studio",
+            "shootType": "Lookbook Launch",
+            "date": "2025-06-08",
+            "startTime": "10:00 AM",
+            "endTime": "2:00 PM",
+            "location": "Mission District Loft",
+            "status": "Pending"
+        },
+        {
+            "id": "bk-05",
+            "client": "Evergreen Architects",
+            "shootType": "Team Headshots",
+            "date": "2025-05-29",
+            "startTime": "1:00 PM",
+            "endTime": "4:00 PM",
+            "location": "Financial District HQ",
+            "status": "Confirmed"
+        },
+        {
+            "id": "bk-06",
+            "client": "Evergreen Architects",
+            "shootType": "Site Progress",
+            "date": "2025-03-16",
+            "startTime": "8:00 AM",
+            "endTime": "11:00 AM",
+            "location": "Oakland Waterfront",
+            "status": "Confirmed"
+        },
+        {
+            "id": "bk-07",
+            "client": "Atlas Fitness",
+            "shootType": "Campaign Refresh",
+            "date": "2025-02-19",
+            "startTime": "7:00 AM",
+            "endTime": "10:00 AM",
+            "location": "SOMA Studio",
+            "status": "Editing"
+        },
+        {
+            "id": "bk-08",
+            "client": "Violet & Thread",
+            "shootType": "Spring Collection",
+            "date": "2025-01-27",
+            "startTime": "9:00 AM",
+            "endTime": "1:00 PM",
+            "location": "Dogpatch Warehouse",
+            "status": "Confirmed"
+        },
+        {
+            "id": "bk-09",
+            "client": "Harbor & Co",
+            "shootType": "Product Launch",
+            "date": "2024-12-03",
+            "startTime": "10:00 AM",
+            "endTime": "12:00 PM",
+            "location": "Sausalito Studio",
+            "status": "Confirmed"
+        },
+        {
+            "id": "bk-10",
+            "client": "Lumen Studio",
+            "shootType": "Agency Portfolio",
+            "date": "2024-11-18",
+            "startTime": "1:00 PM",
+            "endTime": "5:00 PM",
+            "location": "North Beach Loft",
+            "status": "Editing"
+        },
+        {
+            "id": "bk-11",
+            "client": "Beacon Realty",
+            "shootType": "Property Showcase",
+            "date": "2024-10-09",
+            "startTime": "9:30 AM",
+            "endTime": "12:30 PM",
+            "location": "Pacific Heights Residence",
+            "status": "Confirmed"
+        },
+        {
+            "id": "bk-12",
+            "client": "Sona Patel",
+            "shootType": "Holiday Campaign",
+            "date": "2024-09-14",
+            "startTime": "2:00 PM",
+            "endTime": "6:00 PM",
+            "location": "Marin Headlands",
+            "status": "Confirmed"
+        }
+    ]
+}
+

--- a/content/data/crm-invoices.json
+++ b/content/data/crm-invoices.json
@@ -1,0 +1,86 @@
+{
+    "type": "CrmInvoices",
+    "items": [
+        {
+            "id": "1031",
+            "client": "Evelyn Sanders",
+            "project": "Engagement Session",
+            "amount": 1850,
+            "dueDate": "2025-05-06",
+            "status": "Sent"
+        },
+        {
+            "id": "1030",
+            "client": "Harrison & June",
+            "project": "Wedding Collection",
+            "amount": 5200,
+            "dueDate": "2025-05-18",
+            "status": "Overdue"
+        },
+        {
+            "id": "1029",
+            "client": "Sona Patel",
+            "project": "Brand Lifestyle Campaign",
+            "amount": 2400,
+            "dueDate": "2025-04-25",
+            "status": "Paid"
+        },
+        {
+            "id": "1028",
+            "client": "Fern & Pine Studio",
+            "project": "Lookbook Launch",
+            "amount": 1950,
+            "dueDate": "2025-04-08",
+            "status": "Paid"
+        },
+        {
+            "id": "1027",
+            "client": "Evergreen Architects",
+            "project": "Team Headshots",
+            "amount": 1650,
+            "dueDate": "2025-03-19",
+            "status": "Paid"
+        },
+        {
+            "id": "1026",
+            "client": "Violet & Thread",
+            "project": "Spring Collection",
+            "amount": 2100,
+            "dueDate": "2025-02-21",
+            "status": "Paid"
+        },
+        {
+            "id": "1025",
+            "client": "Atlas Fitness",
+            "project": "Brand Campaign",
+            "amount": 2850,
+            "dueDate": "2025-01-29",
+            "status": "Paid"
+        },
+        {
+            "id": "1024",
+            "client": "Harbor & Co",
+            "project": "Product Launch",
+            "amount": 2600,
+            "dueDate": "2024-12-12",
+            "status": "Paid"
+        },
+        {
+            "id": "1023",
+            "client": "Lumen Studio",
+            "project": "Agency Portfolio",
+            "amount": 3400,
+            "dueDate": "2024-11-16",
+            "status": "Paid"
+        },
+        {
+            "id": "1022",
+            "client": "Beacon Realty",
+            "project": "Property Showcase",
+            "amount": 1750,
+            "dueDate": "2024-10-05",
+            "status": "Paid"
+        }
+    ]
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@algolia/autocomplete-js": "^1.17.1",
                 "@algolia/autocomplete-theme-classic": "^1.17.1",
+                "@reduxjs/toolkit": "^2.9.0",
                 "@supabase/supabase-js": "^2.57.4",
                 "algoliasearch": "^4.24.0",
                 "classnames": "^2.5.1",
@@ -21,6 +22,8 @@
                 "next": "15.5.3",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
+                "react-redux": "^9.2.0",
+                "recharts": "^3.2.1",
                 "swiper": "^11.1.4",
                 "tailwindcss": "^3.4.3"
             },
@@ -306,13 +309,11 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
             "dev": true,
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -1641,6 +1642,26 @@
                 "node": "*"
             }
         },
+        "node_modules/@netlify/content-engine/node_modules/redux": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.9.2"
+            }
+        },
+        "node_modules/@netlify/content-engine/node_modules/redux-thunk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+            "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^4"
+            }
+        },
         "node_modules/@netlify/content-engine/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -1999,6 +2020,32 @@
                 "node": ">=4"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+            "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^10.0.3",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@sideway/address": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -2272,6 +2319,18 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+            "license": "MIT"
+        },
         "node_modules/@supabase/auth-js": {
             "version": "2.71.1",
             "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
@@ -2400,6 +2459,69 @@
             "integrity": "sha512-YY+hm3afkDHeSM2rsFXxeZtu0garnusBWNG1+7MknmDWQHqcH2w21/xOU9arJUi8ch4qyFklidANLCu3ihhVwQ==",
             "dev": true
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+            "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "license": "MIT"
+        },
         "node_modules/@types/debug": {
             "version": "0.0.30",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
@@ -2483,7 +2605,7 @@
             "version": "19.1.11",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
             "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -2521,6 +2643,12 @@
             "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ==",
             "dev": true
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
         },
         "node_modules/@types/ws": {
             "version": "8.18.1",
@@ -3218,6 +3346,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/color": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -3487,7 +3624,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/d": {
             "version": "1.0.2",
@@ -3500,6 +3637,127 @@
             },
             "engines": {
                 "node": ">=0.12"
+            }
+        },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/dayjs": {
@@ -3523,6 +3781,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
@@ -3991,6 +4255,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-toolkit": {
+            "version": "1.39.10",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+            "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
         "node_modules/es5-ext": {
             "version": "0.10.64",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
@@ -4169,6 +4443,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "license": "MIT"
         },
         "node_modules/eventsource": {
             "version": "2.0.2",
@@ -5110,6 +5390,16 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "10.1.3",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+            "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
@@ -5191,6 +5481,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/invariant": {
@@ -7090,6 +7389,36 @@
                 "react": "^19.1.1"
             }
         },
+        "node_modules/react-is": {
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+            "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/read": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -7151,29 +7480,47 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/redux": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-            "dev": true,
+        "node_modules/recharts": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+            "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.9.2"
+                "@reduxjs/toolkit": "1.x.x || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^10.1.1",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.1.1",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
         },
         "node_modules/redux-thunk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-            "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
-            "dev": true,
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
             "peerDependencies": {
-                "redux": "^4"
+                "redux": "^5.0.0"
             }
-        },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "dev": true
         },
         "node_modules/renderkid": {
             "version": "2.0.7",
@@ -7217,6 +7564,12 @@
             "engines": {
                 "node": ">=0.10"
             }
+        },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "1.22.8",
@@ -8180,6 +8533,12 @@
                 "node": ">=0.12"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -8386,6 +8745,15 @@
                 "browserslist": ">= 4.21.0"
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+            "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/utf8-byte-length": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -8432,6 +8800,28 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/weak-lru-cache": {
@@ -8975,13 +9365,10 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-            "dev": true,
-            "requires": {
-                "regenerator-runtime": "^0.14.0"
-            }
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "dev": true
         },
         "@babel/template": {
             "version": "7.25.9",
@@ -9721,6 +10108,22 @@
                         "brace-expansion": "^1.1.7"
                     }
                 },
+                "redux": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+                    "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.9.2"
+                    }
+                },
+                "redux-thunk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+                    "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+                    "dev": true,
+                    "requires": {}
+                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -9975,6 +10378,19 @@
             "integrity": "sha512-aefLe96wAWghkx6q1PwbVS1Iz1iGE+HKwkTmtzWLFXeGhbknaIdG2voMwaBGIYGCSxm8sDKR1uLO4aRRAYuc+Q==",
             "dev": true
         },
+        "@reduxjs/toolkit": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+            "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+            "requires": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^10.0.3",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            }
+        },
         "@sideway/address": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -10220,6 +10636,16 @@
                 }
             }
         },
+        "@standard-schema/spec": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+        },
+        "@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+        },
         "@supabase/auth-js": {
             "version": "2.71.1",
             "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
@@ -10332,6 +10758,60 @@
             "integrity": "sha512-YY+hm3afkDHeSM2rsFXxeZtu0garnusBWNG1+7MknmDWQHqcH2w21/xOU9arJUi8ch4qyFklidANLCu3ihhVwQ==",
             "dev": true
         },
+        "@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+        },
+        "@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+        },
+        "@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+        },
+        "@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "requires": {
+                "@types/d3-color": "*"
+            }
+        },
+        "@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+        },
+        "@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "requires": {
+                "@types/d3-time": "*"
+            }
+        },
+        "@types/d3-shape": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+            "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+            "requires": {
+                "@types/d3-path": "*"
+            }
+        },
+        "@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+        },
+        "@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+        },
         "@types/debug": {
             "version": "0.0.30",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
@@ -10414,7 +10894,7 @@
             "version": "19.1.11",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
             "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "csstype": "^3.0.2"
             }
@@ -10450,6 +10930,11 @@
             "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ==",
             "dev": true
+        },
+        "@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
         },
         "@types/ws": {
             "version": "8.18.1",
@@ -10954,6 +11439,11 @@
                 "mimic-response": "^1.0.0"
             }
         },
+        "clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+        },
         "color": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -11163,7 +11653,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-            "dev": true
+            "devOptional": true
         },
         "d": {
             "version": "1.0.2",
@@ -11174,6 +11664,83 @@
                 "es5-ext": "^0.10.64",
                 "type": "^2.7.2"
             }
+        },
+        "d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "requires": {
+                "internmap": "1 - 2"
+            }
+        },
+        "d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+        },
+        "d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+        },
+        "d3-format": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+        },
+        "d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "requires": {
+                "d3-color": "1 - 3"
+            }
+        },
+        "d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
+        },
+        "d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "requires": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            }
+        },
+        "d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "requires": {
+                "d3-path": "^3.1.0"
+            }
+        },
+        "d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "requires": {
+                "d3-array": "2 - 3"
+            }
+        },
+        "d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "requires": {
+                "d3-time": "1 - 3"
+            }
+        },
+        "d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
         },
         "dayjs": {
             "version": "1.11.18",
@@ -11188,6 +11755,11 @@
             "requires": {
                 "ms": "^2.1.3"
             }
+        },
+        "decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
         },
         "decompress-response": {
             "version": "6.0.0",
@@ -11559,6 +12131,11 @@
                 "es-errors": "^1.3.0"
             }
         },
+        "es-toolkit": {
+            "version": "1.39.10",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+            "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w=="
+        },
         "es5-ext": {
             "version": "0.10.64",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
@@ -11698,6 +12275,11 @@
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "dev": true,
             "peer": true
+        },
+        "eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
         },
         "eventsource": {
             "version": "2.0.2",
@@ -12395,6 +12977,11 @@
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true
         },
+        "immer": {
+            "version": "10.1.3",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+            "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw=="
+        },
         "import-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
@@ -12463,6 +13050,11 @@
                     }
                 }
             }
+        },
+        "internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
         },
         "invariant": {
             "version": "2.2.4",
@@ -13826,6 +14418,21 @@
                 "scheduler": "^0.26.0"
             }
         },
+        "react-is": {
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+            "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+            "peer": true
+        },
+        "react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "requires": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            }
+        },
         "read": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -13871,27 +14478,34 @@
                 "picomatch": "^2.2.1"
             }
         },
-        "redux": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-            "dev": true,
+        "recharts": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+            "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
             "requires": {
-                "@babel/runtime": "^7.9.2"
+                "@reduxjs/toolkit": "1.x.x || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^10.1.1",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.1.1",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
             }
         },
-        "redux-thunk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-            "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
-            "dev": true,
-            "requires": {}
+        "redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
         },
-        "regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "dev": true
+        "redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "requires": {}
         },
         "renderkid": {
             "version": "2.0.7",
@@ -13928,6 +14542,11 @@
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
             "dev": true
+        },
+        "reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
         },
         "resolve": {
             "version": "1.22.8",
@@ -14625,6 +15244,11 @@
                 "next-tick": "^1.1.0"
             }
         },
+        "tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+        },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14770,6 +15394,12 @@
                 "picocolors": "^1.1.1"
             }
         },
+        "use-sync-external-store": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+            "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+            "requires": {}
+        },
         "utf8-byte-length": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -14804,6 +15434,27 @@
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "dev": true
+        },
+        "victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "requires": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
+            }
         },
         "weak-lru-cache": {
             "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "@algolia/autocomplete-js": "^1.17.1",
         "@algolia/autocomplete-theme-classic": "^1.17.1",
+        "@reduxjs/toolkit": "^2.9.0",
         "@supabase/supabase-js": "^2.57.4",
         "algoliasearch": "^4.24.0",
         "classnames": "^2.5.1",
@@ -20,6 +21,8 @@
         "next": "15.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-redux": "^9.2.0",
+        "recharts": "^3.2.1",
         "swiper": "^11.1.4",
         "tailwindcss": "^3.4.3"
     },

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+import fs from 'fs/promises';
+import path from 'path';
+import type { GetStaticProps } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -30,128 +33,16 @@ type GalleryRecord = {
     status: GalleryStatus;
 };
 
-const bookingCollection: BookingRecord[] = [
-    {
-        id: 'bk-01',
-        client: 'Evelyn Sanders',
-        shootType: 'Engagement Session',
-        date: '2025-05-11',
-        startTime: '3:00 PM',
-        endTime: '5:00 PM',
-        location: 'Golden Gate Park',
-        status: 'Confirmed'
-    },
-    {
-        id: 'bk-02',
-        client: 'Harrison & June',
-        shootType: 'Wedding Weekend',
-        date: '2025-05-18',
-        startTime: '11:00 AM',
-        endTime: '8:00 PM',
-        location: 'Terranea Resort',
-        status: 'Pending'
-    },
-    {
-        id: 'bk-03',
-        client: 'Sona Patel',
-        shootType: 'Brand Lifestyle',
-        date: '2025-05-21',
-        startTime: '9:00 AM',
-        endTime: '12:00 PM',
-        location: 'Downtown Studio',
-        status: 'Editing'
-    },
-    {
-        id: 'bk-04',
-        client: 'Fern & Pine Studio',
-        shootType: 'Lookbook Launch',
-        date: '2025-06-08',
-        startTime: '10:00 AM',
-        endTime: '2:00 PM',
-        location: 'Mission District Loft',
-        status: 'Pending'
-    },
-    {
-        id: 'bk-05',
-        client: 'Evergreen Architects',
-        shootType: 'Team Headshots',
-        date: '2025-05-29',
-        startTime: '1:00 PM',
-        endTime: '4:00 PM',
-        location: 'Financial District HQ',
-        status: 'Confirmed'
-    },
-    {
-        id: 'bk-06',
-        client: 'Evergreen Architects',
-        shootType: 'Site Progress',
-        date: '2025-03-16',
-        startTime: '8:00 AM',
-        endTime: '11:00 AM',
-        location: 'Oakland Waterfront',
-        status: 'Confirmed'
-    },
-    {
-        id: 'bk-07',
-        client: 'Atlas Fitness',
-        shootType: 'Campaign Refresh',
-        date: '2025-02-19',
-        startTime: '7:00 AM',
-        endTime: '10:00 AM',
-        location: 'SOMA Studio',
-        status: 'Editing'
-    },
-    {
-        id: 'bk-08',
-        client: 'Violet & Thread',
-        shootType: 'Spring Collection',
-        date: '2025-01-27',
-        startTime: '9:00 AM',
-        endTime: '1:00 PM',
-        location: 'Dogpatch Warehouse',
-        status: 'Confirmed'
-    },
-    {
-        id: 'bk-09',
-        client: 'Harbor & Co',
-        shootType: 'Product Launch',
-        date: '2024-12-03',
-        startTime: '10:00 AM',
-        endTime: '12:00 PM',
-        location: 'Sausalito Studio',
-        status: 'Confirmed'
-    },
-    {
-        id: 'bk-10',
-        client: 'Lumen Studio',
-        shootType: 'Agency Portfolio',
-        date: '2024-11-18',
-        startTime: '1:00 PM',
-        endTime: '5:00 PM',
-        location: 'North Beach Loft',
-        status: 'Editing'
-    },
-    {
-        id: 'bk-11',
-        client: 'Beacon Realty',
-        shootType: 'Property Showcase',
-        date: '2024-10-09',
-        startTime: '9:30 AM',
-        endTime: '12:30 PM',
-        location: 'Pacific Heights Residence',
-        status: 'Confirmed'
-    },
-    {
-        id: 'bk-12',
-        client: 'Sona Patel',
-        shootType: 'Holiday Campaign',
-        date: '2024-09-14',
-        startTime: '2:00 PM',
-        endTime: '6:00 PM',
-        location: 'Marin Headlands',
-        status: 'Confirmed'
-    }
-];
+
+type CmsCollection<T> = {
+    items?: T[];
+};
+
+type PhotographyCrmDashboardProps = {
+    bookings: BookingRecord[];
+    invoices: InvoiceRecord[];
+};
+
 
 const clients: ClientRecord[] = [
     {
@@ -215,88 +106,6 @@ const clients: ClientRecord[] = [
     }
 ];
 
-const invoiceCollection: InvoiceRecord[] = [
-    {
-        id: '1031',
-        client: 'Evelyn Sanders',
-        project: 'Engagement Session',
-        amount: 1850,
-        dueDate: '2025-05-06',
-        status: 'Sent'
-    },
-    {
-        id: '1030',
-        client: 'Harrison & June',
-        project: 'Wedding Collection',
-        amount: 5200,
-        dueDate: '2025-05-18',
-        status: 'Overdue'
-    },
-    {
-        id: '1029',
-        client: 'Sona Patel',
-        project: 'Brand Lifestyle Campaign',
-        amount: 2400,
-        dueDate: '2025-04-25',
-        status: 'Paid'
-    },
-    {
-        id: '1028',
-        client: 'Fern & Pine Studio',
-        project: 'Lookbook Launch',
-        amount: 1950,
-        dueDate: '2025-04-08',
-        status: 'Paid'
-    },
-    {
-        id: '1027',
-        client: 'Evergreen Architects',
-        project: 'Team Headshots',
-        amount: 1650,
-        dueDate: '2025-03-19',
-        status: 'Paid'
-    },
-    {
-        id: '1026',
-        client: 'Violet & Thread',
-        project: 'Spring Collection',
-        amount: 2100,
-        dueDate: '2025-02-21',
-        status: 'Paid'
-    },
-    {
-        id: '1025',
-        client: 'Atlas Fitness',
-        project: 'Brand Campaign',
-        amount: 2850,
-        dueDate: '2025-01-29',
-        status: 'Paid'
-    },
-    {
-        id: '1024',
-        client: 'Harbor & Co',
-        project: 'Product Launch',
-        amount: 2600,
-        dueDate: '2024-12-12',
-        status: 'Paid'
-    },
-    {
-        id: '1023',
-        client: 'Lumen Studio',
-        project: 'Agency Portfolio',
-        amount: 3400,
-        dueDate: '2024-11-16',
-        status: 'Paid'
-    },
-    {
-        id: '1022',
-        client: 'Beacon Realty',
-        project: 'Property Showcase',
-        amount: 1750,
-        dueDate: '2024-10-05',
-        status: 'Paid'
-    }
-];
 
 const galleryCollection: GalleryRecord[] = [
     {
@@ -409,7 +218,7 @@ const navigationItems = [
     { id: 'settings', label: 'Settings', href: '#' }
 ];
 
-export default function PhotographyCrmDashboard() {
+export default function PhotographyCrmDashboard({ bookings, invoices }: PhotographyCrmDashboardProps) {
     const [isDarkMode, setIsDarkMode] = React.useState<boolean | null>(null);
     const [isUserMenuOpen, setIsUserMenuOpen] = React.useState(false);
     const userMenuRef = React.useRef<HTMLDivElement | null>(null);
@@ -456,12 +265,15 @@ export default function PhotographyCrmDashboard() {
         setIsDarkMode((previous) => (previous === null ? true : !previous));
     };
 
+    const bookingList = React.useMemo(() => (Array.isArray(bookings) ? bookings : []), [bookings]);
+    const invoiceList = React.useMemo(() => (Array.isArray(invoices) ? invoices : []), [invoices]);
+
     const sortedInvoices = React.useMemo(
         () =>
-            invoiceCollection
+            invoiceList
                 .slice()
                 .sort((first, second) => dayjs(first.dueDate).valueOf() - dayjs(second.dueDate).valueOf()),
-        []
+        [invoiceList]
     );
 
     const currentMonth = sortedInvoices.length
@@ -469,24 +281,24 @@ export default function PhotographyCrmDashboard() {
         : dayjs().startOf('month');
     const previousMonth = currentMonth.subtract(1, 'month');
 
-    const revenueThisMonth = sumInvoicesForMonth(invoiceCollection, currentMonth);
-    const revenuePreviousMonth = sumInvoicesForMonth(invoiceCollection, previousMonth);
+    const revenueThisMonth = sumInvoicesForMonth(invoiceList, currentMonth);
+    const revenuePreviousMonth = sumInvoicesForMonth(invoiceList, previousMonth);
     const revenueChange = calculatePercentChange(revenueThisMonth, revenuePreviousMonth);
 
     const activeBookingStatuses: BookingStatus[] = ['Confirmed', 'Pending'];
 
-    const upcomingShootsCurrent = bookingCollection.filter(
+    const upcomingShootsCurrent = bookingList.filter(
         (booking) => activeBookingStatuses.includes(booking.status) && dayjs(booking.date).isSame(currentMonth, 'month')
     ).length;
-    const upcomingShootsPrevious = bookingCollection.filter(
+    const upcomingShootsPrevious = bookingList.filter(
         (booking) => activeBookingStatuses.includes(booking.status) && dayjs(booking.date).isSame(previousMonth, 'month')
     ).length;
     const upcomingChange = calculatePercentChange(upcomingShootsCurrent, upcomingShootsPrevious);
 
-    const outstandingAmountCurrent = invoiceCollection
+    const outstandingAmountCurrent = invoiceList
         .filter((invoice) => invoice.status !== 'Paid' && dayjs(invoice.dueDate).isSame(currentMonth, 'month'))
         .reduce((total, invoice) => total + invoice.amount, 0);
-    const outstandingAmountPrevious = invoiceCollection
+    const outstandingAmountPrevious = invoiceList
         .filter((invoice) => invoice.status !== 'Paid' && dayjs(invoice.dueDate).isSame(previousMonth, 'month'))
         .reduce((total, invoice) => total + invoice.amount, 0);
     const outstandingChange = calculatePercentChange(outstandingAmountCurrent, outstandingAmountPrevious);
@@ -520,7 +332,7 @@ export default function PhotographyCrmDashboard() {
 
     const upcomingBookings = React.useMemo(
         () =>
-            bookingCollection
+            bookingList
                 .filter(
                     (booking) =>
                         activeBookingStatuses.includes(booking.status) &&
@@ -528,20 +340,20 @@ export default function PhotographyCrmDashboard() {
                 )
                 .sort((first, second) => dayjs(first.date).valueOf() - dayjs(second.date).valueOf())
                 .slice(0, 5),
-        [currentMonth]
+        [bookingList, currentMonth]
     );
 
     const openInvoices = React.useMemo(
         () =>
-            invoiceCollection
+            invoiceList
                 .filter((invoice) => invoice.status !== 'Paid')
                 .sort((first, second) => dayjs(first.dueDate).valueOf() - dayjs(second.dueDate).valueOf()),
-        []
+        [invoiceList]
     );
 
     const analyticsData = React.useMemo(
-        () => buildAnalytics(currentMonth, bookingCollection, invoiceCollection),
-        [currentMonth]
+        () => buildAnalytics(currentMonth, bookingList, invoiceList),
+        [bookingList, currentMonth, invoiceList]
     );
 
     const deliveredGalleries = galleryCollection.filter((gallery) => gallery.status === 'Delivered').length;
@@ -554,10 +366,10 @@ export default function PhotographyCrmDashboard() {
         .map((gallery) => gallery.client);
 
     const totalClients = clients.filter((client) => client.status !== 'Archived').length;
-    const shootsThisYear = bookingCollection.filter((booking) => dayjs(booking.date).year() === currentMonth.year()).length;
+    const shootsThisYear = bookingList.filter((booking) => dayjs(booking.date).year() === currentMonth.year()).length;
     const outstandingInvoiceCount = openInvoices.length;
 
-    const paidRevenue = invoiceCollection
+    const paidRevenue = invoiceList
         .filter((invoice) => invoice.status === 'Paid')
         .reduce((total, invoice) => total + invoice.amount, 0);
     const earningsGoal = 85000;
@@ -827,6 +639,44 @@ export default function PhotographyCrmDashboard() {
         </>
     );
 }
+
+async function readCmsCollection<T>(fileName: string): Promise<T[]> {
+    const filePath = path.join(process.cwd(), 'content', 'data', fileName);
+
+    try {
+        const raw = await fs.readFile(filePath, 'utf-8');
+        const parsed = JSON.parse(raw) as CmsCollection<T> | T[];
+
+        if (Array.isArray(parsed)) {
+            return parsed as T[];
+        }
+
+        if (parsed && typeof parsed === 'object') {
+            const items = (parsed as CmsCollection<T>).items;
+            if (Array.isArray(items)) {
+                return items as T[];
+            }
+        }
+    } catch (error) {
+        return [];
+    }
+
+    return [];
+}
+
+export const getStaticProps: GetStaticProps<PhotographyCrmDashboardProps> = async () => {
+    const [bookings, invoices] = await Promise.all([
+        readCmsCollection<BookingRecord>('crm-bookings.json'),
+        readCmsCollection<InvoiceRecord>('crm-invoices.json')
+    ]);
+
+    return {
+        props: {
+            bookings,
+            invoices
+        }
+    };
+};
 
 const currencyFormatter = new Intl.NumberFormat('en-US', {
     style: 'currency',


### PR DESCRIPTION
## Summary
- integrate a dual-axis OverviewChart built with Recharts, including timeframe toggles and rich tooltips
- source bookings and invoices from CMS JSON via `getStaticProps` so analytics and widgets reflect content data
- add serialized bookings and invoices datasets under `content/data` for CMS editing and reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98c9eebb08329b225348e6b8da3b2