### PR TITLE
Add Codex dashboard homepage and harden invoice display

### DIFF
--- a/src/components/crm/InvoiceTable.tsx
+++ b/src/components/crm/InvoiceTable.tsx
@@ -11,8 +11,10 @@ const statusToneMap: Record<InvoiceStatus, StatusTone> = {
     Overdue: 'danger'
 };
 
-const formatCurrency = (value: number, currency: string) =>
-    new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: 2 }).format(value);
+const formatCurrency = (value: number, currency: string) => {
+    const safeCurrency = typeof currency === 'string' && currency.trim().length === 3 ? currency : 'USD';
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: safeCurrency, maximumFractionDigits: 2 }).format(value);
+};
 
 const formatDate = (value: string) => dayjs(value).format('MMM D, YYYY');
 
@@ -35,151 +37,163 @@ export function InvoiceTable({
 }: InvoiceTableProps) {
     return (
         <div className="space-y-4">
-            {invoices.map((invoice) => (
-                <div
-                    key={invoice.id}
-                    className="space-y-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
-                >
-                    <div className="flex flex-wrap items-start justify-between gap-4">
-                        <div>
-                            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
-                                Invoice {invoice.id}
-                            </p>
-                            <h3 className="text-base font-semibold text-slate-900 dark:text-white">{invoice.client}</h3>
-                            <p className="text-sm text-slate-500 dark:text-slate-400">{invoice.project}</p>
-                            <p className="text-xs text-slate-400 dark:text-slate-500">Issued {formatDate(invoice.issueDate)}</p>
-                        </div>
-                        <div className="text-right">
-                            <p className="text-xl font-semibold text-slate-900 dark:text-white">
-                                {formatCurrency(invoice.amount, invoice.currency)}
-                            </p>
-                            <p className="text-sm text-slate-500 dark:text-slate-400">Due {formatDate(invoice.dueDate)}</p>
-                            {invoice.paymentLink ? (
-                                <a
-                                    href={invoice.paymentLink}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="mt-2 inline-flex items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-100 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200 dark:hover:bg-emerald-500/20"
-                                >
-                                    Pay online
-                                </a>
-                            ) : null}
-                        </div>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-3 text-sm">
-                        <StatusPill tone={statusToneMap[invoice.status]}>{invoice.status}</StatusPill>
-                        <span className="text-slate-500 dark:text-slate-400">
-                            Balance {formatCurrency(invoice.status === 'Paid' ? 0 : invoice.amount, invoice.currency)}
-                        </span>
-                        <div className="ml-auto flex flex-wrap gap-3 text-sm font-semibold">
-                            {invoice.pdfUrl ? (
-                                <a
-                                    href={invoice.pdfUrl}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-[#4534FF] transition hover:bg-slate-100 dark:border-slate-700 dark:text-[#9DAAFF] dark:hover:bg-slate-800"
-                                >
-                                    Download PDF
-                                </a>
-                            ) : null}
-                            {onGeneratePdf ? (
-                                <button
-                                    type="button"
-                                    onClick={() => onGeneratePdf(invoice)}
-                                    disabled={generatingInvoiceId === invoice.id}
-                                    className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
-                                >
-                                    {generatingInvoiceId === invoice.id
-                                        ? 'Preparing…'
-                                        : invoice.pdfUrl
-                                          ? 'Regenerate PDF'
-                                          : 'Generate PDF'}
-                                </button>
-                            ) : null}
-                            {onCreateCheckout && invoice.status !== 'Paid' ? (
-                                <button
-                                    type="button"
-                                    onClick={() => onCreateCheckout(invoice)}
-                                    disabled={checkoutInvoiceId === invoice.id}
-                                    className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-indigo-600 transition hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200 dark:hover:bg-indigo-500/20"
-                                >
-                                    {checkoutInvoiceId === invoice.id ? 'Starting checkout…' : 'Send payment link'}
-                                </button>
-                            ) : null}
-                            <button className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
-                                View details
-                            </button>
-                        </div>
-                    </div>
-                    {onUpdateStatus ? (
-                        <div className="flex flex-wrap gap-2">
-                            {invoice.status === 'Draft' || invoice.status === 'Overdue' ? (
-                                <button
-                                    type="button"
-                                    onClick={() => onUpdateStatus(invoice.id, 'Sent')}
-                                    className="rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-600 transition hover:bg-indigo-100 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200 dark:hover:bg-indigo-500/20"
-                                >
-                                    Mark sent
-                                </button>
-                            ) : null}
-                            {invoice.status === 'Sent' ? (
-                                <button
-                                    type="button"
-                                    onClick={() => onUpdateStatus(invoice.id, 'Overdue')}
-                                    className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-600 transition hover:bg-amber-100 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200 dark:hover:bg-amber-500/20"
-                                >
-                                    Mark overdue
-                                </button>
-                            ) : null}
-                            {invoice.status === 'Sent' || invoice.status === 'Overdue' ? (
-                                <button
-                                    type="button"
-                                    onClick={() => onUpdateStatus(invoice.id, 'Paid')}
-                                    className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-600 transition hover:bg-emerald-100 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200 dark:hover:bg-emerald-500/20"
-                                >
-                                    Mark paid
-                                </button>
-                            ) : null}
-                        </div>
-                    ) : null}
-                    {invoice.lineItems.length > 0 ? (
-                        <div className="space-y-3 rounded-2xl border border-slate-100 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/60">
-                            <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
-                                {invoice.lineItems.slice(0, 3).map((item) => (
-                                    <li key={item.id} className="flex items-center justify-between gap-4">
-                                        <span className="font-medium text-slate-700 dark:text-slate-200">{item.description}</span>
-                                        <span>
-                                            {item.quantity} × {formatCurrency(item.unitPrice, invoice.currency)} ={' '}
-                                            <strong className="text-slate-900 dark:text-white">
-                                                {formatCurrency(item.total, invoice.currency)}
-                                            </strong>
-                                        </span>
-                                    </li>
-                                ))}
-                            </ul>
-                            {invoice.lineItems.length > 3 ? (
-                                <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400 dark:text-slate-500">
-                                    +{invoice.lineItems.length - 3} more line items
+            {invoices.map((invoice) => {
+                const invoiceId = typeof invoice.id === 'string' && invoice.id.trim() ? invoice.id : 'invoice';
+                const currency = typeof invoice.currency === 'string' && invoice.currency.trim().length === 3 ? invoice.currency : 'USD';
+                const project = invoice.project ?? 'New project';
+                const issueDateLabel = invoice.issueDate ? formatDate(invoice.issueDate) : '—';
+                const dueDateLabel = invoice.dueDate ? formatDate(invoice.dueDate) : '—';
+                const lineItems = Array.isArray(invoice.lineItems) ? invoice.lineItems : [];
+                const totals = invoice.totals ?? { subtotal: invoice.amount, taxTotal: 0, total: invoice.amount };
+                const taxRate = Number.isFinite(invoice.taxRate) ? invoice.taxRate : 0;
+                const outstandingAmount = invoice.status === 'Paid' ? 0 : invoice.amount;
+
+                return (
+                    <div
+                        key={invoiceId}
+                        className="space-y-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
+                    >
+                        <div className="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+                                    Invoice {invoiceId}
                                 </p>
-                            ) : null}
-                            <div className="space-y-1 text-sm text-slate-500 dark:text-slate-400">
-                                <div className="flex items-center justify-between">
-                                    <span>Subtotal</span>
-                                    <span>{formatCurrency(invoice.totals.subtotal, invoice.currency)}</span>
-                                </div>
-                                <div className="flex items-center justify-between">
-                                    <span>Tax ({Math.round(invoice.taxRate * 100)}%)</span>
-                                    <span>{formatCurrency(invoice.totals.taxTotal, invoice.currency)}</span>
-                                </div>
-                                <div className="flex items-center justify-between text-base font-semibold text-slate-900 dark:text-white">
-                                    <span>Total</span>
-                                    <span>{formatCurrency(invoice.totals.total, invoice.currency)}</span>
-                                </div>
+                                <h3 className="text-base font-semibold text-slate-900 dark:text-white">{invoice.client}</h3>
+                                <p className="text-sm text-slate-500 dark:text-slate-400">{project}</p>
+                                <p className="text-xs text-slate-400 dark:text-slate-500">Issued {issueDateLabel}</p>
+                            </div>
+                            <div className="text-right">
+                                <p className="text-xl font-semibold text-slate-900 dark:text-white">
+                                    {formatCurrency(invoice.amount, currency)}
+                                </p>
+                                <p className="text-sm text-slate-500 dark:text-slate-400">Due {dueDateLabel}</p>
+                                {invoice.paymentLink ? (
+                                    <a
+                                        href={invoice.paymentLink}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="mt-2 inline-flex items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-100 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200 dark:hover:bg-emerald-500/20"
+                                    >
+                                        Pay online
+                                    </a>
+                                ) : null}
                             </div>
                         </div>
-                    ) : null}
-                </div>
-            ))}
+                        <div className="flex flex-wrap items-center gap-3 text-sm">
+                            <StatusPill tone={statusToneMap[invoice.status]}>{invoice.status}</StatusPill>
+                            <span className="text-slate-500 dark:text-slate-400">
+                                Balance {formatCurrency(outstandingAmount, currency)}
+                            </span>
+                            <div className="ml-auto flex flex-wrap gap-3 text-sm font-semibold">
+                                {invoice.pdfUrl ? (
+                                    <a
+                                        href={invoice.pdfUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-[#4534FF] transition hover:bg-slate-100 dark:border-slate-700 dark:text-[#9DAAFF] dark:hover:bg-slate-800"
+                                    >
+                                        Download PDF
+                                    </a>
+                                ) : null}
+                                {onGeneratePdf ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => onGeneratePdf(invoice)}
+                                        disabled={generatingInvoiceId === invoice.id}
+                                        className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                                    >
+                                        {generatingInvoiceId === invoice.id
+                                            ? 'Preparing…'
+                                            : invoice.pdfUrl
+                                              ? 'Regenerate PDF'
+                                              : 'Generate PDF'}
+                                    </button>
+                                ) : null}
+                                {onCreateCheckout && invoice.status !== 'Paid' ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => onCreateCheckout(invoice)}
+                                        disabled={checkoutInvoiceId === invoice.id}
+                                        className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-indigo-600 transition hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200 dark:hover:bg-indigo-500/20"
+                                    >
+                                        {checkoutInvoiceId === invoice.id ? 'Starting checkout…' : 'Send payment link'}
+                                    </button>
+                                ) : null}
+                                <button className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
+                                    View details
+                                </button>
+                            </div>
+                        </div>
+                        {onUpdateStatus ? (
+                            <div className="flex flex-wrap gap-2">
+                                {invoice.status === 'Draft' || invoice.status === 'Overdue' ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => onUpdateStatus(invoice.id, 'Sent')}
+                                        className="rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-600 transition hover:bg-indigo-100 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200 dark:hover:bg-indigo-500/20"
+                                    >
+                                        Mark sent
+                                    </button>
+                                ) : null}
+                                {invoice.status === 'Sent' ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => onUpdateStatus(invoice.id, 'Overdue')}
+                                        className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-600 transition hover:bg-amber-100 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200 dark:hover:bg-amber-500/20"
+                                    >
+                                        Mark overdue
+                                    </button>
+                                ) : null}
+                                {invoice.status === 'Sent' || invoice.status === 'Overdue' ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => onUpdateStatus(invoice.id, 'Paid')}
+                                        className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-600 transition hover:bg-emerald-100 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200 dark:hover:bg-emerald-500/20"
+                                    >
+                                        Mark paid
+                                    </button>
+                                ) : null}
+                            </div>
+                        ) : null}
+                        {lineItems.length > 0 ? (
+                            <div className="space-y-3 rounded-2xl border border-slate-100 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/60">
+                                <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                                    {lineItems.slice(0, 3).map((item) => (
+                                        <li key={item.id} className="flex items-center justify-between gap-4">
+                                            <span className="font-medium text-slate-700 dark:text-slate-200">{item.description}</span>
+                                            <span>
+                                                {item.quantity} × {formatCurrency(item.unitPrice, currency)} ={' '}
+                                                <strong className="text-slate-900 dark:text-white">
+                                                    {formatCurrency(item.total, currency)}
+                                                </strong>
+                                            </span>
+                                        </li>
+                                    ))}
+                                </ul>
+                                {lineItems.length > 3 ? (
+                                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400 dark:text-slate-500">
+                                        +{lineItems.length - 3} more line items
+                                    </p>
+                                ) : null}
+                                <div className="space-y-1 text-sm text-slate-500 dark:text-slate-400">
+                                    <div className="flex items-center justify-between">
+                                        <span>Subtotal</span>
+                                        <span>{formatCurrency(totals.subtotal, currency)}</span>
+                                    </div>
+                                    <div className="flex items-center justify-between">
+                                        <span>Tax ({Math.round(taxRate * 100)}%)</span>
+                                        <span>{formatCurrency(totals.taxTotal, currency)}</span>
+                                    </div>
+                                    <div className="flex items-center justify-between text-base font-semibold text-slate-900 dark:text-white">
+                                        <span>Total</span>
+                                        <span>{formatCurrency(totals.total, currency)}</span>
+                                    </div>
+                                </div>
+                            </div>
+                        ) : null}
+                    </div>
+                );
+            })}
         </div>
     );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,2 +1,479 @@
