### PR TITLE
Add secure client portal with gallery presentation views

### DIFF
--- a/content/data/crm-galleries.json
+++ b/content/data/crm-galleries.json
@@ -7,7 +7,106 @@
             "shootType": "Engagement Session",
             "deliveryDueDate": "2025-05-14",
             "status": "Pending",
-            "coverImage": "/images/main-hero.jpg"
+            "coverImage": "/images/main-hero.jpg",
+            "assets": [
+                {
+                    "id": "gal-01-asset-01",
+                    "fileName": "aurora-dunes.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 512000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-01/aurora-dunes.svg",
+                    "publicUrl": "/images/galleries/aurora-dunes.svg",
+                    "width": 1600,
+                    "height": 1000,
+                    "title": "Sunset over the dunes",
+                    "caption": "A sweeping view captured just after golden hour."
+                },
+                {
+                    "id": "gal-01-asset-02",
+                    "fileName": "golden-hour-ridge.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 468000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-01/golden-hour-ridge.svg",
+                    "publicUrl": "/images/galleries/golden-hour-ridge.svg",
+                    "width": 1000,
+                    "height": 1600,
+                    "title": "Golden ridge embrace",
+                    "caption": "Portraits along the windswept ridge moments before sunset."
+                },
+                {
+                    "id": "gal-01-asset-03",
+                    "fileName": "seaside-trail.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 489000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-01/seaside-trail.svg",
+                    "publicUrl": "/images/galleries/seaside-trail.svg",
+                    "width": 1600,
+                    "height": 960,
+                    "title": "Coastal path walk",
+                    "caption": "Candid laughter along the bluffs."
+                },
+                {
+                    "id": "gal-01-asset-04",
+                    "fileName": "botanical-study.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 420000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-01/botanical-study.svg",
+                    "publicUrl": "/images/galleries/botanical-study.svg",
+                    "width": 1400,
+                    "height": 1400,
+                    "title": "Details in the greenhouse",
+                    "caption": "Close-up details from the greenhouse mini session."
+                },
+                {
+                    "id": "gal-01-asset-05",
+                    "fileName": "artisan-details.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 398000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-01/artisan-details.svg",
+                    "publicUrl": "/images/galleries/artisan-details.svg",
+                    "width": 1000,
+                    "height": 1500,
+                    "title": "Heirloom keepsakes",
+                    "caption": "Flat-lay featuring stationery and rings."
+                },
+                {
+                    "id": "gal-01-asset-06",
+                    "fileName": "craftsmanship.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 536000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-01/craftsmanship.svg",
+                    "publicUrl": "/images/galleries/craftsmanship.svg",
+                    "width": 1600,
+                    "height": 900,
+                    "title": "Reception setup",
+                    "caption": "Soft-lit reception tables moments before guests arrived."
+                }
+            ],
+            "totalStorageBytes": 2823000,
+            "totalStorageFormatted": "2.82 MB",
+            "storageSummary": {
+                "assetCount": 6,
+                "totalBytes": 2823000,
+                "formattedTotal": "2.82 MB"
+            },
+            "portalSettings": {
+                "password": "wanderlust-love",
+                "token": "evelyn-portal",
+                "hint": "Use the phrase we texted after your session.",
+                "welcomeMessage": "Hi Evelyn! Relive your engagement weekend highlights here.",
+                "defaultView": "pinterest",
+                "availableViews": [
+                    "pinterest",
+                    "lightbox",
+                    "carousel"
+                ]
+            }
         },
         {
             "id": "gal-02",
@@ -17,8 +116,80 @@
             "status": "Pending",
             "projectId": "proj-02",
             "coverImage": "/images/hero3.svg",
+            "assets": [
+                {
+                    "id": "gal-02-asset-01",
+                    "fileName": "collaboration.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 548000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-02/collaboration.svg",
+                    "publicUrl": "/images/galleries/collaboration.svg",
+                    "width": 1600,
+                    "height": 900,
+                    "title": "Celebration welcome party",
+                    "caption": "Welcome party toasts at the rooftop venue."
+                },
+                {
+                    "id": "gal-02-asset-02",
+                    "fileName": "skyline-dusk.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 502000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-02/skyline-dusk.svg",
+                    "publicUrl": "/images/galleries/skyline-dusk.svg",
+                    "width": 1600,
+                    "height": 1000,
+                    "title": "City skyline portraits",
+                    "caption": "Evening skyline portraits with the couple."
+                },
+                {
+                    "id": "gal-02-asset-03",
+                    "fileName": "cobalt-harbor.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 486000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-02/cobalt-harbor.svg",
+                    "publicUrl": "/images/galleries/cobalt-harbor.svg",
+                    "width": 1600,
+                    "height": 1060,
+                    "title": "Harbor rehearsal dinner",
+                    "caption": "Reflections from the harbor-side rehearsal dinner."
+                },
+                {
+                    "id": "gal-02-asset-04",
+                    "fileName": "studio-session.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 472000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-02/studio-session.svg",
+                    "publicUrl": "/images/galleries/studio-session.svg",
+                    "width": 1600,
+                    "height": 1100,
+                    "title": "Editorial studio portraits",
+                    "caption": "Clean studio portrait series for the couple."
+                }
+            ],
+            "totalStorageBytes": 2008000,
+            "totalStorageFormatted": "2.01 MB",
+            "storageSummary": {
+                "assetCount": 4,
+                "totalBytes": 2008000,
+                "formattedTotal": "2.01 MB"
+            },
             "customFields": {
                 "deliveryEmail": "hello@harrisonandjune.com"
+            },
+            "portalSettings": {
+                "password": "hj-weekend-2025",
+                "hint": "It combines your initials with the event year.",
+                "welcomeMessage": "Welcome back! Your full wedding weekend story is ready.",
+                "defaultView": "carousel",
+                "availableViews": [
+                    "carousel",
+                    "lightbox",
+                    "pinterest"
+                ]
             }
         },
         {
@@ -30,8 +201,66 @@
             "status": "Delivered",
             "projectId": "proj-03",
             "coverImage": "/images/abstract-feature1.svg",
+            "assets": [
+                {
+                    "id": "gal-03-asset-01",
+                    "fileName": "studio-session.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 458000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-03/studio-session.svg",
+                    "publicUrl": "/images/galleries/studio-session.svg",
+                    "width": 1600,
+                    "height": 1100,
+                    "title": "Launch hero scene",
+                    "caption": "Primary hero scene for the lifestyle campaign."
+                },
+                {
+                    "id": "gal-03-asset-02",
+                    "fileName": "collaboration.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 446000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-03/collaboration.svg",
+                    "publicUrl": "/images/galleries/collaboration.svg",
+                    "width": 1600,
+                    "height": 900,
+                    "title": "Team ideation",
+                    "caption": "Creative team collaborating during concept exploration."
+                },
+                {
+                    "id": "gal-03-asset-03",
+                    "fileName": "craftsmanship.svg",
+                    "contentType": "image/svg+xml",
+                    "size": 430000,
+                    "storageBucket": "public",
+                    "storagePath": "galleries/gal-03/craftsmanship.svg",
+                    "publicUrl": "/images/galleries/craftsmanship.svg",
+                    "width": 1600,
+                    "height": 900,
+                    "title": "Product detail vignette",
+                    "caption": "Handcrafted materials styled for the product story."
+                }
+            ],
+            "totalStorageBytes": 1334000,
+            "totalStorageFormatted": "1.33 MB",
+            "storageSummary": {
+                "assetCount": 3,
+                "totalBytes": 1334000,
+                "formattedTotal": "1.33 MB"
+            },
             "customFields": {
                 "deliveryEmail": "sona@patelcreative.co"
+            },
+            "portalSettings": {
+                "token": "sona-brand-access",
+                "hint": "Use the token shared in your kickoff recap.",
+                "welcomeMessage": "Sona, download final selects for the campaign launch.",
+                "defaultView": "lightbox",
+                "availableViews": [
+                    "lightbox",
+                    "pinterest"
+                ]
             }
         },
         {

--- a/public/images/galleries/artisan-details.svg
+++ b/public/images/galleries/artisan-details.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1500" role="img" aria-labelledby="title desc">
+  <title id="title">Artisan details</title>
+  <desc id="desc">Soft neutrals with organic shapes suggesting handcrafted objects.</desc>
+  <defs>
+    <linearGradient id="artisan-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f1f5f9" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+  </defs>
+  <rect width="1000" height="1500" fill="url(#artisan-bg)" />
+  <g fill="#fde68a" opacity="0.85">
+    <path d="M180,960 C320,820 360,620 440,440 C520,260 640,160 780,180 C640,300 620,440 560,620 C500,800 360,1020 180,960 Z" />
+  </g>
+  <g fill="#fbbf24" opacity="0.55">
+    <circle cx="620" cy="420" r="120" />
+    <circle cx="720" cy="560" r="80" />
+  </g>
+  <g fill="#94a3b8" opacity="0.4">
+    <rect x="220" y="1080" width="320" height="220" rx="40" />
+    <rect x="580" y="1020" width="200" height="240" rx="60" />
+  </g>
+</svg>

--- a/public/images/galleries/aurora-dunes.svg
+++ b/public/images/galleries/aurora-dunes.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000" role="img" aria-labelledby="title desc">
+  <title id="title">Abstract dunes beneath aurora sky</title>
+  <desc id="desc">Soft gradient bands flow across a desert landscape beneath a glowing sky.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="50%" stop-color="#1e3a8a" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <linearGradient id="dunes" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#f97316" stop-opacity="0.95" />
+    </linearGradient>
+    <radialGradient id="sun" cx="70%" cy="20%" r="35%">
+      <stop offset="0%" stop-color="#fef9c3" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#fde68a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="1000" fill="url(#sky)" />
+  <circle cx="1150" cy="160" r="250" fill="url(#sun)" />
+  <path d="M0,640 C280,600 420,700 720,640 C980,580 1180,720 1600,640 L1600,1000 L0,1000 Z" fill="url(#dunes)" />
+  <path d="M0,720 C360,650 520,780 820,720 C1120,660 1270,820 1600,740 L1600,1000 L0,1000 Z" fill="#f59e0b" opacity="0.45" />
+</svg>

--- a/public/images/galleries/botanical-study.svg
+++ b/public/images/galleries/botanical-study.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1400" role="img" aria-labelledby="title desc">
+  <title id="title">Botanical study</title>
+  <desc id="desc">Illustrated foliage with layered leaves in fresh greens.</desc>
+  <defs>
+    <linearGradient id="leaf-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#bbf7d0" />
+      <stop offset="100%" stop-color="#22c55e" />
+    </linearGradient>
+    <linearGradient id="background" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ecfccb" />
+      <stop offset="100%" stop-color="#f1f5f9" />
+    </linearGradient>
+  </defs>
+  <rect width="1400" height="1400" fill="url(#background)" />
+  <g fill="url(#leaf-gradient)" opacity="0.9">
+    <path d="M320,980 C460,620 760,520 960,260 C820,580 900,760 740,920 C560,1120 420,1080 320,980 Z" />
+    <path d="M520,1120 C700,780 860,760 1080,520 C960,820 1040,980 900,1140 C760,1260 620,1240 520,1120 Z" opacity="0.65" />
+    <path d="M360,820 C500,540 760,420 960,220 C840,520 860,720 700,880 C520,1040 420,960 360,820 Z" opacity="0.5" />
+  </g>
+</svg>

--- a/public/images/galleries/cobalt-harbor.svg
+++ b/public/images/galleries/cobalt-harbor.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1060" role="img" aria-labelledby="title desc">
+  <title id="title">Cobalt harbor reflections</title>
+  <desc id="desc">Stylized waterfront skyline with shimmering reflections in deep blues.</desc>
+  <defs>
+    <linearGradient id="harbor-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="40%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <linearGradient id="harbor-water" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1e293b" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1060" fill="url(#harbor-sky)" />
+  <g fill="#f8fafc" opacity="0.85">
+    <rect x="160" y="180" width="120" height="320" rx="20" />
+    <rect x="320" y="220" width="160" height="380" rx="20" />
+    <rect x="540" y="140" width="180" height="460" rx="24" />
+    <rect x="820" y="200" width="200" height="400" rx="18" />
+    <rect x="1100" y="260" width="140" height="340" rx="16" />
+    <rect x="1280" y="240" width="120" height="360" rx="16" />
+  </g>
+  <rect y="620" width="1600" height="440" fill="url(#harbor-water)" />
+  <g fill="#bae6fd" opacity="0.45">
+    <rect x="160" y="660" width="120" height="320" rx="20" />
+    <rect x="320" y="700" width="160" height="260" rx="20" />
+    <rect x="540" y="660" width="180" height="300" rx="24" />
+    <rect x="820" y="700" width="200" height="260" rx="18" />
+    <rect x="1100" y="720" width="140" height="220" rx="16" />
+    <rect x="1280" y="720" width="120" height="220" rx="16" />
+  </g>
+</svg>

--- a/public/images/galleries/collaboration.svg
+++ b/public/images/galleries/collaboration.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">Team collaboration</title>
+  <desc id="desc">Vibrant abstract forms representing collaboration and connection.</desc>
+  <defs>
+    <linearGradient id="collab-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#14b8a6" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="#0f172a" />
+  <circle cx="420" cy="480" r="320" fill="url(#collab-bg)" opacity="0.75" />
+  <circle cx="1040" cy="400" r="260" fill="#fef3c7" opacity="0.6" />
+  <circle cx="1160" cy="580" r="180" fill="#f472b6" opacity="0.45" />
+  <circle cx="760" cy="620" r="220" fill="#38bdf8" opacity="0.55" />
+</svg>

--- a/public/images/galleries/craftsmanship.svg
+++ b/public/images/galleries/craftsmanship.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">Craftsmanship vignette</title>
+  <desc id="desc">Soft focus workshop scene rendered in warm neutrals.</desc>
+  <defs>
+    <linearGradient id="craft-bg" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f1f5f9" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+    <radialGradient id="craft-light" cx="30%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#facc15" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#craft-bg)" />
+  <ellipse cx="580" cy="360" rx="320" ry="220" fill="#f8fafc" opacity="0.45" />
+  <ellipse cx="1080" cy="460" rx="420" ry="260" fill="#f8fafc" opacity="0.35" />
+  <rect x="460" y="420" width="280" height="200" rx="24" fill="#fbbf24" opacity="0.6" />
+  <rect x="880" y="460" width="320" height="180" rx="28" fill="#f97316" opacity="0.45" />
+  <ellipse cx="640" cy="380" rx="220" ry="140" fill="url(#craft-light)" />
+</svg>

--- a/public/images/galleries/golden-hour-ridge.svg
+++ b/public/images/galleries/golden-hour-ridge.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1600" role="img" aria-labelledby="title desc">
+  <title id="title">Golden hour ridge</title>
+  <desc id="desc">Warm light wraps rolling hills with silhouetted trees at sunset.</desc>
+  <defs>
+    <linearGradient id="ridge-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fb7185" />
+      <stop offset="55%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#facc15" />
+    </linearGradient>
+    <linearGradient id="ridge-hills" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="1000" height="1600" fill="url(#ridge-sky)" />
+  <path d="M0,1080 C180,1020 320,1120 520,1080 C720,1040 860,1160 1000,1100 L1000,1600 L0,1600 Z" fill="#1d4ed8" opacity="0.45" />
+  <path d="M0,1180 C220,1120 360,1220 520,1180 C720,1120 860,1280 1000,1220 L1000,1600 L0,1600 Z" fill="url(#ridge-hills)" />
+  <g fill="#0f172a" opacity="0.75">
+    <circle cx="280" cy="1130" r="22" />
+    <circle cx="340" cy="1120" r="18" />
+    <circle cx="760" cy="1200" r="20" />
+    <circle cx="820" cy="1190" r="15" />
+  </g>
+</svg>

--- a/public/images/galleries/seaside-trail.svg
+++ b/public/images/galleries/seaside-trail.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 960" role="img" aria-labelledby="title desc">
+  <title id="title">Seaside trail</title>
+  <desc id="desc">Coastal trail winding along ocean cliffs.</desc>
+  <defs>
+    <linearGradient id="sea-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="60%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="sea-cliffs" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#ea580c" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="960" fill="url(#sea-sky)" />
+  <path d="M0,520 C200,440 380,520 540,480 C720,440 820,360 1000,340 C1180,320 1400,360 1600,320 L1600,960 L0,960 Z" fill="#0f172a" opacity="0.5" />
+  <path d="M0,580 C180,540 360,600 520,560 C700,520 840,420 1000,400 C1180,380 1360,440 1600,400 L1600,960 L0,960 Z" fill="url(#sea-cliffs)" />
+  <path d="M0,640 C220,620 420,720 620,680 C780,640 900,580 1100,600 C1300,620 1500,700 1600,720 L1600,960 L0,960 Z" fill="#facc15" opacity="0.4" />
+</svg>

--- a/public/images/galleries/skyline-dusk.svg
+++ b/public/images/galleries/skyline-dusk.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000" role="img" aria-labelledby="title desc">
+  <title id="title">Skyline at dusk</title>
+  <desc id="desc">City skyline silhouette with gradient evening sky.</desc>
+  <defs>
+    <linearGradient id="dusk-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="50%" stop-color="#f43f5e" />
+      <stop offset="100%" stop-color="#312e81" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1000" fill="url(#dusk-sky)" />
+  <g fill="#0f172a">
+    <rect x="120" y="420" width="120" height="320" />
+    <rect x="260" y="360" width="180" height="380" />
+    <rect x="480" y="300" width="160" height="440" />
+    <rect x="680" y="360" width="200" height="380" />
+    <rect x="920" y="320" width="180" height="420" />
+    <rect x="1140" y="380" width="200" height="360" />
+    <rect x="1380" y="340" width="160" height="400" />
+  </g>
+  <rect y="740" width="1600" height="260" fill="#0f172a" opacity="0.75" />
+</svg>

--- a/public/images/galleries/studio-session.svg
+++ b/public/images/galleries/studio-session.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1100" role="img" aria-labelledby="title desc">
+  <title id="title">Studio session</title>
+  <desc id="desc">Minimal studio interior with lighting gradients and soft shadows.</desc>
+  <defs>
+    <linearGradient id="studio-bg" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f4f4f5" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+    <radialGradient id="studio-light" cx="35%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#f1f5f9" />
+      <stop offset="100%" stop-color="#e2e8f0" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="1100" fill="url(#studio-bg)" />
+  <rect x="220" y="320" width="1160" height="540" rx="40" fill="#1f2937" opacity="0.08" />
+  <rect x="260" y="360" width="1080" height="460" rx="32" fill="#1f2937" opacity="0.1" />
+  <ellipse cx="900" cy="520" rx="420" ry="260" fill="url(#studio-light)" />
+  <rect x="520" y="460" width="320" height="220" rx="28" fill="#334155" opacity="0.45" />
+  <rect x="880" y="500" width="360" height="180" rx="24" fill="#0f172a" opacity="0.35" />
+</svg>

--- a/src/components/gallery/CarouselGallery.tsx
+++ b/src/components/gallery/CarouselGallery.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+
+import type { GalleryAsset } from '../../data/crm';
+
+type CarouselGalleryProps = {
+    assets: GalleryAsset[];
+    className?: string;
+    autoPlayInterval?: number;
+    showThumbnails?: boolean;
+};
+
+const combineClassNames = (...values: Array<string | undefined>): string =>
+    values.filter(Boolean).join(' ');
+
+const DEFAULT_AUTOPLAY_INTERVAL = 6000;
+
+export function CarouselGallery({
+    assets,
+    className,
+    autoPlayInterval = DEFAULT_AUTOPLAY_INTERVAL,
+    showThumbnails = true
+}: CarouselGalleryProps) {
+    const [activeIndex, setActiveIndex] = React.useState(0);
+    const assetCount = assets?.length ?? 0;
+
+    const goToIndex = React.useCallback(
+        (index: number) => {
+            if (!assetCount) return;
+            const normalizedIndex = (index + assetCount) % assetCount;
+            setActiveIndex(normalizedIndex);
+        },
+        [assetCount]
+    );
+
+    const goToNext = React.useCallback(() => {
+        goToIndex(activeIndex + 1);
+    }, [activeIndex, goToIndex]);
+
+    const goToPrevious = React.useCallback(() => {
+        goToIndex(activeIndex - 1);
+    }, [activeIndex, goToIndex]);
+
+    React.useEffect(() => {
+        if (!assetCount || autoPlayInterval <= 0) {
+            return;
+        }
+
+        const timer = window.setInterval(() => {
+            setActiveIndex((prev) => ((prev + 1) % assetCount + assetCount) % assetCount);
+        }, autoPlayInterval);
+
+        return () => window.clearInterval(timer);
+    }, [autoPlayInterval, assetCount]);
+
+    React.useEffect(() => {
+        setActiveIndex(0);
+    }, [assetCount]);
+
+    if (!assetCount) {
+        return (
+            <div className={combineClassNames('rounded-xl border border-dashed border-slate-300 p-12 text-center text-slate-500', className)}>
+                Carousel view will appear when gallery assets are available.
+            </div>
+        );
+    }
+
+    return (
+        <div className={combineClassNames('rounded-2xl border border-slate-200 bg-white p-6 shadow-sm', className)}>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                    <h3 className="text-lg font-semibold text-slate-900">Immersive carousel</h3>
+                    <p className="text-sm text-slate-500">Swipe, click, or allow the carousel to auto-play through gallery highlights.</p>
+                </div>
+                <div className="flex items-center gap-2 text-sm text-slate-500">
+                    <span>
+                        Slide {activeIndex + 1} of {assetCount}
+                    </span>
+                    <div className="h-2 w-28 overflow-hidden rounded-full bg-slate-200">
+                        <div
+                            className="h-full bg-indigo-500 transition-all duration-500"
+                            style={{ width: `${((activeIndex + 1) / assetCount) * 100}%` }}
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div className="relative mt-6">
+                <div className="overflow-hidden rounded-2xl bg-slate-900/5">
+                    <div
+                        className="flex transition-transform duration-500 ease-out"
+                        style={{ transform: `translateX(-${activeIndex * 100}%)` }}
+                    >
+                        {assets.map((asset) => (
+                            <div key={asset.id} className="w-full shrink-0">
+                                <div className="relative aspect-[16/9] overflow-hidden">
+                                    <img
+                                        src={asset.publicUrl}
+                                        alt={asset.title ?? asset.caption ?? asset.fileName}
+                                        className="h-full w-full object-cover"
+                                    />
+                                </div>
+                                <div className="bg-white px-6 py-5 text-slate-600">
+                                    <h4 className="text-base font-semibold text-slate-900">{asset.title ?? asset.fileName}</h4>
+                                    {asset.caption ? <p className="mt-1 text-sm text-slate-500">{asset.caption}</p> : null}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                <div className="pointer-events-none absolute inset-y-0 left-0 flex w-full items-center justify-between px-3">
+                    <button
+                        type="button"
+                        onClick={goToPrevious}
+                        className="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full bg-white/80 text-slate-900 shadow transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                        aria-label="View previous slide"
+                    >
+                        ◀
+                    </button>
+                    <button
+                        type="button"
+                        onClick={goToNext}
+                        className="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full bg-white/80 text-slate-900 shadow transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                        aria-label="View next slide"
+                    >
+                        ▶
+                    </button>
+                </div>
+            </div>
+
+            <div className="mt-4 flex justify-center gap-2">
+                {assets.map((asset, index) => (
+                    <button
+                        key={asset.id}
+                        type="button"
+                        onClick={() => goToIndex(index)}
+                        className={combineClassNames(
+                            'h-3 w-3 rounded-full transition',
+                            index === activeIndex ? 'bg-indigo-500' : 'bg-slate-300 hover:bg-slate-400'
+                        )}
+                        aria-label={`Go to slide ${index + 1}`}
+                        aria-current={index === activeIndex}
+                    />
+                ))}
+            </div>
+
+            {showThumbnails ? (
+                <div className="mt-6 flex gap-3 overflow-x-auto">
+                    {assets.map((asset, index) => (
+                        <button
+                            key={asset.id}
+                            type="button"
+                            onClick={() => goToIndex(index)}
+                            className={combineClassNames(
+                                'relative flex h-20 w-28 shrink-0 overflow-hidden rounded-xl ring-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500',
+                                index === activeIndex ? 'ring-indigo-500' : 'ring-transparent hover:ring-indigo-300'
+                            )}
+                        >
+                            <img src={asset.publicUrl} alt={asset.title ?? asset.fileName} className="h-full w-full object-cover" />
+                        </button>
+                    ))}
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+export default CarouselGallery;

--- a/src/components/gallery/LightboxGallery.tsx
+++ b/src/components/gallery/LightboxGallery.tsx
@@ -1,0 +1,256 @@
+import * as React from 'react';
+
+import type { GalleryAsset } from '../../data/crm';
+
+type LightboxGalleryProps = {
+    assets: GalleryAsset[];
+    className?: string;
+    thumbnailClassName?: string;
+};
+
+const combineClassNames = (...values: Array<string | undefined>): string =>
+    values.filter(Boolean).join(' ');
+
+const ZOOM_STEP = 0.25;
+const MAX_ZOOM = 3;
+const MIN_ZOOM = 1;
+
+export function LightboxGallery({ assets, className, thumbnailClassName }: LightboxGalleryProps) {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const [activeIndex, setActiveIndex] = React.useState(0);
+    const [zoom, setZoom] = React.useState(1);
+
+    const hasAssets = Boolean(assets && assets.length > 0);
+    const activeAsset = hasAssets ? assets[activeIndex] : undefined;
+
+    const openLightbox = React.useCallback(
+        (index: number) => {
+            if (!hasAssets) return;
+            setActiveIndex(index);
+            setZoom(1);
+            setIsOpen(true);
+        },
+        [hasAssets]
+    );
+
+    const closeLightbox = React.useCallback(() => {
+        setIsOpen(false);
+        setZoom(1);
+    }, []);
+
+    const goToPrevious = React.useCallback(() => {
+        setActiveIndex((prev) => {
+            if (!assets || assets.length === 0) {
+                return prev;
+            }
+
+            const nextIndex = prev - 1;
+            return nextIndex < 0 ? assets.length - 1 : nextIndex;
+        });
+        setZoom(1);
+    }, [assets]);
+
+    const goToNext = React.useCallback(() => {
+        setActiveIndex((prev) => {
+            if (!assets || assets.length === 0) {
+                return prev;
+            }
+
+            const nextIndex = prev + 1;
+            return nextIndex >= assets.length ? 0 : nextIndex;
+        });
+        setZoom(1);
+    }, [assets]);
+
+    React.useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                closeLightbox();
+            } else if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                goToPrevious();
+            } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                goToNext();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [isOpen, closeLightbox, goToNext, goToPrevious]);
+
+    React.useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const originalOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.body.style.overflow = originalOverflow;
+        };
+    }, [isOpen]);
+
+    const increaseZoom = React.useCallback(() => {
+        setZoom((current) => Math.min(MAX_ZOOM, Number((current + ZOOM_STEP).toFixed(2))));
+    }, []);
+
+    const decreaseZoom = React.useCallback(() => {
+        setZoom((current) => Math.max(MIN_ZOOM, Number((current - ZOOM_STEP).toFixed(2))));
+    }, []);
+
+    const resetZoom = React.useCallback(() => {
+        setZoom(1);
+    }, []);
+
+    if (!hasAssets) {
+        return (
+            <div className={combineClassNames('rounded-xl border border-dashed border-slate-300 p-12 text-center text-slate-500', className)}>
+                Lightbox view becomes available once assets have been uploaded.
+            </div>
+        );
+    }
+
+    return (
+        <div className={combineClassNames('space-y-6', className)}>
+            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                        <h3 className="text-lg font-semibold text-slate-900">Interactive lightbox</h3>
+                        <p className="text-sm text-slate-500">Click any image to open the immersive lightbox with zoom controls.</p>
+                    </div>
+                    <div className="text-sm text-slate-500">
+                        {assets.length} {assets.length === 1 ? 'asset' : 'assets'} available
+                    </div>
+                </div>
+                <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                    {assets.map((asset, index) => (
+                        <button
+                            key={asset.id}
+                            type="button"
+                            onClick={() => openLightbox(index)}
+                            className={combineClassNames(
+                                'group relative aspect-[4/3] overflow-hidden rounded-xl bg-slate-100 shadow-sm ring-1 ring-black/5 transition duration-150 hover:-translate-y-1 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500',
+                                thumbnailClassName
+                            )}
+                        >
+                            <img
+                                src={asset.publicUrl}
+                                alt={asset.title ?? asset.caption ?? asset.fileName}
+                                className="h-full w-full object-cover"
+                                loading={index < 6 ? 'eager' : 'lazy'}
+                            />
+                            <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent p-3 text-left text-white">
+                                <p className="line-clamp-1 text-sm font-medium">
+                                    {asset.title ?? asset.fileName}
+                                </p>
+                            </div>
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {isOpen && activeAsset ? (
+                <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/90 backdrop-blur">
+                    <div className="flex flex-col gap-4 px-6 pt-6 text-white sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <p className="text-xs uppercase tracking-[0.3em] text-white/60">Lightbox view</p>
+                            <h2 className="mt-1 text-2xl font-semibold">
+                                {activeAsset.title ?? activeAsset.fileName}
+                            </h2>
+                            {activeAsset.caption ? (
+                                <p className="mt-2 max-w-2xl text-sm text-white/80">{activeAsset.caption}</p>
+                            ) : null}
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                            <button
+                                type="button"
+                                onClick={decreaseZoom}
+                                className="rounded-full bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                            >
+                                Zoom -
+                            </button>
+                            <button
+                                type="button"
+                                onClick={resetZoom}
+                                className="rounded-full bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                            >
+                                Reset
+                            </button>
+                            <button
+                                type="button"
+                                onClick={increaseZoom}
+                                className="rounded-full bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                            >
+                                Zoom +
+                            </button>
+                            <button
+                                type="button"
+                                onClick={closeLightbox}
+                                className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                            >
+                                Close
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="relative flex flex-1 items-center justify-center px-6 pb-6">
+                        <button
+                            type="button"
+                            onClick={goToPrevious}
+                            className="absolute left-6 hidden h-12 w-12 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:flex"
+                            aria-label="View previous asset"
+                        >
+                            ◀
+                        </button>
+                        <div className="max-h-[80vh] w-full max-w-5xl overflow-hidden rounded-2xl bg-black/30 p-4">
+                            <img
+                                src={activeAsset.publicUrl}
+                                alt={activeAsset.title ?? activeAsset.caption ?? activeAsset.fileName}
+                                style={{ transform: `scale(${zoom})` }}
+                                className="mx-auto max-h-[72vh] w-full object-contain transition-transform duration-200 ease-out"
+                            />
+                        </div>
+                        <button
+                            type="button"
+                            onClick={goToNext}
+                            className="absolute right-6 hidden h-12 w-12 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:flex"
+                            aria-label="View next asset"
+                        >
+                            ▶
+                        </button>
+                    </div>
+
+                    <div className="flex gap-3 overflow-x-auto px-6 pb-8">
+                        {assets.map((asset, index) => (
+                            <button
+                                key={asset.id}
+                                type="button"
+                                onClick={() => openLightbox(index)}
+                                className={combineClassNames(
+                                    'relative flex h-20 w-28 shrink-0 overflow-hidden rounded-lg ring-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white',
+                                    index === activeIndex ? 'ring-white' : 'ring-transparent hover:ring-white/40'
+                                )}
+                            >
+                                <img src={asset.publicUrl} alt={asset.title ?? asset.fileName} className="h-full w-full object-cover" />
+                                {index === activeIndex ? (
+                                    <span className="pointer-events-none absolute inset-0 rounded-lg ring-2 ring-offset-2 ring-offset-black/30 ring-white" />
+                                ) : null}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+export default LightboxGallery;

--- a/src/components/gallery/PinterestMasonryGrid.tsx
+++ b/src/components/gallery/PinterestMasonryGrid.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+
+import type { GalleryAsset } from '../../data/crm';
+
+type CaptionRenderer = (asset: GalleryAsset, index: number) => React.ReactNode;
+
+type PinterestMasonryGridProps = {
+    assets: GalleryAsset[];
+    className?: string;
+    columnClassName?: string;
+    gap?: string;
+    onAssetClick?: (asset: GalleryAsset, index: number) => void;
+    renderCaption?: CaptionRenderer;
+};
+
+const combineClassNames = (...values: Array<string | undefined>): string =>
+    values.filter(Boolean).join(' ');
+
+const DEFAULT_COLUMNS_CLASSNAME = 'columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-4 sm:gap-6 [column-fill:_balance]';
+
+export function PinterestMasonryGrid({
+    assets,
+    className,
+    columnClassName = DEFAULT_COLUMNS_CLASSNAME,
+    gap = '1.5rem',
+    onAssetClick,
+    renderCaption
+}: PinterestMasonryGridProps) {
+    if (!assets || assets.length === 0) {
+        return (
+            <div className={combineClassNames('rounded-xl border border-dashed border-slate-300 p-12 text-center text-slate-500', className)}>
+                No assets available for this gallery yet.
+            </div>
+        );
+    }
+
+    return (
+        <div className={combineClassNames('w-full', className)}>
+            <div className={columnClassName} style={{ columnGap: gap }}>
+                {assets.map((asset, index) => {
+                    const altText = asset.title ?? asset.caption ?? asset.fileName;
+                    const captionNode =
+                        renderCaption?.(asset, index) ?? (
+                            <div className="flex flex-col gap-1 text-left">
+                                <span className="text-sm font-medium leading-snug">{asset.title ?? asset.fileName}</span>
+                                {asset.caption ? (
+                                    <span className="text-xs leading-snug text-white/80">{asset.caption}</span>
+                                ) : null}
+                            </div>
+                        );
+
+                    const content = (
+                        <React.Fragment>
+                            <img
+                                src={asset.publicUrl}
+                                alt={altText}
+                                className="h-full w-full object-cover"
+                                loading={index < 4 ? 'eager' : 'lazy'}
+                            />
+                            {captionNode ? (
+                                <div className="pointer-events-none absolute inset-x-0 bottom-0">
+                                    <div className="bg-gradient-to-t from-black/80 via-black/30 to-transparent p-4 text-white">
+                                        {captionNode}
+                                    </div>
+                                </div>
+                            ) : null}
+                        </React.Fragment>
+                    );
+
+                    if (onAssetClick) {
+                        return (
+                            <button
+                                key={asset.id}
+                                type="button"
+                                onClick={() => onAssetClick(asset, index)}
+                                className="group relative mb-6 block w-full break-inside-avoid overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5 transition duration-200 hover:-translate-y-1 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                            >
+                                {content}
+                            </button>
+                        );
+                    }
+
+                    return (
+                        <div
+                            key={asset.id}
+                            className="relative mb-6 break-inside-avoid overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5"
+                        >
+                            {content}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+export default PinterestMasonryGrid;

--- a/src/components/gallery/index.ts
+++ b/src/components/gallery/index.ts
@@ -1,0 +1,3 @@
+export { CarouselGallery } from './CarouselGallery';
+export { LightboxGallery } from './LightboxGallery';
+export { PinterestMasonryGrid } from './PinterestMasonryGrid';

--- a/src/data/crm.ts
+++ b/src/data/crm.ts
@@ -22,6 +22,21 @@ export type GalleryAsset = {
     projectCode?: string | null;
     dropboxFileId?: string | null;
     dropboxRevision?: string | null;
+    width?: number;
+    height?: number;
+    title?: string;
+    caption?: string;
+};
+
+export type GalleryPortalView = 'pinterest' | 'lightbox' | 'carousel';
+
+export type GalleryPortalSettings = {
+    password?: string;
+    token?: string;
+    hint?: string;
+    welcomeMessage?: string;
+    defaultView?: GalleryPortalView;
+    availableViews?: GalleryPortalView[];
 };
 
 export type GalleryStorageSummary = {
@@ -49,6 +64,7 @@ export type GalleryRecord = {
     dropboxSyncCursor?: string | null;
     dropboxFiles?: string[];
     customFields?: Record<string, string | boolean>;
+    portalSettings?: GalleryPortalSettings;
 };
 
 export type ProjectMilestone = {
@@ -149,10 +165,97 @@ export const galleryCollection: GalleryRecord[] = [
         deliveryDueDate: '2025-05-14',
         status: 'Pending',
         coverImage: '/images/main-hero.jpg',
-        assets: [],
-        totalStorageBytes: 0,
-        totalStorageFormatted: '0 B',
-        storageSummary: { assetCount: 0, totalBytes: 0, formattedTotal: '0 B' }
+        assets: [
+            {
+                id: 'gal-01-asset-01',
+                fileName: 'aurora-dunes.svg',
+                contentType: 'image/svg+xml',
+                size: 512000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-01/aurora-dunes.svg',
+                publicUrl: '/images/galleries/aurora-dunes.svg',
+                width: 1600,
+                height: 1000,
+                title: 'Sunset over the dunes',
+                caption: 'A sweeping view captured just after golden hour.'
+            },
+            {
+                id: 'gal-01-asset-02',
+                fileName: 'golden-hour-ridge.svg',
+                contentType: 'image/svg+xml',
+                size: 468000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-01/golden-hour-ridge.svg',
+                publicUrl: '/images/galleries/golden-hour-ridge.svg',
+                width: 1000,
+                height: 1600,
+                title: 'Golden ridge embrace',
+                caption: 'Portraits along the windswept ridge moments before sunset.'
+            },
+            {
+                id: 'gal-01-asset-03',
+                fileName: 'seaside-trail.svg',
+                contentType: 'image/svg+xml',
+                size: 489000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-01/seaside-trail.svg',
+                publicUrl: '/images/galleries/seaside-trail.svg',
+                width: 1600,
+                height: 960,
+                title: 'Coastal path walk',
+                caption: 'Candid laughter along the bluffs.'
+            },
+            {
+                id: 'gal-01-asset-04',
+                fileName: 'botanical-study.svg',
+                contentType: 'image/svg+xml',
+                size: 420000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-01/botanical-study.svg',
+                publicUrl: '/images/galleries/botanical-study.svg',
+                width: 1400,
+                height: 1400,
+                title: 'Details in the greenhouse',
+                caption: 'Close-up details from the greenhouse mini session.'
+            },
+            {
+                id: 'gal-01-asset-05',
+                fileName: 'artisan-details.svg',
+                contentType: 'image/svg+xml',
+                size: 398000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-01/artisan-details.svg',
+                publicUrl: '/images/galleries/artisan-details.svg',
+                width: 1000,
+                height: 1500,
+                title: 'Heirloom keepsakes',
+                caption: 'Flat-lay featuring stationery and rings.'
+            },
+            {
+                id: 'gal-01-asset-06',
+                fileName: 'craftsmanship.svg',
+                contentType: 'image/svg+xml',
+                size: 536000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-01/craftsmanship.svg',
+                publicUrl: '/images/galleries/craftsmanship.svg',
+                width: 1600,
+                height: 900,
+                title: 'Reception setup',
+                caption: 'Soft-lit reception tables moments before guests arrived.'
+            }
+        ],
+        totalStorageBytes: 2823000,
+        totalStorageFormatted: '2.82 MB',
+        storageSummary: { assetCount: 6, totalBytes: 2823000, formattedTotal: '2.82 MB' },
+        portalSettings: {
+            password: 'wanderlust-love',
+            token: 'evelyn-portal',
+            hint: 'Use the phrase we texted after your session.',
+            welcomeMessage: 'Hi Evelyn! Relive your engagement weekend highlights here.',
+            defaultView: 'pinterest',
+            availableViews: ['pinterest', 'lightbox', 'carousel']
+        }
     },
     {
         id: 'gal-02',
@@ -162,12 +265,72 @@ export const galleryCollection: GalleryRecord[] = [
         status: 'Pending',
         projectId: 'proj-02',
         coverImage: '/images/hero3.svg',
-        assets: [],
-        totalStorageBytes: 0,
-        totalStorageFormatted: '0 B',
-        storageSummary: { assetCount: 0, totalBytes: 0, formattedTotal: '0 B' },
+        assets: [
+            {
+                id: 'gal-02-asset-01',
+                fileName: 'collaboration.svg',
+                contentType: 'image/svg+xml',
+                size: 548000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-02/collaboration.svg',
+                publicUrl: '/images/galleries/collaboration.svg',
+                width: 1600,
+                height: 900,
+                title: 'Celebration welcome party',
+                caption: 'Welcome party toasts at the rooftop venue.'
+            },
+            {
+                id: 'gal-02-asset-02',
+                fileName: 'skyline-dusk.svg',
+                contentType: 'image/svg+xml',
+                size: 502000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-02/skyline-dusk.svg',
+                publicUrl: '/images/galleries/skyline-dusk.svg',
+                width: 1600,
+                height: 1000,
+                title: 'City skyline portraits',
+                caption: 'Evening skyline portraits with the couple.'
+            },
+            {
+                id: 'gal-02-asset-03',
+                fileName: 'cobalt-harbor.svg',
+                contentType: 'image/svg+xml',
+                size: 486000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-02/cobalt-harbor.svg',
+                publicUrl: '/images/galleries/cobalt-harbor.svg',
+                width: 1600,
+                height: 1060,
+                title: 'Harbor rehearsal dinner',
+                caption: 'Reflections from the harbor-side rehearsal dinner.'
+            },
+            {
+                id: 'gal-02-asset-04',
+                fileName: 'studio-session.svg',
+                contentType: 'image/svg+xml',
+                size: 472000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-02/studio-session.svg',
+                publicUrl: '/images/galleries/studio-session.svg',
+                width: 1600,
+                height: 1100,
+                title: 'Editorial studio portraits',
+                caption: 'Clean studio portrait series for the couple.'
+            }
+        ],
+        totalStorageBytes: 2008000,
+        totalStorageFormatted: '2.01 MB',
+        storageSummary: { assetCount: 4, totalBytes: 2008000, formattedTotal: '2.01 MB' },
         customFields: {
             deliveryEmail: 'hello@harrisonandjune.com'
+        },
+        portalSettings: {
+            password: 'hj-weekend-2025',
+            hint: 'It combines your initials with the event year.',
+            welcomeMessage: 'Welcome back! Your full wedding weekend story is ready.',
+            defaultView: 'carousel',
+            availableViews: ['carousel', 'lightbox', 'pinterest']
         }
     },
     {
@@ -179,12 +342,59 @@ export const galleryCollection: GalleryRecord[] = [
         status: 'Delivered',
         projectId: 'proj-03',
         coverImage: '/images/abstract-feature1.svg',
-        assets: [],
-        totalStorageBytes: 0,
-        totalStorageFormatted: '0 B',
-        storageSummary: { assetCount: 0, totalBytes: 0, formattedTotal: '0 B' },
+        assets: [
+            {
+                id: 'gal-03-asset-01',
+                fileName: 'studio-session.svg',
+                contentType: 'image/svg+xml',
+                size: 458000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-03/studio-session.svg',
+                publicUrl: '/images/galleries/studio-session.svg',
+                width: 1600,
+                height: 1100,
+                title: 'Launch hero scene',
+                caption: 'Primary hero scene for the lifestyle campaign.'
+            },
+            {
+                id: 'gal-03-asset-02',
+                fileName: 'collaboration.svg',
+                contentType: 'image/svg+xml',
+                size: 446000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-03/collaboration.svg',
+                publicUrl: '/images/galleries/collaboration.svg',
+                width: 1600,
+                height: 900,
+                title: 'Team ideation',
+                caption: 'Creative team collaborating during concept exploration.'
+            },
+            {
+                id: 'gal-03-asset-03',
+                fileName: 'craftsmanship.svg',
+                contentType: 'image/svg+xml',
+                size: 430000,
+                storageBucket: 'public',
+                storagePath: 'galleries/gal-03/craftsmanship.svg',
+                publicUrl: '/images/galleries/craftsmanship.svg',
+                width: 1600,
+                height: 900,
+                title: 'Product detail vignette',
+                caption: 'Handcrafted materials styled for the product story.'
+            }
+        ],
+        totalStorageBytes: 1334000,
+        totalStorageFormatted: '1.33 MB',
+        storageSummary: { assetCount: 3, totalBytes: 1334000, formattedTotal: '1.33 MB' },
         customFields: {
             deliveryEmail: 'sona@patelcreative.co'
+        },
+        portalSettings: {
+            token: 'sona-brand-access',
+            hint: 'Use the token shared in your kickoff recap.',
+            welcomeMessage: 'Sona, download final selects for the campaign launch.',
+            defaultView: 'lightbox',
+            availableViews: ['lightbox', 'pinterest']
         }
     },
     {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './crm';
+export { getStaticProps } from './crm';

--- a/src/pages/portal/[galleryId].tsx
+++ b/src/pages/portal/[galleryId].tsx
@@ -1,0 +1,302 @@
+import * as React from 'react';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import type { GetStaticPaths, GetStaticProps, InferGetStaticPropsType, NextPage } from 'next';
+import dayjs from 'dayjs';
+
+import {
+    galleryCollection,
+    type GalleryAsset,
+    type GalleryPortalSettings,
+    type GalleryPortalView,
+    type GalleryRecord
+} from '../../data/crm';
+import { CarouselGallery, LightboxGallery, PinterestMasonryGrid } from '../../components/gallery';
+
+type GalleryPortalPageProps = {
+    gallery: GalleryRecord;
+};
+
+type AuthFormElements = HTMLFormElement & {
+    portalSecret: HTMLInputElement;
+};
+
+const VIEW_DEFINITIONS: Record<GalleryPortalView, { label: string; description: string }> = {
+    pinterest: {
+        label: 'Pinterest grid',
+        description: 'Organic masonry layout ideal for storytelling and social selects.'
+    },
+    lightbox: {
+        label: 'Lightbox',
+        description: 'Immersive full-screen viewer with zoom and keyboard navigation.'
+    },
+    carousel: {
+        label: 'Carousel',
+        description: 'Auto-playing hero carousel highlighting marquee scenes.'
+    }
+};
+
+const computeAvailableViews = (settings?: GalleryPortalSettings): GalleryPortalView[] => {
+    const whitelist: GalleryPortalView[] = ['pinterest', 'lightbox', 'carousel'];
+    if (!settings?.availableViews || settings.availableViews.length === 0) {
+        return whitelist;
+    }
+
+    const normalized = settings.availableViews.filter((view): view is GalleryPortalView =>
+        whitelist.includes(view as GalleryPortalView)
+    );
+
+    return normalized.length > 0 ? normalized : whitelist;
+};
+
+const safeCompare = (valueA?: string | null, valueB?: string | null) => {
+    if (!valueA || !valueB) {
+        return false;
+    }
+    return valueA.trim() === valueB.trim();
+};
+
+const formatDate = (value?: string) => {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = dayjs(value);
+    return parsed.isValid() ? parsed.format('MMM D, YYYY') : value;
+};
+
+const GalleryPortalPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({ gallery }) => {
+    const router = useRouter();
+
+    const assets: GalleryAsset[] = React.useMemo(() => gallery.assets ?? [], [gallery.assets]);
+    const availableViews = React.useMemo(() => computeAvailableViews(gallery.portalSettings), [gallery.portalSettings]);
+    const initialView = React.useMemo(() => {
+        const preferred = gallery.portalSettings?.defaultView;
+        if (preferred && availableViews.includes(preferred)) {
+            return preferred;
+        }
+        return availableViews[0];
+    }, [availableViews, gallery.portalSettings?.defaultView]);
+
+    const [activeView, setActiveView] = React.useState<GalleryPortalView>(initialView);
+    const [isAuthenticated, setIsAuthenticated] = React.useState<boolean>(() => {
+        const requiresCredential = Boolean(gallery.portalSettings?.password || gallery.portalSettings?.token);
+        return !requiresCredential;
+    });
+    const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+    const [pendingCredential, setPendingCredential] = React.useState('');
+
+    React.useEffect(() => {
+        if (availableViews.includes(activeView)) {
+            return;
+        }
+        setActiveView(availableViews[0]);
+    }, [availableViews, activeView]);
+
+    React.useEffect(() => {
+        if (!gallery.portalSettings?.token) {
+            return;
+        }
+
+        const queryToken = Array.isArray(router.query.token) ? router.query.token[0] : router.query.token;
+        if (queryToken && safeCompare(queryToken, gallery.portalSettings.token)) {
+            setIsAuthenticated(true);
+            setErrorMessage(null);
+        }
+    }, [router.query, gallery.portalSettings?.token]);
+
+    const handleCredentialSubmit = React.useCallback(
+        (value: string) => {
+            const trimmed = value.trim();
+            if (!trimmed) {
+                setErrorMessage('Enter the password or one-time token shared with you.');
+                return;
+            }
+
+            const matchesPassword = safeCompare(trimmed, gallery.portalSettings?.password);
+            const matchesToken = safeCompare(trimmed, gallery.portalSettings?.token);
+
+            if (matchesPassword || matchesToken) {
+                setIsAuthenticated(true);
+                setErrorMessage(null);
+                return;
+            }
+
+            setErrorMessage('That code is incorrect. Double-check your invitation email and try again.');
+        },
+        [gallery.portalSettings?.password, gallery.portalSettings?.token]
+    );
+
+    const handleSubmit = React.useCallback(
+        (event: React.FormEvent<AuthFormElements>) => {
+            event.preventDefault();
+            handleCredentialSubmit(event.currentTarget.portalSecret.value);
+        },
+        [handleCredentialSubmit]
+    );
+
+    React.useEffect(() => {
+        setPendingCredential('');
+    }, [isAuthenticated]);
+
+    if (router.isFallback) {
+        return <div className="flex min-h-screen items-center justify-center bg-slate-950 text-white">Loading portal…</div>;
+    }
+
+    const heroImage = gallery.coverImage ?? '/images/main-hero.jpg';
+    const welcomeMessage = gallery.portalSettings?.welcomeMessage;
+
+    const statusItems = [
+        { label: 'Shoot type', value: gallery.shootType },
+        { label: 'Status', value: gallery.status },
+        { label: 'Delivery due', value: formatDate(gallery.deliveryDueDate) },
+        { label: 'Delivered', value: formatDate(gallery.deliveredAt) },
+        { label: 'Expires', value: formatDate(gallery.expiresAt) },
+        { label: 'Assets', value: assets.length ? `${assets.length} files` : 'Not yet available' }
+    ].filter((item) => Boolean(item.value));
+
+    const activeViewDescription = VIEW_DEFINITIONS[activeView]?.description;
+
+    return (
+        <>
+            <Head>
+                <title>{gallery.client} | Client portal</title>
+                <meta
+                    name="description"
+                    content={welcomeMessage ?? `Private gallery portal for ${gallery.client}.`}
+                />
+            </Head>
+            {!isAuthenticated ? (
+                <main className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-white">
+                    <div className="w-full max-w-lg rounded-3xl border border-white/10 bg-slate-900/70 p-10 shadow-2xl backdrop-blur">
+                        <p className="text-xs uppercase tracking-[0.3em] text-white/60">Secure portal</p>
+                        <h1 className="mt-3 text-3xl font-semibold leading-tight">Enter your gallery password</h1>
+                        <p className="mt-3 text-sm text-white/70">
+                            {welcomeMessage ?? 'This gallery is protected. Use the access code shared via email or text.'}
+                        </p>
+                        <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+                            <div>
+                                <label htmlFor="portalSecret" className="text-sm font-medium text-white">
+                                    Access code
+                                </label>
+                                <input
+                                    id="portalSecret"
+                                    name="portalSecret"
+                                    type="password"
+                                    autoComplete="off"
+                                    value={pendingCredential}
+                                    onChange={(event) => setPendingCredential(event.target.value)}
+                                    className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/50 focus:border-white focus:outline-none focus:ring-2 focus:ring-white"
+                                    placeholder="Enter password or token"
+                                />
+                                {gallery.portalSettings?.hint ? (
+                                    <p className="mt-2 text-xs text-white/60">Hint: {gallery.portalSettings.hint}</p>
+                                ) : null}
+                                {errorMessage ? <p className="mt-2 text-sm text-rose-300">{errorMessage}</p> : null}
+                            </div>
+                            <button
+                                type="submit"
+                                className="w-full rounded-xl bg-white py-3 text-base font-semibold text-slate-900 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                            >
+                                Unlock gallery
+                            </button>
+                        </form>
+                    </div>
+                </main>
+            ) : (
+                <main className="min-h-screen bg-slate-950 text-white">
+                    <section className="relative isolate overflow-hidden">
+                        <div className="absolute inset-0">
+                            <img src={heroImage} alt="" className="h-full w-full object-cover opacity-40" />
+                            <div className="absolute inset-0 bg-slate-950/70" />
+                        </div>
+                        <div className="relative z-10 mx-auto flex max-w-5xl flex-col gap-8 px-6 py-24 sm:px-10">
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-white/60">Client portal</p>
+                                <h1 className="mt-3 text-4xl font-semibold sm:text-5xl">{gallery.client}</h1>
+                                <p className="mt-4 max-w-2xl text-base text-white/80">
+                                    {welcomeMessage ?? 'Your session highlights, ready to view, share, and download.'}
+                                </p>
+                            </div>
+                            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                                {statusItems.map((item) => (
+                                    <div key={item.label} className="rounded-2xl border border-white/15 bg-white/5 p-4 backdrop-blur">
+                                        <p className="text-xs uppercase tracking-wider text-white/60">{item.label}</p>
+                                        <p className="mt-2 text-lg font-semibold text-white">{item.value}</p>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="relative -mt-12 px-6 pb-24 sm:px-10">
+                        <div className="mx-auto max-w-6xl rounded-3xl border border-white/5 bg-white/95 p-8 text-slate-900 shadow-2xl">
+                            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+                                <div>
+                                    <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Presentation mode</p>
+                                    <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+                                        {VIEW_DEFINITIONS[activeView]?.label ?? 'Gallery view'}
+                                    </h2>
+                                    {activeViewDescription ? (
+                                        <p className="mt-2 max-w-xl text-sm text-slate-500">{activeViewDescription}</p>
+                                    ) : null}
+                                </div>
+                                <div className="flex flex-wrap items-center gap-2">
+                                    {availableViews.map((viewOption) => (
+                                        <button
+                                            key={viewOption}
+                                            type="button"
+                                            onClick={() => setActiveView(viewOption)}
+                                            className={
+                                                viewOption === activeView
+                                                    ? 'rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow'
+                                                    : 'rounded-full bg-slate-100 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-200'
+                                            }
+                                        >
+                                            {VIEW_DEFINITIONS[viewOption]?.label ?? viewOption}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <div className="mt-8 space-y-6">
+                                {activeView === 'pinterest' ? (
+                                    <PinterestMasonryGrid assets={assets} />
+                                ) : null}
+                                {activeView === 'lightbox' ? <LightboxGallery assets={assets} /> : null}
+                                {activeView === 'carousel' ? <CarouselGallery assets={assets} /> : null}
+                            </div>
+                        </div>
+                    </section>
+                </main>
+            )}
+        </>
+    );
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+    return {
+        paths: galleryCollection.map((gallery) => ({ params: { galleryId: gallery.id } })),
+        fallback: false
+    };
+};
+
+export const getStaticProps: GetStaticProps<GalleryPortalPageProps> = async ({ params }) => {
+    const galleryIdParam = Array.isArray(params?.galleryId) ? params?.galleryId[0] : params?.galleryId;
+
+    const gallery = galleryCollection.find((item) => item.id === galleryIdParam);
+
+    if (!gallery) {
+        return {
+            notFound: true
+        };
+    }
+
+    return {
+        props: {
+            gallery
+        }
+    };
+};
+
+export default GalleryPortalPage;


### PR DESCRIPTION
## Summary
- introduce reusable Pinterest grid, lightbox, and carousel gallery components backed by gallery metadata
- add a password/token-gated client portal route with presentation mode switching and hero layout
- extend gallery records with asset metadata, portal settings, and sample artwork assets plus propagate content data
- ensure homepage exports data fetching for static build compatibility

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca175ffb5883299a9f71a4f2e7c4c6