### PR TITLE
feat: refresh CRM dark mode surfaces

### DIFF
--- a/src/components/crm/BookingList.tsx
+++ b/src/components/crm/BookingList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import dayjs from 'dayjs';
 
 import StatusPill, { StatusTone } from './StatusPill';
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT } from './theme';
 
 export type BookingStatus = 'Confirmed' | 'Pending' | 'Editing';
 
@@ -27,17 +28,27 @@ const formatDate = (value: string) => dayjs(value).format('ddd, MMM D');
 
 export function BookingList({ bookings }: { bookings: BookingRecord[] }) {
     return (
-        <ol className="relative space-y-6 border-l border-slate-200 pl-6 dark:border-slate-800">
+        <ol className="relative space-y-6 border-l border-slate-200 pl-6 dark:border-white/10">
             {bookings.map((booking) => (
                 <li key={booking.id} className="relative">
-                    <span className="absolute -left-3 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-indigo-500 dark:border-slate-900 dark:bg-indigo-500/20 dark:text-indigo-300">
+                    <span className="absolute -left-3 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-[#2DD4BF]/20 text-[#0F766E] shadow-sm dark:border-[#0b162c] dark:bg-[#2DD4BF]/30 dark:text-[#5EEAD4]">
                         •
                     </span>
-                    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-                        <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="relative overflow-hidden rounded-xl border border-white/30 bg-white/75 p-4 shadow-sm backdrop-blur-lg transition dark:border-white/10 dark:bg-[#0d1c33]/70">
+                        <span
+                            aria-hidden="true"
+                            className="pointer-events-none absolute -right-16 -top-10 h-32 w-32 rounded-full blur-3xl"
+                            style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 70%)` }}
+                        />
+                        <span
+                            aria-hidden="true"
+                            className="pointer-events-none absolute -bottom-14 left-6 h-32 w-32 rounded-full blur-3xl"
+                            style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 75%)` }}
+                        />
+                        <div className="relative z-10 flex flex-wrap items-start justify-between gap-3">
                             <div>
-                                <p className="text-sm font-medium text-indigo-600 dark:text-indigo-400">{formatDate(booking.date)}</p>
-                                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{booking.client}</h3>
+                                <p className="text-sm font-semibold text-[#0F766E] dark:text-[#5EEAD4]">{formatDate(booking.date)}</p>
+                                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-50">{booking.client}</h3>
                                 <p className="text-sm text-slate-500 dark:text-slate-400">{booking.shootType}</p>
                             </div>
                             <div className="text-right text-sm text-slate-500 dark:text-slate-400">
@@ -48,7 +59,7 @@ export function BookingList({ bookings }: { bookings: BookingRecord[] }) {
                                 <p>{booking.location}</p>
                             </div>
                         </div>
-                        <div className="mt-3">
+                        <div className="relative z-10 mt-3">
                             <StatusPill tone={statusToneMap[booking.status]}>{booking.status}</StatusPill>
                         </div>
                     </div>

--- a/src/components/crm/ClientTable.tsx
+++ b/src/components/crm/ClientTable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import dayjs from 'dayjs';
 
 import StatusPill, { StatusTone } from './StatusPill';
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT } from './theme';
 
 export type ClientStatus = 'Active' | 'Lead' | 'Archived';
 
@@ -27,9 +28,19 @@ const formatDate = (value?: string) => (value ? dayjs(value).format('MMM D, YYYY
 
 export function ClientTable({ clients }: { clients: ClientRecord[] }) {
     return (
-        <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-800">
-            <table className="min-w-full divide-y divide-slate-200 text-left dark:divide-slate-800">
-                <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:text-slate-300">
+        <div className="relative overflow-hidden rounded-2xl border border-white/30 bg-white/75 shadow-lg backdrop-blur-lg dark:border-white/10 dark:bg-[#0d1c33]/70">
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -right-28 -top-24 h-64 w-64 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 65%)` }}
+            />
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -bottom-24 left-12 h-60 w-60 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 70%)` }}
+            />
+            <table className="relative z-10 min-w-full divide-y divide-white/40 text-left dark:divide-white/10">
+                <thead className="bg-white/40 text-xs font-semibold uppercase tracking-wide text-slate-600 backdrop-blur dark:bg-transparent dark:text-slate-300">
                     <tr>
                         <th scope="col" className="px-5 py-3">
                             Client
@@ -48,15 +59,15 @@ export function ClientTable({ clients }: { clients: ClientRecord[] }) {
                         </th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+                <tbody className="divide-y divide-white/30 text-sm dark:divide-white/10">
                     {clients.map((client) => (
-                        <tr key={client.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/60">
+                        <tr key={client.id} className="transition hover:bg-[#2DD4BF]/10 dark:hover:bg-white/5">
                             <td className="px-5 py-4">
-                                <div className="font-medium text-slate-900 dark:text-white">{client.name}</div>
+                                <div className="font-medium text-slate-900 dark:text-slate-50">{client.name}</div>
                                 <div className="text-sm text-slate-500 dark:text-slate-400">{client.email}</div>
                             </td>
                             <td className="px-5 py-4">
-                                <div className="text-sm font-medium text-slate-900 dark:text-white">{client.shoots}</div>
+                                <div className="text-sm font-medium text-slate-900 dark:text-slate-50">{client.shoots}</div>
                                 {client.phone && <div className="text-xs text-slate-500 dark:text-slate-400">{client.phone}</div>}
                             </td>
                             <td className="px-5 py-4 text-slate-600 dark:text-slate-400">{formatDate(client.lastShoot)}</td>

--- a/src/components/crm/DashboardCard.tsx
+++ b/src/components/crm/DashboardCard.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT, GLASS_PANEL_CLASSNAME } from './theme';
+
 type DashboardCardProps = {
     title: string;
     value: string;
@@ -15,27 +17,34 @@ type DashboardCardProps = {
 
 const trendClassNames = (isPositive?: boolean) =>
     classNames('text-sm font-medium', {
-        'text-emerald-600 dark:text-emerald-400': isPositive !== false,
+        'text-[#0F766E] dark:text-[#5EEAD4]': isPositive !== false,
         'text-rose-600 dark:text-rose-400': isPositive === false
     });
 
 export function DashboardCard({ title, value, trend, className, children }: DashboardCardProps) {
     return (
-        <div
-            className={classNames(
-                'flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900',
-                className
-            )}
-        >
-            <p className="text-sm font-medium text-slate-500 dark:text-slate-300">{title}</p>
-            <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 dark:text-white">{value}</p>
-            {trend && (
-                <p className={classNames('mt-2 flex items-center gap-2', trendClassNames(trend.isPositive))}>
-                    <span>{trend.value}</span>
-                    {trend.label && <span className="text-slate-500 dark:text-slate-400">{trend.label}</span>}
-                </p>
-            )}
-            {children && <div className="mt-4 flex-grow text-sm text-slate-500 dark:text-slate-300">{children}</div>}
+        <div className={classNames(GLASS_PANEL_CLASSNAME, 'flex h-full flex-col p-5', className)}>
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -right-16 top-0 h-40 w-40 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 70%)` }}
+            />
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -bottom-16 left-4 h-36 w-36 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 70%)` }}
+            />
+            <div className="relative z-10">
+                <p className="text-sm font-medium text-slate-600 dark:text-slate-300">{title}</p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{value}</p>
+                {trend && (
+                    <p className={classNames('mt-2 flex items-center gap-2', trendClassNames(trend.isPositive))}>
+                        <span>{trend.value}</span>
+                        {trend.label && <span className="text-slate-500 dark:text-slate-400">{trend.label}</span>}
+                    </p>
+                )}
+                {children && <div className="mt-4 flex-grow text-sm text-slate-500 dark:text-slate-300">{children}</div>}
+            </div>
         </div>
     );
 }

--- a/src/components/crm/InvoiceTable.tsx
+++ b/src/components/crm/InvoiceTable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import dayjs from 'dayjs';
 
 import StatusPill, { StatusTone } from './StatusPill';
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT } from './theme';
 
 export type InvoiceStatus = 'Draft' | 'Sent' | 'Paid' | 'Overdue';
 
@@ -31,21 +32,36 @@ export function InvoiceTable({ invoices }: { invoices: InvoiceRecord[] }) {
     return (
         <div className="space-y-4">
             {invoices.map((invoice) => (
-                <div key={invoice.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-                    <div className="flex items-start justify-between gap-3">
+                <div
+                    key={invoice.id}
+                    className="relative overflow-hidden rounded-xl border border-white/30 bg-white/75 p-4 shadow-sm backdrop-blur-lg transition dark:border-white/10 dark:bg-[#0d1c33]/70"
+                >
+                    <span
+                        aria-hidden="true"
+                        className="pointer-events-none absolute -right-20 -top-16 h-48 w-48 rounded-full blur-3xl"
+                        style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 70%)` }}
+                    />
+                    <span
+                        aria-hidden="true"
+                        className="pointer-events-none absolute -bottom-16 left-10 h-44 w-44 rounded-full blur-3xl"
+                        style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 75%)` }}
+                    />
+                    <div className="relative z-10 flex items-start justify-between gap-3">
                         <div>
-                            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Invoice {invoice.id}</p>
-                            <h3 className="text-base font-semibold text-slate-900 dark:text-white">{invoice.client}</h3>
+                            <p className="text-xs font-semibold uppercase tracking-wider text-[#0F766E] dark:text-[#5EEAD4]">Invoice {invoice.id}</p>
+                            <h3 className="text-base font-semibold text-slate-900 dark:text-slate-50">{invoice.client}</h3>
                             <p className="text-sm text-slate-500 dark:text-slate-400">{invoice.project}</p>
                         </div>
                         <div className="text-right">
-                            <p className="text-lg font-semibold text-slate-900 dark:text-white">{formatCurrency(invoice.amount)}</p>
+                            <p className="text-lg font-semibold text-slate-900 dark:text-slate-50">{formatCurrency(invoice.amount)}</p>
                             <p className="text-sm text-slate-500 dark:text-slate-400">Due {formatDate(invoice.dueDate)}</p>
                         </div>
                     </div>
-                    <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                    <div className="relative z-10 mt-4 flex flex-wrap items-center justify-between gap-3">
                         <StatusPill tone={statusToneMap[invoice.status]}>{invoice.status}</StatusPill>
-                        <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">View invoice</button>
+                        <button className="text-sm font-semibold text-[#0F766E] transition hover:text-[#0d8a80] dark:text-[#5EEAD4] dark:hover:text-[#7df7e0]">
+                            View invoice
+                        </button>
                     </div>
                 </div>
             ))}

--- a/src/components/crm/OverviewChart.tsx
+++ b/src/components/crm/OverviewChart.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
+import classNames from 'classnames';
+import * as Recharts from 'recharts';
+
 import {
-    Bar,
-    CartesianGrid,
-    ComposedChart,
-    Line,
-    ResponsiveContainer,
-    Tooltip,
-    XAxis,
-    YAxis
-} from 'recharts';
+    CRM_BRAND_ACCENT,
+    CRM_BRAND_ACCENT_EMPHASIS,
+    CRM_BRAND_ACCENT_GLOW,
+    CRM_BRAND_ACCENT_GLOW_SOFT,
+    GLASS_PANEL_CLASSNAME
+} from './theme';
 
 export type Timeframe = 'weekly' | 'monthly' | 'yearly';
 
@@ -18,8 +18,18 @@ export type ChartPoint = {
     revenue: number;
 };
 
+const Bar = (Recharts as any).Bar as React.ComponentType<any>;
+const Line = (Recharts as any).Line as React.ComponentType<any>;
+const CartesianGrid = (Recharts as any).CartesianGrid as React.ComponentType<any>;
+const ComposedChart = (Recharts as any).ComposedChart as React.ComponentType<any>;
+const ResponsiveContainer = (Recharts as any).ResponsiveContainer as React.ComponentType<any>;
+const Tooltip = (Recharts as any).Tooltip as React.ComponentType<any>;
+const XAxis = (Recharts as any).XAxis as React.ComponentType<any>;
+const YAxis = (Recharts as any).YAxis as React.ComponentType<any>;
+
 type OverviewChartProps = {
     data: Record<Timeframe, ChartPoint[]>;
+    isDarkMode?: boolean;
 };
 
 const timeframeOptions: Array<{ id: Timeframe; label: string }> = [
@@ -48,9 +58,10 @@ type ChartTooltipProps = {
     active?: boolean;
     payload?: Array<{ value?: number; name?: string; dataKey?: string }>;
     label?: string;
+    isDarkMode?: boolean;
 };
 
-function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
+function ChartTooltip({ active, payload, label, isDarkMode }: ChartTooltipProps) {
     if (!active || !payload || payload.length === 0) {
         return null;
     }
@@ -58,29 +69,44 @@ function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
     const shootsEntry = payload.find((entry) => entry.dataKey === 'shoots');
     const revenueEntry = payload.find((entry) => entry.dataKey === 'revenue');
 
+    const accentColor = isDarkMode ? '#5EEAD4' : '#0F766E';
+    const surfaceClass = isDarkMode
+        ? 'border-white/10 bg-[#0b162c]/90 text-slate-200'
+        : 'border-white/40 bg-white/95 text-slate-600';
+
     return (
-        <div className="rounded-xl border border-slate-200 bg-white p-3 text-sm shadow-lg dark:border-slate-700 dark:bg-slate-900">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">{label}</p>
-            <div className="mt-2 space-y-1 text-slate-600 dark:text-slate-300">
+        <div className={classNames('rounded-xl border p-3 text-sm shadow-xl backdrop-blur', surfaceClass)}>
+            <p
+                className="text-xs font-semibold uppercase tracking-[0.3em]"
+                style={{ color: accentColor }}
+            >
+                {label}
+            </p>
+            <div className="mt-2 space-y-1">
                 {shootsEntry && (
                     <div className="flex items-center justify-between gap-6">
-                        <span className="flex items-center gap-2">
-                            <span className="inline-flex h-2.5 w-2.5 rounded-full bg-indigo-500" aria-hidden="true" />
+                        <span className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                            <span
+                                className="inline-flex h-2.5 w-2.5 rounded-full"
+                                aria-hidden="true"
+                                style={{ backgroundColor: accentColor }}
+                            />
                             Shoots
                         </span>
-                        <span className="font-semibold text-slate-900 dark:text-white">{shootsEntry.value}</span>
+                        <span className="font-semibold text-slate-900 dark:text-slate-50">{shootsEntry.value}</span>
                     </div>
                 )}
                 {revenueEntry && (
                     <div className="flex items-center justify-between gap-6">
-                        <span className="flex items-center gap-2">
+                        <span className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
                             <span
-                                className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full border-2 border-emerald-400"
+                                className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full border-2"
                                 aria-hidden="true"
+                                style={{ borderColor: accentColor }}
                             />
                             Revenue
                         </span>
-                        <span className="font-semibold text-slate-900 dark:text-white">
+                        <span className="font-semibold text-slate-900 dark:text-slate-50">
                             {formatCurrency(Number(revenueEntry.value))}
                         </span>
                     </div>
@@ -90,7 +116,7 @@ function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
     );
 }
 
-export function OverviewChart({ data }: OverviewChartProps) {
+export function OverviewChart({ data, isDarkMode = false }: OverviewChartProps) {
     const [timeframe, setTimeframe] = React.useState<Timeframe>('monthly');
     const [isMounted, setIsMounted] = React.useState(false);
 
@@ -103,16 +129,46 @@ export function OverviewChart({ data }: OverviewChartProps) {
     const totalShoots = activeData.reduce((total, point) => total + point.shoots, 0);
     const totalRevenue = activeData.reduce((total, point) => total + point.revenue, 0);
 
+    const chartColors = React.useMemo(
+        () => ({
+            axis: isDarkMode ? 'rgba(203, 213, 225, 0.65)' : 'rgba(71, 85, 105, 0.65)',
+            grid: isDarkMode ? 'rgba(148, 163, 184, 0.22)' : 'rgba(100, 116, 139, 0.18)',
+            cursor: isDarkMode ? 'rgba(94, 234, 212, 0.12)' : 'rgba(45, 212, 191, 0.08)',
+            barStart: isDarkMode ? 'rgba(94, 234, 212, 0.55)' : 'rgba(45, 212, 191, 0.55)',
+            barEnd: isDarkMode ? 'rgba(17, 94, 89, 0.22)' : 'rgba(45, 212, 191, 0.12)',
+            lineStroke: isDarkMode ? '#5EEAD4' : CRM_BRAND_ACCENT_EMPHASIS,
+            dotStroke: isDarkMode ? '#030a16' : '#ecfeff',
+            legendAccent: isDarkMode ? '#5EEAD4' : CRM_BRAND_ACCENT_EMPHASIS,
+            legendRing: isDarkMode ? 'rgba(94, 234, 212, 0.4)' : 'rgba(45, 212, 191, 0.35)',
+            legendTextClass: isDarkMode ? 'text-slate-400' : 'text-slate-500'
+        }),
+        [isDarkMode]
+    );
+
+    const activeToggleStyles = isDarkMode
+        ? { backgroundColor: 'rgba(94, 234, 212, 0.18)', color: '#5EEAD4', boxShadow: '0 0 0 1px rgba(94, 234, 212, 0.4)' }
+        : { backgroundColor: 'rgba(45, 212, 191, 0.18)', color: '#0F766E', boxShadow: '0 0 0 1px rgba(45, 212, 191, 0.3)' };
+
     return (
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
-            <div className="flex flex-wrap items-start justify-between gap-4">
+        <section className={classNames(GLASS_PANEL_CLASSNAME, 'p-6')}>
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -right-28 -top-24 h-72 w-72 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 65%)` }}
+            />
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -bottom-28 left-12 h-72 w-72 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 70%)` }}
+            />
+            <div className="relative z-10 flex flex-wrap items-start justify-between gap-4">
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Studio overview</h2>
-                    <p className="mt-1 text-sm text-slate-500 dark:text-slate-300">
+                    <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Studio overview</h2>
+                    <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
                         Shoots scheduled and revenue performance across time horizons.
                     </p>
                 </div>
-                <div className="inline-flex shrink-0 rounded-full border border-slate-200 bg-slate-50 p-1 text-sm font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                <div className="inline-flex shrink-0 rounded-full border border-white/30 bg-white/50 p-1 text-sm font-medium text-slate-600 backdrop-blur dark:border-white/10 dark:bg-[#0d1c33]/70 dark:text-slate-300">
                     {timeframeOptions.map((option) => {
                         const isActive = option.id === timeframe;
                         return (
@@ -121,12 +177,11 @@ export function OverviewChart({ data }: OverviewChartProps) {
                                 type="button"
                                 onClick={() => setTimeframe(option.id)}
                                 aria-pressed={isActive}
-                                className={[
-                                    'rounded-full px-3 py-1 transition',
-                                    isActive
-                                        ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
-                                        : 'hover:text-slate-900 dark:hover:text-white'
-                                ].join(' ')}
+                                className={classNames(
+                                    'rounded-full px-3 py-1 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:ring-[rgba(45,212,191,0.35)]',
+                                    isActive ? 'shadow-sm' : 'hover:text-slate-900 dark:hover:text-slate-100'
+                                )}
+                                style={isActive ? activeToggleStyles : undefined}
                             >
                                 {option.label}
                             </button>
@@ -134,24 +189,37 @@ export function OverviewChart({ data }: OverviewChartProps) {
                     })}
                 </div>
             </div>
-            <div className="mt-6 space-y-6">
-                <div className="flex flex-wrap items-center gap-4 text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
+            <div className="relative z-10 mt-6 space-y-6">
+                <div
+                    className={classNames(
+                        'flex flex-wrap items-center gap-4 text-xs font-semibold uppercase tracking-[0.3em]',
+                        chartColors.legendTextClass
+                    )}
+                >
                     <div className="flex items-center gap-2">
-                        <span className="inline-flex h-2.5 w-2.5 rounded-full bg-indigo-500" aria-hidden="true" />
+                        <span
+                            className="inline-flex h-2.5 w-2.5 rounded-full"
+                            aria-hidden="true"
+                            style={{ backgroundColor: chartColors.legendAccent }}
+                        />
                         Shoots
                     </div>
                     <div className="flex items-center gap-2">
-                        <span className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full border-2 border-emerald-400" aria-hidden="true" />
+                        <span
+                            className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full border-2"
+                            aria-hidden="true"
+                            style={{ borderColor: chartColors.legendRing }}
+                        />
                         Revenue
                     </div>
                 </div>
                 <div className="overflow-x-auto">
                     {!hasData ? (
-                        <p className="rounded-xl bg-slate-50 p-6 text-sm text-slate-500 dark:bg-slate-800/40 dark:text-slate-400">
+                        <p className="rounded-xl border border-white/30 bg-white/70 p-6 text-sm text-slate-600 backdrop-blur-md dark:border-white/10 dark:bg-[#0d1c33]/70 dark:text-slate-300">
                             No analytics available for this timeframe yet.
                         </p>
                     ) : (
-                        <div className="h-72 min-w-[560px] text-slate-400 dark:text-slate-500">
+                        <div className="h-72 min-w-[560px]">
                             {!isMounted ? (
                                 <div className="flex h-full items-center justify-center text-sm text-slate-500 dark:text-slate-400">
                                     Loading chart…
@@ -166,46 +234,46 @@ export function OverviewChart({ data }: OverviewChartProps) {
                                     >
                                         <defs>
                                             <linearGradient id="shootsGradient" x1="0" y1="0" x2="0" y2="1">
-                                                <stop offset="0%" stopColor="rgba(99, 102, 241, 0.65)" />
-                                                <stop offset="100%" stopColor="rgba(99, 102, 241, 0.15)" />
+                                                <stop offset="0%" stopColor={chartColors.barStart} />
+                                                <stop offset="100%" stopColor={chartColors.barEnd} />
                                             </linearGradient>
                                         </defs>
-                                        <CartesianGrid vertical={false} stroke="currentColor" strokeOpacity={0.12} strokeDasharray="4 6" />
+                                        <CartesianGrid vertical={false} stroke={chartColors.grid} strokeDasharray="4 6" />
                                         <XAxis
                                             dataKey="label"
-                                            axisLine={{ stroke: 'currentColor', strokeOpacity: 0.18 }}
-                                            tickLine={{ stroke: 'currentColor', strokeOpacity: 0.18 }}
-                                            tick={{ fill: 'currentColor', fontSize: 12 }}
+                                            axisLine={{ stroke: chartColors.axis }}
+                                            tickLine={{ stroke: chartColors.axis }}
+                                            tick={{ fill: chartColors.axis, fontSize: 12 }}
                                         />
                                         <YAxis
                                             yAxisId="shoots"
                                             allowDecimals={false}
-                                            axisLine={{ stroke: 'currentColor', strokeOpacity: 0.18 }}
-                                            tickLine={{ stroke: 'currentColor', strokeOpacity: 0.18 }}
-                                            tick={{ fill: 'currentColor', fontSize: 12 }}
+                                            axisLine={{ stroke: chartColors.axis }}
+                                            tickLine={{ stroke: chartColors.axis }}
+                                            tick={{ fill: chartColors.axis, fontSize: 12 }}
                                             domain={[0, (dataMax: number) => (dataMax ? Math.ceil(dataMax * 1.2) : 1)]}
                                         />
                                         <YAxis
                                             yAxisId="revenue"
                                             orientation="right"
-                                            axisLine={{ stroke: 'currentColor', strokeOpacity: 0.18 }}
-                                            tickLine={{ stroke: 'currentColor', strokeOpacity: 0.18 }}
-                                            tick={{ fill: 'currentColor', fontSize: 12 }}
+                                            axisLine={{ stroke: chartColors.axis }}
+                                            tickLine={{ stroke: chartColors.axis }}
+                                            tick={{ fill: chartColors.axis, fontSize: 12 }}
                                             tickFormatter={(value: number) => formatCurrencyCompact(value)}
                                             domain={[0, (dataMax: number) => (dataMax ? Math.ceil(dataMax * 1.15) : 1)]}
                                         />
                                         <Tooltip
-                                            content={(tooltipProps) => <ChartTooltip {...tooltipProps} />}
-                                            cursor={{ fill: 'rgba(99, 102, 241, 0.08)' }}
+                                            content={(tooltipProps) => <ChartTooltip {...tooltipProps} isDarkMode={isDarkMode} />}
+                                            cursor={{ fill: chartColors.cursor }}
                                         />
                                         <Bar yAxisId="shoots" dataKey="shoots" fill="url(#shootsGradient)" radius={[10, 10, 0, 0]} maxBarSize={40} />
                                         <Line
                                             yAxisId="revenue"
                                             type="monotone"
                                             dataKey="revenue"
-                                            stroke="#10b981"
+                                            stroke={chartColors.lineStroke}
                                             strokeWidth={3}
-                                            dot={{ r: 5, strokeWidth: 2, stroke: '#0f172a', fill: '#10b981' }}
+                                            dot={{ r: 5, strokeWidth: 2, stroke: chartColors.dotStroke, fill: chartColors.lineStroke }}
                                             activeDot={{ r: 6 }}
                                         />
                                     </ComposedChart>
@@ -215,13 +283,13 @@ export function OverviewChart({ data }: OverviewChartProps) {
                     )}
                 </div>
                 <dl className="grid gap-4 sm:grid-cols-2">
-                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/40">
-                        <dt className="font-medium text-slate-500 dark:text-slate-400">Total shoots</dt>
-                        <dd className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">{totalShoots}</dd>
+                    <div className="rounded-xl border border-white/30 bg-white/70 p-4 text-sm shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-[#0d1c33]/70">
+                        <dt className="font-medium text-slate-600 dark:text-slate-400">Total shoots</dt>
+                        <dd className="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-50">{totalShoots}</dd>
                     </div>
-                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/40">
-                        <dt className="font-medium text-slate-500 dark:text-slate-400">Revenue booked</dt>
-                        <dd className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">{formatCurrency(totalRevenue)}</dd>
+                    <div className="rounded-xl border border-white/30 bg-white/70 p-4 text-sm shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-[#0d1c33]/70">
+                        <dt className="font-medium text-slate-600 dark:text-slate-400">Revenue booked</dt>
+                        <dd className="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-50">{formatCurrency(totalRevenue)}</dd>
                     </div>
                 </dl>
             </div>

--- a/src/components/crm/QuickActionModal.tsx
+++ b/src/components/crm/QuickActionModal.tsx
@@ -5,6 +5,7 @@ import {
     QuickActionModalType,
     useQuickActionSettings
 } from './quick-action-settings';
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT } from './theme';
 
 type BaseFieldType =
     | 'text'
@@ -50,7 +51,7 @@ type QuickActionModalProps = {
 };
 
 const inputBaseStyles =
-    'w-full rounded-xl border border-white/50 bg-white/60 px-3 py-2 text-sm text-slate-800 shadow-sm backdrop-blur focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-100 dark:focus:border-indigo-400';
+    'w-full rounded-xl border border-white/40 bg-white/70 px-3 py-2 text-sm text-slate-800 shadow-sm backdrop-blur focus:border-[#14B8A6] focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.35)] dark:border-white/10 dark:bg-[#0d1c33]/70 dark:text-slate-100 dark:focus:border-[#2DD4BF] dark:focus:ring-[rgba(45,212,191,0.35)]';
 
 export function QuickActionModal({
     type,
@@ -185,32 +186,43 @@ export function QuickActionModal({
         <div
             ref={overlayRef}
             onClick={handleOverlayClick}
-            className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm"
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-[#030a16]/80 p-4 backdrop-blur-md"
+            style={{ backgroundImage: `radial-gradient(circle at top, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 55%)` }}
         >
             <div
                 role="dialog"
                 aria-modal="true"
-                className="relative w-full max-w-2xl rounded-3xl border border-white/20 bg-white/80 p-8 shadow-2xl backdrop-blur-xl transition dark:border-slate-700/60 dark:bg-slate-950/70"
+                className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-white/25 bg-white/85 p-8 shadow-2xl backdrop-blur-2xl transition dark:border-white/10 dark:bg-[#0b162c]/85"
                 onClick={(event) => event.stopPropagation()}
             >
+                <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute -right-28 -top-24 h-72 w-72 rounded-full blur-3xl"
+                    style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 65%)` }}
+                />
+                <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute -bottom-24 left-8 h-64 w-64 rounded-full blur-3xl"
+                    style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 70%)` }}
+                />
                 <button
                     type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/70 text-slate-500 shadow-sm transition hover:text-slate-800 focus:outline-none focus:ring-2 focus:ring-indigo-300 dark:bg-slate-900/60 dark:text-slate-300"
+                    className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/70 text-slate-500 shadow-sm transition hover:text-[#0F766E] focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.35)] dark:bg-[#0d1c33]/70 dark:text-slate-300 dark:hover:text-[#5EEAD4]"
                     aria-label="Close modal"
                 >
                     ×
                 </button>
-                <div className="mb-6 space-y-2">
-                    <span className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-indigo-600 dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-indigo-200">
+                <div className="relative z-10 mb-6 space-y-2">
+                    <span className="inline-flex items-center rounded-full border border-[#2DD4BF]/30 bg-[#2DD4BF]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-[#0F766E] dark:border-[#2DD4BF]/40 dark:bg-[#2DD4BF]/20 dark:text-[#5EEAD4]">
                         {type === 'booking' && 'Schedule shoot'}
                         {type === 'invoice' && 'Create invoice'}
                         {type === 'gallery' && 'Upload gallery'}
                     </span>
-                    <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{title}</h2>
+                    <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">{title}</h2>
                     <p className="text-sm text-slate-600 dark:text-slate-300">{subtitle}</p>
                 </div>
-                <form ref={formRef} className="space-y-4" onSubmit={handleSubmit}>
+                <form ref={formRef} className="relative z-10 space-y-4" onSubmit={handleSubmit}>
                     <div className="grid gap-4 md:grid-cols-2">
                         {fields.map((field) => (
                             <FieldInput
@@ -226,14 +238,14 @@ export function QuickActionModal({
                         <button
                             type="button"
                             onClick={onClose}
-                            className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200"
+                            className="inline-flex items-center justify-center rounded-full border border-white/40 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-white/80 focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.25)] dark:border-white/10 dark:bg-[#0d1c33]/70 dark:text-slate-200 dark:hover:bg-[#10213b]/70"
                         >
                             Cancel
                         </button>
                         <button
                             type="submit"
                             disabled={isSubmitting}
-                            className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300 disabled:cursor-not-allowed disabled:bg-indigo-400"
+                            className="inline-flex items-center justify-center rounded-full bg-[#0F766E] px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-[#0d8a80] focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.35)] disabled:cursor-not-allowed disabled:bg-[#0F766E]/60 dark:bg-[#2DD4BF] dark:text-slate-900 dark:hover:bg-[#34E0C7]"
                         >
                             {isSubmitting ? 'Saving…' : submitLabel}
                         </button>
@@ -326,7 +338,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
                         type="checkbox"
                         checked={Boolean(value)}
                         onChange={(event) => onChange(event.target.checked)}
-                        className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600"
+                        className="h-4 w-4 rounded border-white/40 text-[#0F766E] focus:ring-[rgba(45,212,191,0.35)] dark:border-white/20 dark:bg-[#0d1c33]"
                     />
                     <span>{field.placeholder || 'Enabled'}</span>
                 </label>

--- a/src/components/crm/SectionCard.tsx
+++ b/src/components/crm/SectionCard.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT, GLASS_PANEL_CLASSNAME } from './theme';
+
 type SectionCardProps = {
     title: string;
     description?: string;
@@ -11,20 +13,29 @@ type SectionCardProps = {
 
 export function SectionCard({ title, description, action, children, className }: SectionCardProps) {
     return (
-        <section
-            className={classNames(
-                'rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900',
-                className
-            )}
-        >
-            <div className="flex flex-wrap items-start justify-between gap-3">
+        <section className={classNames(GLASS_PANEL_CLASSNAME, 'p-6', className)}>
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 65%)` }}
+            />
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -bottom-24 left-10 h-56 w-56 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 70%)` }}
+            />
+            <div className="relative z-10 flex flex-wrap items-start justify-between gap-3">
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
-                    {description && <p className="mt-1 text-sm text-slate-500 dark:text-slate-300">{description}</p>}
+                    <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">{title}</h2>
+                    {description && <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{description}</p>}
                 </div>
-                {action && <div className="flex shrink-0 items-center gap-2 text-sm font-medium text-indigo-600 dark:text-indigo-400">{action}</div>}
+                {action && (
+                    <div className="relative z-10 flex shrink-0 items-center gap-2 text-sm font-semibold text-[#0F766E] dark:text-[#5EEAD4]">
+                        {action}
+                    </div>
+                )}
             </div>
-            <div className="mt-5">{children}</div>
+            <div className="relative z-10 mt-5">{children}</div>
         </section>
     );
 }

--- a/src/components/crm/StatCard.tsx
+++ b/src/components/crm/StatCard.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+import classNames from 'classnames';
+
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT, GLASS_PANEL_CLASSNAME } from './theme';
 
 type StatCardProps = {
     title: string;
@@ -19,31 +22,43 @@ export function StatCard({ title, value, change, changeLabel, icon }: StatCardPr
     const TrendIcon = isPositive ? TrendUpIcon : TrendDownIcon;
 
     return (
-        <article className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
-            <div className="flex items-center justify-between">
-                <div className="rounded-full bg-indigo-50 p-3 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
-                    <span className="block h-5 w-5" aria-hidden="true">
-                        {icon}
-                    </span>
+        <article className={classNames(GLASS_PANEL_CLASSNAME, 'flex h-full flex-col justify-between p-6')}>
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -right-16 -top-12 h-40 w-40 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 65%)` }}
+            />
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -bottom-20 left-6 h-48 w-48 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 70%)` }}
+            />
+            <div className="relative z-10">
+                <div className="flex items-center justify-between">
+                    <div className="rounded-full bg-[#2DD4BF]/10 p-3 text-[#0F766E] shadow-sm dark:bg-[#2DD4BF]/20 dark:text-[#5EEAD4]">
+                        <span className="block h-5 w-5" aria-hidden="true">
+                            {icon}
+                        </span>
+                    </div>
                 </div>
-            </div>
-            <div className="mt-10">
-                <p className="text-sm font-medium text-slate-500 dark:text-slate-300">{title}</p>
-                <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-900 dark:text-white">{value}</p>
-                <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-                    <span
-                        className={[
-                            'inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide',
-                            isPositive
-                                ? 'bg-emerald-100 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300'
-                                : 'bg-rose-100 text-rose-600 dark:bg-rose-500/10 dark:text-rose-300'
-                        ].join(' ')}
-                    >
-                        <TrendIcon className="h-3.5 w-3.5" />
-                        {formatChange(change)}
-                    </span>
-                    <span className="ml-2">{changeLabel}</span>
-                </p>
+                <div className="mt-10">
+                    <p className="text-sm font-medium text-slate-600 dark:text-slate-300">{title}</p>
+                    <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{value}</p>
+                    <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                        <span
+                            className={[
+                                'inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide',
+                                isPositive
+                                    ? 'bg-[#2DD4BF]/15 text-[#0F766E] dark:bg-[#2DD4BF]/20 dark:text-[#5EEAD4]'
+                                    : 'bg-rose-100 text-rose-600 dark:bg-rose-500/10 dark:text-rose-300'
+                            ].join(' ')}
+                        >
+                            <TrendIcon className="h-3.5 w-3.5" />
+                            {formatChange(change)}
+                        </span>
+                        <span className="ml-2">{changeLabel}</span>
+                    </p>
+                </div>
             </div>
         </article>
     );

--- a/src/components/crm/StatusPill.tsx
+++ b/src/components/crm/StatusPill.tsx
@@ -12,7 +12,7 @@ const toneStyles: Record<StatusTone, string> = {
     success: 'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-200 dark:ring-emerald-500/40',
     warning: 'bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-200 dark:ring-amber-500/40',
     danger: 'bg-rose-50 text-rose-700 ring-rose-200 dark:bg-rose-500/10 dark:text-rose-200 dark:ring-rose-500/40',
-    info: 'bg-indigo-50 text-indigo-700 ring-indigo-200 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/40',
+    info: 'bg-[#2DD4BF]/10 text-[#0F766E] ring-[#2DD4BF]/30 dark:bg-[#2DD4BF]/20 dark:text-[#5EEAD4] dark:ring-[#2DD4BF]/30',
     neutral: 'bg-slate-100 text-slate-700 ring-slate-200 dark:bg-slate-700/40 dark:text-slate-200 dark:ring-slate-600'
 };
 

--- a/src/components/crm/TaskList.tsx
+++ b/src/components/crm/TaskList.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
 
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT } from './theme';
+
 export type TaskRecord = {
     id: string;
     title: string;
@@ -15,22 +17,37 @@ export function TaskList({ tasks }: { tasks: TaskRecord[] }) {
     return (
         <ul className="space-y-3">
             {tasks.map((task) => (
-                <li key={task.id} className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                <li
+                    key={task.id}
+                    className="relative flex items-start gap-3 overflow-hidden rounded-xl border border-white/30 bg-white/75 p-4 shadow-sm backdrop-blur-lg transition dark:border-white/10 dark:bg-[#0d1c33]/70"
+                >
+                    <span
+                        aria-hidden="true"
+                        className="pointer-events-none absolute -right-16 -top-16 h-40 w-40 rounded-full blur-3xl"
+                        style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 70%)` }}
+                    />
+                    <span
+                        aria-hidden="true"
+                        className="pointer-events-none absolute -bottom-16 left-10 h-36 w-36 rounded-full blur-3xl"
+                        style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 75%)` }}
+                    />
                     <input
                         type="checkbox"
                         checked={task.completed}
                         readOnly
-                        className="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900"
+                        className="relative z-10 mt-1 h-4 w-4 rounded border-white/40 text-[#0F766E] focus:ring-[rgba(45,212,191,0.35)] dark:border-white/20 dark:bg-[#0d1c33]"
                     />
-                    <div className="flex-1">
-                        <p className="text-sm font-medium text-slate-900 dark:text-white">{task.title}</p>
+                    <div className="relative z-10 flex-1">
+                        <p className="text-sm font-medium text-slate-900 dark:text-slate-50">{task.title}</p>
                         <p className="text-xs text-slate-500 dark:text-slate-400">
                             Due {formatDate(task.dueDate)}
                             {task.assignee ? ` · ${task.assignee}` : ''}
                         </p>
                     </div>
                     {!task.completed && (
-                        <button className="text-xs font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">Open</button>
+                        <button className="relative z-10 text-xs font-semibold text-[#0F766E] transition hover:text-[#0d8a80] dark:text-[#5EEAD4] dark:hover:text-[#7df7e0]">
+                            Open
+                        </button>
                     )}
                 </li>
             ))}

--- a/src/components/crm/theme.ts
+++ b/src/components/crm/theme.ts
@@ -1,0 +1,9 @@
+export const CRM_BRAND_ACCENT = '#2DD4BF';
+export const CRM_BRAND_ACCENT_EMPHASIS = '#14B8A6';
+export const CRM_BRAND_ACCENT_GLOW = 'rgba(45, 212, 191, 0.28)';
+export const CRM_BRAND_ACCENT_GLOW_SOFT = 'rgba(45, 212, 191, 0.16)';
+export const CRM_NAVY_SURFACE = '#071427';
+export const CRM_NAVY_SURFACE_SOFT = '#0B1C33';
+export const CRM_NAVY_BORDER = 'rgba(148, 163, 184, 0.2)';
+export const GLASS_PANEL_CLASSNAME =
+    'relative overflow-hidden rounded-2xl border border-white/40 bg-white/80 shadow-lg backdrop-blur-xl transition hover:shadow-xl dark:border-white/10 dark:bg-[#0b162c]/75';

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -19,6 +19,7 @@ import {
     type InvoiceStatus,
     type ChartPoint
 } from '../../components/crm';
+import { CRM_BRAND_ACCENT_GLOW, CRM_BRAND_ACCENT_GLOW_SOFT } from '../../components/crm/theme';
 import {
     BellIcon,
     CalendarIcon,
@@ -603,11 +604,11 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                 <title>Photography CRM Dashboard</title>
                 <meta name="description" content="Command center for managing photography clients, shoots and invoices." />
             </Head>
-            <div className="min-h-screen bg-slate-100 transition-colors dark:bg-slate-950">
+            <div className="min-h-screen bg-slate-100 transition-colors dark:bg-[#050b19]">
                 <div className="flex min-h-screen">
-                    <aside className="hidden w-64 flex-col border-r border-slate-200 bg-slate-950 text-slate-100 shadow-lg lg:flex dark:border-slate-900">
+                    <aside className="hidden w-64 flex-col border-r border-slate-200 bg-white/85 text-slate-900 shadow-lg backdrop-blur-lg lg:flex dark:border-[#132542] dark:bg-[radial-gradient(circle_at_top_left,#14294f_0%,#050b19_100%)] dark:text-slate-100">
                         <div className="flex h-16 items-center px-6">
-                            <span className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-400">Navigation</span>
+                            <span className="text-xs font-semibold uppercase tracking-[0.32em] text-[#0F766E] dark:text-[#5EEAD4]">Navigation</span>
                         </div>
                         <nav className="flex flex-1 flex-col gap-1 px-4 py-4">
                             {navigationItems.map((item) => (
@@ -617,8 +618,8 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                     className={[
                                         'flex items-center gap-3 rounded-xl px-4 py-2.5 text-sm font-medium transition',
                                         item.isActive
-                                            ? 'bg-slate-900/80 text-white shadow-inner'
-                                            : 'text-slate-300 hover:bg-slate-900/60 hover:text-white'
+                                            ? 'bg-[#2DD4BF]/20 text-[#0F766E] shadow-inner dark:bg-white/10 dark:text-[#5EEAD4]'
+                                            : 'text-slate-500 hover:bg-[#2DD4BF]/10 hover:text-[#0F766E] dark:text-slate-300 dark:hover:bg-white/5 dark:hover:text-[#5EEAD4]'
                                     ].join(' ')}
                                 >
                                     <span className="inline-flex h-2 w-2 rounded-full bg-current" aria-hidden="true" />
@@ -626,36 +627,36 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                 </Link>
                             ))}
                         </nav>
-                        <div className="px-6 pb-8 text-xs text-slate-500">
-                            <p className="font-semibold text-slate-200">Codex Environment</p>
-                            <p className="mt-1 text-slate-400">Organize every shoot, deliverable, and client moment.</p>
+                        <div className="px-6 pb-8 text-xs text-slate-500 dark:text-slate-400">
+                            <p className="font-semibold text-[#0F766E] dark:text-[#5EEAD4]">Codex Environment</p>
+                            <p className="mt-1 text-slate-500 dark:text-slate-400">Organize every shoot, deliverable, and client moment.</p>
                         </div>
                     </aside>
                     <div className="flex min-h-screen flex-1 flex-col">
-                        <header className="sticky top-0 z-30 flex h-16 items-center justify-between border-b border-slate-200 bg-white/90 px-6 backdrop-blur transition-colors dark:border-slate-800 dark:bg-slate-900/80">
+                        <header className="sticky top-0 z-30 flex h-16 items-center justify-between border-b border-slate-200 bg-white/85 px-6 backdrop-blur transition-colors dark:border-[#132542] dark:bg-[#071427]/85">
                             <div className="flex items-center gap-3">
-                                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white shadow-sm">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#0F766E] font-semibold text-white shadow-md dark:bg-[#2DD4BF] dark:text-slate-900">
                                     CE
                                 </div>
                                 <div>
-                                    <p className="text-xs font-semibold uppercase tracking-[0.32em] text-indigo-600 dark:text-indigo-400">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[#0F766E] dark:text-[#5EEAD4]">
                                         Codex Environment
                                     </p>
-                                    <p className="text-base font-semibold text-slate-900 dark:text-white">Studio CRM</p>
+                                    <p className="text-base font-semibold text-slate-900 dark:text-slate-50">Studio CRM</p>
                                 </div>
                             </div>
                             <div className="flex items-center gap-3">
                                 <button
                                     type="button"
                                     onClick={toggleDarkMode}
-                                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-white"
+                                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/80 text-slate-600 transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.35)] dark:border-white/20 dark:bg-[#0d1c33]/70 dark:text-slate-200 dark:hover:text-white"
                                     aria-label={isDarkMode ? 'Activate light mode' : 'Activate dark mode'}
                                 >
                                     {isDarkMode ? <SunIcon className="h-5 w-5" /> : <MoonIcon className="h-5 w-5" />}
                                 </button>
                                 <button
                                     type="button"
-                                    className="relative inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:text-white"
+                                    className="relative inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/80 text-slate-600 transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.35)] dark:border-white/20 dark:bg-[#0d1c33]/70 dark:text-slate-200 dark:hover:text-white"
                                     aria-label="Open notifications"
                                 >
                                     <BellIcon className="h-5 w-5" />
@@ -665,11 +666,11 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                     <button
                                         type="button"
                                         onClick={() => setIsUserMenuOpen((open) => !open)}
-                                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-2 py-1 pl-1 pr-3 text-sm font-medium text-slate-700 shadow-sm transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:text-white"
+                                        className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/80 px-2 py-1 pl-1 pr-3 text-sm font-medium text-slate-700 shadow-sm transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.35)] dark:border-white/20 dark:bg-[#0d1c33]/70 dark:text-slate-200 dark:hover:text-white"
                                         aria-haspopup="menu"
                                         aria-expanded={isUserMenuOpen}
                                     >
-                                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-600 text-sm font-semibold text-white">
+                                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#0F766E] text-sm font-semibold text-white dark:bg-[#2DD4BF] dark:text-slate-900">
                                             AL
                                         </span>
                                         <span className="hidden text-left sm:block">
@@ -679,8 +680,8 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                         <ChevronDownIcon className={`h-4 w-4 transition ${isUserMenuOpen ? 'rotate-180' : ''}`} />
                                     </button>
                                     {isUserMenuOpen && (
-                                        <div className="absolute right-0 mt-3 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white py-2 shadow-lg dark:border-slate-700 dark:bg-slate-900">
-                                            <button className="block w-full px-4 py-2 text-left text-sm font-medium text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800">
+                                        <div className="absolute right-0 mt-3 w-44 overflow-hidden rounded-xl border border-white/40 bg-white/85 py-2 shadow-lg backdrop-blur dark:border-white/20 dark:bg-[#0d1c33]/85">
+                                            <button className="block w-full px-4 py-2 text-left text-sm font-medium text-slate-700 hover:bg-white/80 dark:text-slate-200 dark:hover:bg-white/5">
                                                 Profile
                                             </button>
                                             <button className="block w-full px-4 py-2 text-left text-sm font-medium text-rose-600 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-500/10">
@@ -695,7 +696,7 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                             <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 pt-10">
                                 <header className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
                                     <div>
-                                        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600 dark:text-indigo-400">
+                                        <p className="text-sm font-semibold uppercase tracking-widest text-[#0F766E] dark:text-[#5EEAD4]">
                                             Studio Command Center
                                         </p>
                                         <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">
@@ -712,7 +713,7 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                                 key={action.id}
                                                 type="button"
                                                 onClick={() => setActiveModal(action.modal)}
-                                                className="inline-flex items-center justify-center rounded-full border border-indigo-200 bg-white px-4 py-2 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50 dark:border-indigo-500/40 dark:bg-slate-900/60 dark:text-indigo-300 dark:hover:bg-slate-800/60"
+                                                className="inline-flex items-center justify-center rounded-full border border-[#2DD4BF]/40 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0F766E] shadow-sm transition hover:bg-[#2DD4BF]/10 focus:outline-none focus:ring-2 focus:ring-[rgba(45,212,191,0.35)] dark:border-[#2DD4BF]/30 dark:bg-[#0d1c33]/70 dark:text-[#5EEAD4] dark:hover:bg-white/10"
                                             >
                                                 {action.label}
                                             </button>
@@ -734,21 +735,31 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                 </section>
 
                                 <div className="grid gap-6 xl:grid-cols-[2fr_minmax(0,1fr)]">
-                                    <OverviewChart data={analyticsData} />
-                                    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
-                                        <div className="flex items-center gap-4">
+                                    <OverviewChart data={analyticsData} isDarkMode={Boolean(isDarkMode)} />
+                                    <section className="relative overflow-hidden rounded-2xl border border-white/30 bg-white/75 p-6 shadow-sm backdrop-blur-lg transition hover:shadow-xl dark:border-white/10 dark:bg-[#0d1c33]/70">
+                                        <span
+                                            aria-hidden="true"
+                                            className="pointer-events-none absolute -right-24 -top-16 h-56 w-56 rounded-full blur-3xl"
+                                            style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 70%)` }}
+                                        />
+                                        <span
+                                            aria-hidden="true"
+                                            className="pointer-events-none absolute -bottom-20 left-8 h-52 w-52 rounded-full blur-3xl"
+                                            style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 75%)` }}
+                                        />
+                                        <div className="relative z-10 flex items-center gap-4">
                                             <Image
                                                 src="/images/avatar4.svg"
                                                 alt="Avery Logan"
                                                 width={64}
                                                 height={64}
-                                                className="h-16 w-16 rounded-full border border-slate-200 bg-white p-1 dark:border-slate-700"
+                                                className="h-16 w-16 rounded-full border border-white/40 bg-white/80 p-1 shadow-sm dark:border-white/20 dark:bg-[#0d1c33]/70"
                                             />
                                             <div>
-                                                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-indigo-600 dark:text-indigo-400">
+                                                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[#0F766E] dark:text-[#5EEAD4]">
                                                     Lead Photographer
                                                 </p>
-                                                <h2 className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">Avery Logan</h2>
+                                                <h2 className="mt-1 text-xl font-semibold text-slate-900 dark:text-slate-50">Avery Logan</h2>
                                                 <p className="text-sm text-slate-500 dark:text-slate-400">San Francisco Bay Area</p>
                                             </div>
                                         </div>
@@ -756,19 +767,19 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                             {profileStats.map((stat) => (
                                                 <div
                                                     key={stat.id}
-                                                    className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/40"
+                                                    className="rounded-xl border border-white/30 bg-white/70 p-4 text-sm shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-[#0d1c33]/70"
                                                 >
-                                                    <dt className="font-medium text-slate-500 dark:text-slate-400">{stat.label}</dt>
-                                                    <dd className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">{stat.value}</dd>
+                                                    <dt className="font-medium text-slate-600 dark:text-slate-400">{stat.label}</dt>
+                                                    <dd className="mt-1 text-xl font-semibold text-slate-900 dark:text-slate-50">{stat.value}</dd>
                                                 </div>
                                             ))}
                                         </dl>
-                                        <div className="mt-8 rounded-2xl bg-slate-50 p-5 dark:bg-slate-800/40">
+                                        <div className="mt-8 rounded-2xl border border-white/30 bg-white/70 p-5 shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-[#0d1c33]/70">
                                             <div className="flex flex-col gap-6 sm:flex-row sm:items-center">
                                                 <EarningsProgress percentage={earningsPercentage} />
                                                 <div>
-                                                    <p className="text-sm font-medium text-slate-500 dark:text-slate-300">Earnings goal</p>
-                                                    <p className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">
+                                                    <p className="text-sm font-medium text-slate-600 dark:text-slate-300">Earnings goal</p>
+                                                    <p className="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-50">
                                                         {formatCurrency(paidRevenue)}
                                                     </p>
                                                     <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
@@ -777,15 +788,15 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                                 </div>
                                             </div>
                                         </div>
-                                        <div className="mt-6 border-t border-slate-200 pt-6 dark:border-slate-800">
-                                            <h3 className="text-xs font-semibold uppercase tracking-[0.32em] text-indigo-600 dark:text-indigo-400">Galleries</h3>
+                                        <div className="mt-6 border-t border-white/30 pt-6 dark:border-white/10">
+                                            <h3 className="text-xs font-semibold uppercase tracking-[0.32em] text-[#0F766E] dark:text-[#5EEAD4]">Galleries</h3>
                                             <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                                                 {deliveredGalleries} delivered · {pendingGalleries} pending ({galleryCompletion}% complete)
                                             </p>
                                             <div className="mt-4 flex items-center gap-3">
-                                                <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+                                                <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200/70 dark:bg-[#102540]">
                                                     <div
-                                                        className="h-full rounded-full bg-indigo-500"
+                                                        className="h-full rounded-full bg-[#2DD4BF]"
                                                         style={{ width: `${galleryCompletion}%` }}
                                                     />
                                                 </div>
@@ -806,7 +817,7 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                             title="Upcoming Shoots"
                                             description="Stay ready for every session with a quick view of the week ahead."
                                             action={
-                                                <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                <button className="text-sm font-semibold text-[#0F766E] transition hover:text-[#0d8a80] dark:text-[#5EEAD4] dark:hover:text-[#7df7e0]">
                                                     Open calendar
                                                 </button>
                                             }
@@ -818,7 +829,7 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                             title="Active Clients"
                                             description="From loyal regulars to new leads, see who needs attention next."
                                             action={
-                                                <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                <button className="text-sm font-semibold text-[#0F766E] transition hover:text-[#0d8a80] dark:text-[#5EEAD4] dark:hover:text-[#7df7e0]">
                                                     View all clients
                                                 </button>
                                             }
@@ -838,7 +849,7 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                             title="Studio Tasks"
                                             description="Keep production moving with next actions across your team."
                                             action={
-                                                <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                <button className="text-sm font-semibold text-[#0F766E] transition hover:text-[#0d8a80] dark:text-[#5EEAD4] dark:hover:text-[#7df7e0]">
                                                     Create task
                                                 </button>
                                             }
@@ -893,9 +904,19 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                                 {upcomingShootReminders.map((reminder) => (
                                                     <li
                                                         key={reminder.id}
-                                                        className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+                                                        className="relative overflow-hidden rounded-xl border border-white/30 bg-white/75 p-4 shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-[#0d1c33]/70"
                                                     >
-                                                        <div className="flex items-start justify-between gap-3">
+                                                        <span
+                                                            aria-hidden="true"
+                                                            className="pointer-events-none absolute -right-16 -top-12 h-32 w-32 rounded-full blur-3xl"
+                                                            style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW}, transparent 70%)` }}
+                                                        />
+                                                        <span
+                                                            aria-hidden="true"
+                                                            className="pointer-events-none absolute -bottom-16 left-6 h-32 w-32 rounded-full blur-3xl"
+                                                            style={{ background: `radial-gradient(circle at center, ${CRM_BRAND_ACCENT_GLOW_SOFT}, transparent 75%)` }}
+                                                        />
+                                                        <div className="relative z-10 flex items-start justify-between gap-3">
                                                             <div>
                                                                 <p className="text-sm font-semibold text-slate-900 dark:text-white">
                                                                     {reminder.client}
@@ -911,13 +932,13 @@ export default function PhotographyCrmDashboard({ bookings, invoices }: Photogra
                                                                 <p>{reminder.startTime}</p>
                                                             </div>
                                                         </div>
-                                                        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs">
+                                                        <div className="relative z-10 mt-3 flex flex-wrap items-center justify-between gap-2 text-xs">
                                                             <span
                                                                 className={[
                                                                     'inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold',
                                                                     reminder.daysUntil <= 3
                                                                         ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300'
-                                                                        : 'bg-indigo-100 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300'
+                                                                        : 'bg-[#2DD4BF]/15 text-[#0F766E] dark:bg-[#2DD4BF]/20 dark:text-[#5EEAD4]'
                                                                 ].join(' ')}
                                                             >
                                                                 {formatDaysUntil(reminder.daysUntil)}


### PR DESCRIPTION
## Summary
- introduce CRM accent constants and a reusable glass panel style for shared surfaces
- retheme the CRM dashboard layout with deep navy dark mode navigation, accent highlights, and glass quick actions
- refresh charts, stats, modals, and CRM list cards with glass gradients, accent badges, and dark-mode aware colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a5ed003c832988773bcf0f0ad494