-export { default } from './crm';
-export { getStaticProps } from './crm';
+import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import Head from 'next/head';
+import type { IncomingMessage } from 'http';
+import dayjs from 'dayjs';
+
+import { DashboardCard, OverviewChart, type ChartPoint } from 'src/components/crm';
+
+type CodexBookingRecord = {
+    id?: string;
+    client?: string;
+    date?: string;
+    time?: string;
+    startTime?: string;
+    endTime?: string;
+    start_time?: string;
+    end_time?: string;
+    shoot_type?: string;
+    shootType?: string;
+    status?: string;
+};
+
+type CodexInvoiceRecord = {
+    id?: string;
+    client?: string;
+    amount?: number | string;
+    due_date?: string;
+    dueDate?: string;
+    status?: string;
+};
+
+type DashboardBooking = {
+    id: string;
+    client: string;
+    date: string;
+    status: string;
+    shootType: string;
+    startTime?: string;
+    endTime?: string;
+};
+
+type DashboardInvoice = {
+    id: string;
+    client: string;
+    amount: number;
+    dueDate: string;
+    status: string;
+};
+
+type ChartData = Record<'weekly' | 'monthly' | 'yearly', ChartPoint[]>;
+
+type DashboardMetrics = {
+    monthlyRevenue: number;
+    upcomingShoots: number;
+    outstandingInvoices: number;
+    outstandingAmount: number;
+    currentMonthLabel: string;
+};
+
+type DashboardPageProps = {
+    metrics: DashboardMetrics;
+    chartData: ChartData;
+};
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+});
+
+function formatCurrency(value: number): string {
+    return currencyFormatter.format(value);
+}
+
+const ACTIVE_BOOKING_STATUSES = new Set(['confirmed', 'pending']);
+
+function CodexDashboardPage({ metrics, chartData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+    const { monthlyRevenue, upcomingShoots, outstandingInvoices, outstandingAmount, currentMonthLabel } = metrics;
+
+    return (
+        <>
+            <Head>
+                <title>Codex Studio Dashboard</title>
+                <meta
+                    name="description"
+                    content="Studio performance insights sourced from Codex CRM collections."
+                />
+            </Head>
+            <main className="min-h-screen bg-slate-50 py-12 text-slate-900 dark:bg-slate-950 dark:text-slate-50">
+                <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6">
+                    <header className="space-y-3">
+                        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
+                            Codex Studio
+                        </p>
+                        <h1 className="text-3xl font-semibold tracking-tight">Operations dashboard</h1>
+                        <p className="max-w-2xl text-sm text-slate-600 dark:text-slate-300">
+                            Live KPIs sourced from Codex CRM bookings and invoices keep the studio team aligned on revenue
+                            goals and production workload.
+                        </p>
+                    </header>
+
+                    <section className="grid gap-6 md:grid-cols-3">
+                        <DashboardCard title="Monthly Revenue" value={formatCurrency(monthlyRevenue)}>
+                            <p className="text-xs leading-relaxed text-slate-600 dark:text-slate-300">
+                                Sum of paid invoices collected in {currentMonthLabel}.
+                            </p>
+                        </DashboardCard>
+                        <DashboardCard title="Upcoming Shoots" value={upcomingShoots.toString()}>
+                            <p className="text-xs leading-relaxed text-slate-600 dark:text-slate-300">
+                                Confirmed or pending sessions happening in the next 30 days.
+                            </p>
+                        </DashboardCard>
+                        <DashboardCard title="Outstanding Invoices" value={outstandingInvoices.toString()}>
+                            <p className="text-xs leading-relaxed text-slate-600 dark:text-slate-300">
+                                {outstandingInvoices === 0 ? 'All invoices are current.' : null}
+                                {outstandingInvoices > 0 ? `Open balance totals ${formatCurrency(outstandingAmount)}.` : null}
+                            </p>
+                        </DashboardCard>
+                    </section>
+
+                    <section>
+                        <OverviewChart data={chartData} />
+                    </section>
+                </div>
+            </main>
+        </>
+    );
+}
+
+export default CodexDashboardPage;
+
+export const getServerSideProps: GetServerSideProps<DashboardPageProps> = async ({ req }) => {
+    const baseUrl = resolveBaseUrl(req);
+
+    const [bookingPayload, invoicePayload] = await Promise.all([
+        fetchCodexCollection<CodexBookingRecord>(baseUrl, 'bookings'),
+        fetchCodexCollection<CodexInvoiceRecord>(baseUrl, 'invoices')
+    ]);
+
+    const bookings = normalizeBookings(bookingPayload);
+    const invoices = normalizeInvoices(invoicePayload);
+
+    const today = dayjs();
+    const startOfToday = today.startOf('day');
+    const currentMonth = today.startOf('month');
+    const endOfWindow = startOfToday.add(30, 'day').endOf('day');
+
+    const monthlyRevenue = invoices
+        .filter((invoice) => invoice.status === 'Paid' && dayjs(invoice.dueDate).isSame(currentMonth, 'month'))
+        .reduce((total, invoice) => total + invoice.amount, 0);
+
+    const upcomingShoots = bookings.filter((booking) => {
+        const date = dayjs(booking.date);
+        if (!date.isValid()) {
+            return false;
+        }
+        const normalizedStatus = booking.status.toLowerCase();
+        if (!ACTIVE_BOOKING_STATUSES.has(normalizedStatus)) {
+            return false;
+        }
+        return (
+            (date.isSame(startOfToday, 'day') || date.isAfter(startOfToday)) &&
+            (date.isBefore(endOfWindow) || date.isSame(endOfWindow))
+        );
+    }).length;
+
+    const outstandingInvoices = invoices.filter((invoice) => invoice.status !== 'Paid').length;
+    const outstandingAmount = invoices
+        .filter((invoice) => invoice.status !== 'Paid')
+        .reduce((total, invoice) => total + invoice.amount, 0);
+
+    const chartData = buildAnalytics(currentMonth, bookings, invoices);
+
+    return {
+        props: {
+            metrics: {
+                monthlyRevenue,
+                upcomingShoots,
+                outstandingInvoices,
+                outstandingAmount,
+                currentMonthLabel: currentMonth.format('MMMM YYYY')
+            },
+            chartData
+        }
+    };
+};
+
+async function fetchCodexCollection<T>(baseUrl: string, resource: 'bookings' | 'invoices'): Promise<T[]> {
+    try {
+        const url = new URL(`/api/crm/${resource}`, baseUrl);
+        const response = await fetch(url.toString(), { headers: { accept: 'application/json' } });
+        if (!response.ok) {
+            return [];
+        }
+        const raw = await response.text();
+        if (!raw) {
+            return [];
+        }
+        const parsed = JSON.parse(raw) as { data?: unknown };
+        if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.data)) {
+            return [];
+        }
+        return parsed.data as T[];
+    } catch (error) {
+        console.warn('Unable to fetch Codex collection', error);
+        return [];
+    }
+}
+
+function resolveBaseUrl(req: IncomingMessage): string {
+    const forwardedProto = req.headers['x-forwarded-proto'];
+    const forwardedHost = req.headers['x-forwarded-host'];
+    const hostHeader = forwardedHost ?? req.headers.host ?? process.env.NEXT_PUBLIC_SITE_URL;
+
+    let host = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
+    if (!host) {
+        return 'http://localhost:3000';
+    }
+
+    if (host.startsWith('http://') || host.startsWith('https://')) {
+        return host;
+    }
+
+    const protoHeader = Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto;
+    const protocol = protoHeader ?? (host.includes('localhost') ? 'http' : 'https');
+    return `${protocol}://${host}`;
+}
+
+function normalizeBookings(records: CodexBookingRecord[]): DashboardBooking[] {
+    return records
+        .map((record, index) => {
+            if (!isPlainObject(record)) {
+                return null;
+            }
+
+            const date = parseDate(record.date);
+            if (!date) {
+                return null;
+            }
+
+            const status = toTitleCase(record.status ?? 'Pending');
+            const shootType = parseString(record.shoot_type ?? record.shootType, 'Session');
+            const client = parseString(record.client, 'Client');
+            const id = parseString(record.id, `booking-${index}`);
+            const { startTime, endTime } = parseTimeRange(record);
+
+            return {
+                id,
+                client,
+                date,
+                status,
+                shootType,
+                startTime,
+                endTime
+            } as DashboardBooking;
+        })
+        .filter((booking): booking is DashboardBooking => booking !== null && dayjs(booking.date).isValid());
+}
+
+function normalizeInvoices(records: CodexInvoiceRecord[]): DashboardInvoice[] {
+    return records
+        .map((record, index) => {
+            if (!isPlainObject(record)) {
+                return null;
+            }
+
+            const dueDate = parseDate(record.due_date ?? record.dueDate);
+            const amount = parseAmount(record.amount);
+
+            if (!dueDate || amount === null) {
+                return null;
+            }
+
+            const status = toTitleCase(record.status ?? 'Draft');
+            const client = parseString(record.client, 'Client');
+            const id = parseString(record.id, `invoice-${index}`);
+
+            return {
+                id,
+                client,
+                amount,
+                dueDate,
+                status
+            } as DashboardInvoice;
+        })
+        .filter((invoice): invoice is DashboardInvoice => invoice !== null && dayjs(invoice.dueDate).isValid());
+}
+
+function buildAnalytics(referenceMonth: dayjs.Dayjs, bookings: DashboardBooking[], invoices: DashboardInvoice[]): ChartData {
+    const safeBookings = bookings.filter((booking) => dayjs(booking.date).isValid());
+    const safeInvoices = invoices.filter((invoice) => dayjs(invoice.dueDate).isValid());
+
+    return {
+        weekly: buildWeeklyAnalytics(referenceMonth, safeBookings, safeInvoices),
+        monthly: buildMonthlyAnalytics(referenceMonth, safeBookings, safeInvoices),
+        yearly: buildYearlyAnalytics(referenceMonth, safeBookings, safeInvoices)
+    };
+}
+
+function buildWeeklyAnalytics(
+    referenceMonth: dayjs.Dayjs,
+    bookings: DashboardBooking[],
+    invoices: DashboardInvoice[]
+): ChartPoint[] {
+    const weeksToDisplay = 6;
+    const result: ChartPoint[] = [];
+    const referenceEnd = referenceMonth.endOf('month');
+
+    for (let offset = weeksToDisplay - 1; offset >= 0; offset -= 1) {
+        const anchor = referenceEnd.subtract(offset, 'week');
+        const weekStart = startOfWeek(anchor);
+        const weekEnd = endOfWeek(anchor);
+
+        const shoots = bookings.filter((booking) => isWithinRange(dayjs(booking.date), weekStart, weekEnd)).length;
+        const revenue = invoices
+            .filter((invoice) => isWithinRange(dayjs(invoice.dueDate), weekStart, weekEnd))
+            .reduce((total, invoice) => total + invoice.amount, 0);
+
+        result.push({
+            label: weekStart.format('MMM D'),
+            shoots,
+            revenue
+        });
+    }
+
+    return result;
+}
+
+function buildMonthlyAnalytics(
+    referenceMonth: dayjs.Dayjs,
+    bookings: DashboardBooking[],
+    invoices: DashboardInvoice[]
+): ChartPoint[] {
+    const monthsToDisplay = 6;
+    const result: ChartPoint[] = [];
+
+    for (let offset = monthsToDisplay - 1; offset >= 0; offset -= 1) {
+        const month = referenceMonth.subtract(offset, 'month');
+        const shoots = bookings.filter((booking) => dayjs(booking.date).isSame(month, 'month')).length;
+        const revenue = invoices
+            .filter((invoice) => dayjs(invoice.dueDate).isSame(month, 'month'))
+            .reduce((total, invoice) => total + invoice.amount, 0);
+
+        result.push({
+            label: month.format('MMM'),
+            shoots,
+            revenue
+        });
+    }
+
+    return result;
+}
+
+function buildYearlyAnalytics(
+    referenceMonth: dayjs.Dayjs,
+    bookings: DashboardBooking[],
+    invoices: DashboardInvoice[]
+): ChartPoint[] {
+    const yearsToDisplay = 3;
+    const result: ChartPoint[] = [];
+    const latestYear = referenceMonth.year();
+
+    for (let offset = yearsToDisplay - 1; offset >= 0; offset -= 1) {
+        const year = latestYear - offset;
+        const shoots = bookings.filter((booking) => dayjs(booking.date).year() === year).length;
+        const revenue = invoices
+            .filter((invoice) => dayjs(invoice.dueDate).year() === year)
+            .reduce((total, invoice) => total + invoice.amount, 0);
+
+        result.push({
+            label: year.toString(),
+            shoots,
+            revenue
+        });
+    }
+
+    return result;
+}
+
+function startOfWeek(value: dayjs.Dayjs): dayjs.Dayjs {
+    return value.subtract(value.day(), 'day').startOf('day');
+}
+
+function endOfWeek(value: dayjs.Dayjs): dayjs.Dayjs {
+    return startOfWeek(value).add(6, 'day').endOf('day');
+}
+
+function isWithinRange(value: dayjs.Dayjs, start: dayjs.Dayjs, end: dayjs.Dayjs): boolean {
+    return (value.isAfter(start) || value.isSame(start)) && (value.isBefore(end) || value.isSame(end));
+}
+
+function parseTimeRange(record: CodexBookingRecord): { startTime?: string; endTime?: string } {
+    const start = parseString(record.startTime ?? record.start_time, '');
+    const end = parseString(record.endTime ?? record.end_time, '');
+
+    if (start || end) {
+        return {
+            startTime: start || undefined,
+            endTime: end || undefined
+        };
+    }
+
+    const timeValue = parseString(record.time, '');
+    if (!timeValue) {
+        return {};
+    }
+
+    const [startPart, endPart] = splitTimeRange(timeValue);
+    return {
+        startTime: startPart,
+        endTime: endPart
+    };
+}
+
+function splitTimeRange(value: string): [string | undefined, string | undefined] {
+    const parts = value
+        .split(/[\u2013\u2014-]/)
+        .map((part) => part.trim())
+        .filter(Boolean);
+
+    if (parts.length === 0) {
+        return [undefined, undefined];
+    }
+
+    if (parts.length === 1) {
+        return [parts[0], undefined];
+    }
+
+    return [parts[0], parts[1]];
+}
+
+function parseAmount(value: CodexInvoiceRecord['amount']): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        const cleaned = value.replace(/[^0-9.,-]/g, '').replace(/,/g, '.');
+        if (!cleaned) {
+            return null;
+        }
+        const parsed = Number.parseFloat(cleaned);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    return null;
+}
+
+function parseDate(value: string | undefined): string | null {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return null;
+    }
+    return trimmed;
+}
+
+function parseString(value: unknown, fallback: string): string {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) {
+            return trimmed;
+        }
+    }
+    return fallback;
+}
+
+function toTitleCase(value: string): string {
+    if (!value) {
+        return '';
+    }
+    const lower = value.toLowerCase();
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- replace the root index page with a Codex operations dashboard that fetches bookings and invoices from the CRM API, calculates KPI metrics, and renders the overview chart
- normalize bookings and invoices retrieved from Codex to keep analytics resilient to partial CMS entries
- add defensive currency, date, and line-item fallbacks to the invoice table so it can render incomplete Codex data without runtime errors

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca2488d0948329b7f20c541ded36e3