### PR TITLE
Refactor CRM layout with top navigation

### DIFF
--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -3,11 +3,17 @@ import classNames from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
+import { adminUser } from '../../data/crm';
+import { useThemeMode } from '../../utils/use-theme-mode';
 import { ApertureMark } from './ApertureMark';
 import {
     AddressBookIcon,
+    AppsIcon,
+    BellIcon,
     CalendarIcon,
-    MenuIcon,
+    CheckIcon,
+    ChevronDownIcon,
+    FolderIcon,
     MoonIcon,
     PhotoIcon,
     ReceiptIcon,
@@ -16,37 +22,182 @@ import {
     SunIcon,
     UsersIcon
 } from './icons';
-import { useThemeMode } from '../../utils/use-theme-mode';
 
-const navItems = [
-    { href: '/crm', label: 'Dashboard', icon: SparklesIcon },
+type WorkspaceLayoutProps = {
+    children: React.ReactNode;
+};
+
+type NavItem = {
+    href: string;
+    label: string;
+    icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+};
+
+type AccentOption = {
+    id: string;
+    label: string;
+    swatch: string;
+    soft: string;
+    contrast?: string;
+};
+
+type QuickAccessApp = {
+    id: string;
+    name: string;
+    href: string;
+    initials: string;
+    description: string;
+    color: string;
+    textColor?: string;
+};
+
+type AppCollection = {
+    id: string;
+    label: string;
+    apps: QuickAccessApp[];
+};
+
+type NotificationTone = 'success' | 'warning' | 'info';
+
+type NotificationItem = {
+    id: string;
+    title: string;
+    description: string;
+    time: string;
+    tone: NotificationTone;
+};
+
+const navItems: NavItem[] = [
+    { href: '/crm', label: 'Home', icon: SparklesIcon },
     { href: '/bookings', label: 'Calendar', icon: CalendarIcon },
     { href: '/contacts', label: 'Contacts', icon: AddressBookIcon },
     { href: '/clients', label: 'Clients', icon: UsersIcon },
     { href: '/galleries', label: 'Galleries', icon: PhotoIcon },
-    { href: '/invoices', label: 'Invoices', icon: ReceiptIcon },
-    { href: '/crm/sidebar', label: 'Sidebar modules', icon: SettingsIcon }
-] as const;
+    { href: '/projects', label: 'Projects', icon: FolderIcon },
+    { href: '/accounts-payable', label: 'Accounts Payable', icon: ReceiptIcon },
+    { href: '/settings', label: 'Settings', icon: SettingsIcon }
+];
 
-type WorkspaceLayoutContextValue = {
-    isSidebarOpen: boolean;
-    toggleSidebar: () => void;
-    closeSidebar: () => void;
-};
+const ACCENT_STORAGE_KEY = 'crm-accent-preference';
+const DEFAULT_ACCENT_ID = 'indigo';
 
-const WorkspaceLayoutContext = React.createContext<WorkspaceLayoutContextValue | null>(null);
+const accentOptions: AccentOption[] = [
+    { id: 'slate', label: 'Slate', swatch: '#475569', soft: 'rgba(71, 85, 105, 0.18)' },
+    { id: 'indigo', label: 'Indigo', swatch: '#6366f1', soft: 'rgba(99, 102, 241, 0.22)' },
+    { id: 'violet', label: 'Violet', swatch: '#8b5cf6', soft: 'rgba(139, 92, 246, 0.22)' },
+    { id: 'emerald', label: 'Emerald', swatch: '#10b981', soft: 'rgba(16, 185, 129, 0.2)' },
+    { id: 'amber', label: 'Amber', swatch: '#f59e0b', soft: 'rgba(245, 158, 11, 0.25)', contrast: '#111827' },
+    { id: 'rose', label: 'Rose', swatch: '#f43f5e', soft: 'rgba(244, 63, 94, 0.2)' }
+];
 
-export function useWorkspaceLayout(): WorkspaceLayoutContextValue {
-    const context = React.useContext(WorkspaceLayoutContext);
-    if (!context) {
-        throw new Error('useWorkspaceLayout must be used within a WorkspaceLayout');
+const appCollections: AppCollection[] = [
+    {
+        id: 'google',
+        label: 'Google Workspace',
+        apps: [
+            {
+                id: 'analytics',
+                name: 'Google Analytics',
+                initials: 'GA',
+                description: 'Monitor marketing funnels and site traffic.',
+                href: 'https://analytics.google.com',
+                color: '#6366f1'
+            },
+            {
+                id: 'drive',
+                name: 'Google Drive',
+                initials: 'GD',
+                description: 'Browse shared folders and deliverables.',
+                href: 'https://drive.google.com',
+                color: '#10b981'
+            },
+            {
+                id: 'meet',
+                name: 'Google Meet',
+                initials: 'GM',
+                description: 'Launch virtual consultations and reviews.',
+                href: 'https://meet.google.com',
+                color: '#f59e0b',
+                textColor: '#111827'
+            },
+            {
+                id: 'photos',
+                name: 'Google Photos',
+                initials: 'GP',
+                description: 'Reference archived shoots and mood boards.',
+                href: 'https://photos.google.com',
+                color: '#ec4899'
+            }
+        ]
+    },
+    {
+        id: 'social',
+        label: 'Social Launchpad',
+        apps: [
+            {
+                id: 'instagram',
+                name: 'Instagram',
+                initials: 'IG',
+                description: 'Share teasers and behind-the-scenes reels.',
+                href: 'https://www.instagram.com',
+                color: '#f472b6'
+            },
+            {
+                id: 'facebook',
+                name: 'Facebook',
+                initials: 'FB',
+                description: 'Connect with leads and publish announcements.',
+                href: 'https://www.facebook.com',
+                color: '#3b82f6'
+            },
+            {
+                id: 'pinterest',
+                name: 'Pinterest',
+                initials: 'PN',
+                description: 'Curate inspiration boards for upcoming shoots.',
+                href: 'https://www.pinterest.com',
+                color: '#ef4444'
+            },
+            {
+                id: 'tiktok',
+                name: 'TikTok',
+                initials: 'TT',
+                description: 'Publish highlight reels and client testimonials.',
+                href: 'https://www.tiktok.com',
+                color: '#0ea5e9'
+            }
+        ]
     }
-    return context;
-}
+];
 
-type WorkspaceLayoutProps = {
-    children: React.ReactNode;
-    onSidebarChange?: (isOpen: boolean) => void;
+const notifications: NotificationItem[] = [
+    {
+        id: 'notif-1',
+        title: 'Payment received',
+        description: 'Invoice 032 was paid by Evergreen Architects.',
+        time: '5 minutes ago',
+        tone: 'success'
+    },
+    {
+        id: 'notif-2',
+        title: 'Gallery ready for review',
+        description: 'Fern & Pine Studio uploaded final selects.',
+        time: '32 minutes ago',
+        tone: 'info'
+    },
+    {
+        id: 'notif-3',
+        title: 'Signature requested',
+        description: 'Contract for Atlas Fitness renewal is waiting.',
+        time: '2 hours ago',
+        tone: 'warning'
+    }
+];
+
+const notificationToneBadge: Record<NotificationTone, string> = {
+    success: 'bg-success-lt text-success',
+    info: 'bg-primary-lt text-primary',
+    warning: 'bg-warning-lt text-warning'
 };
 
 function matchPath(currentPath: string, target: string) {
@@ -59,156 +210,532 @@ function matchPath(currentPath: string, target: string) {
     return currentPath.startsWith(target) && target !== '/';
 }
 
-export function WorkspaceLayout({ children, onSidebarChange }: WorkspaceLayoutProps) {
+function useDropdown<T extends HTMLElement>() {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const containerRef = React.useRef<T | null>(null);
+
+    const close = React.useCallback(() => {
+        setIsOpen(false);
+    }, []);
+
+    const toggle = React.useCallback(() => {
+        setIsOpen((previous) => !previous);
+    }, []);
+
+    React.useEffect(() => {
+        function handlePointer(event: MouseEvent | TouchEvent) {
+            if (!containerRef.current) {
+                return;
+            }
+            if (containerRef.current.contains(event.target as Node)) {
+                return;
+            }
+            setIsOpen(false);
+        }
+
+        document.addEventListener('mousedown', handlePointer);
+        document.addEventListener('touchstart', handlePointer);
+        return () => {
+            document.removeEventListener('mousedown', handlePointer);
+            document.removeEventListener('touchstart', handlePointer);
+        };
+    }, []);
+
+    return { isOpen, close, toggle, containerRef } as const;
+}
+
+export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     const router = useRouter();
-    const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);
-    const { theme, toggleTheme } = useThemeMode();
+    const { theme, setTheme, toggleTheme } = useThemeMode();
+    const [isNavOpen, setIsNavOpen] = React.useState(false);
 
-    React.useEffect(() => {
-        setIsSidebarOpen(false);
-    }, [router.asPath]);
+    const {
+        isOpen: isAppsOpen,
+        close: closeApps,
+        toggle: toggleApps,
+        containerRef: appsDropdownRef
+    } = useDropdown<HTMLDivElement>();
+    const {
+        isOpen: isThemeMenuOpen,
+        close: closeThemeMenu,
+        toggle: toggleThemeMenu,
+        containerRef: themeDropdownRef
+    } = useDropdown<HTMLDivElement>();
+    const {
+        isOpen: isNotificationsOpen,
+        close: closeNotifications,
+        toggle: toggleNotifications,
+        containerRef: notificationsDropdownRef
+    } = useDropdown<HTMLDivElement>();
+    const {
+        isOpen: isProfileOpen,
+        close: closeProfile,
+        toggle: toggleProfile,
+        containerRef: profileDropdownRef
+    } = useDropdown<HTMLDivElement>();
 
-    React.useEffect(() => {
-        onSidebarChange?.(isSidebarOpen);
-    }, [isSidebarOpen, onSidebarChange]);
-
-    const contextValue = React.useMemo<WorkspaceLayoutContextValue>(() => ({
-        isSidebarOpen,
-        toggleSidebar: () => setIsSidebarOpen((previous) => !previous),
-        closeSidebar: () => setIsSidebarOpen(false)
-    }), [isSidebarOpen]);
+    const [accent, setAccent] = React.useState<string>(() => {
+        if (typeof window === 'undefined') {
+            return DEFAULT_ACCENT_ID;
+        }
+        try {
+            const stored = window.localStorage.getItem(ACCENT_STORAGE_KEY);
+            if (stored && accentOptions.some((option) => option.id === stored)) {
+                return stored;
+            }
+        } catch (error) {
+            console.warn('Unable to read stored accent preference', error);
+        }
+        return DEFAULT_ACCENT_ID;
+    });
 
     const activeItem = React.useMemo(() => {
         const path = router.pathname;
         return navItems.find((item) => matchPath(path, item.href)) ?? null;
     }, [router.pathname]);
 
-    const sidebarClassName = classNames('navbar navbar-vertical navbar-expand-lg', 'navbar-dark bg-body-tertiary', {
-        show: isSidebarOpen
-    });
+    React.useEffect(() => {
+        setIsNavOpen(false);
+        closeApps();
+        closeThemeMenu();
+        closeNotifications();
+        closeProfile();
+    }, [router.asPath, closeApps, closeThemeMenu, closeNotifications, closeProfile]);
+
+    React.useEffect(() => {
+        function handleKeydown(event: KeyboardEvent) {
+            if (event.key === 'Escape') {
+                setIsNavOpen(false);
+                closeApps();
+                closeThemeMenu();
+                closeNotifications();
+                closeProfile();
+            }
+        }
+
+        document.addEventListener('keydown', handleKeydown);
+        return () => {
+            document.removeEventListener('keydown', handleKeydown);
+        };
+    }, [closeApps, closeThemeMenu, closeNotifications, closeProfile]);
+
+    React.useEffect(() => {
+        const selectedAccent = accentOptions.find((option) => option.id === accent) ?? accentOptions[0];
+
+        if (typeof document !== 'undefined') {
+            const root = document.documentElement;
+            root.style.setProperty('--crm-accent', selectedAccent.swatch);
+            root.style.setProperty('--crm-accent-soft', selectedAccent.soft);
+            root.style.setProperty('--crm-accent-contrast', selectedAccent.contrast ?? '#ffffff');
+
+            const body = document.body;
+            if (body) {
+                body.dataset.crmAccent = selectedAccent.id;
+            }
+        }
+
+        try {
+            if (typeof window !== 'undefined') {
+                window.localStorage.setItem(ACCENT_STORAGE_KEY, accent);
+            }
+        } catch (error) {
+            console.warn('Unable to persist accent preference', error);
+        }
+    }, [accent]);
+
+    const activeAccent = accentOptions.find((option) => option.id === accent) ?? accentOptions[0];
+
+    const handleSelectAccent = React.useCallback((nextAccent: string) => {
+        setAccent(nextAccent);
+    }, []);
+
+    const headingLabel = activeItem ? activeItem.label : 'Workspace';
 
     return (
-        <WorkspaceLayoutContext.Provider value={contextValue}>
-            <div className={classNames('page', theme === 'dark' ? 'theme-dark' : 'theme-light')}>
-                <aside className={sidebarClassName} data-bs-theme={theme}>
-                    <div className="container-fluid">
-                        <button
-                            type="button"
-                            className="navbar-toggler"
-                            aria-label="Toggle navigation"
-                            onClick={() => setIsSidebarOpen((previous) => !previous)}
+        <div className={classNames('page', theme === 'dark' ? 'theme-dark' : 'theme-light')}>
+            <header className="navbar navbar-expand-md shadow-sm border-bottom crm-top-nav" data-bs-theme={theme}>
+                <div className="container-xl">
+                    <Link href="/crm" className="navbar-brand d-flex align-items-center gap-2">
+                        <span className="avatar avatar-sm bg-primary-lt text-primary">
+                            <ApertureMark className="icon" aria-hidden />
+                        </span>
+                        <span className="crm-brand-name">
+                            <span className="crm-brand-accent">APERTURE</span>{' '}
+                            <span className="text-secondary">Studio CRM</span>
+                        </span>
+                    </Link>
+                    <button
+                        type="button"
+                        className="navbar-toggler"
+                        aria-label="Toggle navigation"
+                        aria-expanded={isNavOpen}
+                        onClick={() => setIsNavOpen((previous) => !previous)}
+                    >
+                        <span className="navbar-toggler-icon" />
+                    </button>
+                    <div className={classNames('collapse navbar-collapse', { show: isNavOpen })}>
+                        <ul className="navbar-nav">
+                            {navItems.map((item) => {
+                                const isActive = matchPath(router.pathname, item.href);
+                                return (
+                                    <li key={item.href} className="nav-item">
+                                        <Link
+                                            href={item.href}
+                                            className={classNames('nav-link', { active: isActive })}
+                                            aria-current={isActive ? 'page' : undefined}
+                                        >
+                                            <span className="nav-link-icon d-md-none d-lg-inline-block">
+                                                <item.icon className="icon" aria-hidden />
+                                            </span>
+                                            <span className="nav-link-title">{item.label}</span>
+                                        </Link>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                        <form className="navbar-search ms-md-4 mt-3 mt-md-0" role="search">
+                            <div className="input-icon">
+                                <span className="input-icon-addon">
+                                    <svg
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        strokeWidth="1.5"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        className="icon"
+                                        aria-hidden
+                                    >
+                                        <circle cx="11" cy="11" r="7" />
+                                        <path d="m20 20-2.6-2.6" />
+                                    </svg>
+                                </span>
+                                <input
+                                    type="search"
+                                    className="form-control"
+                                    placeholder="Search clients, projects, invoices"
+                                    aria-label="Search workspace"
+                                />
+                            </div>
+                        </form>
+                    </div>
+                    <div className="navbar-nav flex-row order-md-last align-items-center gap-2 ms-3">
+                        <Link
+                            href="/bookings"
+                            className="btn btn-primary d-none d-xl-inline-flex align-items-center gap-2"
                         >
-                            <span className="navbar-toggler-icon" />
-                        </button>
-                        <Link href="/crm" className="navbar-brand navbar-brand-autodark d-flex align-items-center gap-2">
-                            <span className="avatar avatar-sm bg-primary-lt text-primary">
-                                <ApertureMark className="icon" aria-hidden />
-                            </span>
-                            <span className="fw-semibold">Codex Studio CRM</span>
+                            <CalendarIcon className="icon" aria-hidden />
+                            New booking
                         </Link>
-                        <div className={classNames('collapse navbar-collapse', { show: isSidebarOpen })}>
-                            <ul className="navbar-nav pt-lg-3" role="navigation" aria-label="Workspace navigation">
-                                {navItems.map((item) => {
-                                    const isActive = matchPath(router.pathname, item.href);
-                                    return (
-                                        <li key={item.href} className="nav-item">
-                                            <Link
-                                                href={item.href}
-                                                className={classNames('nav-link', { active: isActive })}
-                                                aria-current={isActive ? 'page' : undefined}
+                        <div
+                            className={classNames('nav-item dropdown', { show: isAppsOpen })}
+                            ref={appsDropdownRef}
+                        >
+                            <button
+                                type="button"
+                                className="btn btn-icon"
+                                aria-label="Open quick launch"
+                                aria-expanded={isAppsOpen}
+                                onClick={toggleApps}
+                            >
+                                <AppsIcon className="icon" aria-hidden />
+                            </button>
+                            <div
+                                className={classNames(
+                                    'dropdown-menu dropdown-menu-end dropdown-menu-card dropdown-menu-xl',
+                                    { show: isAppsOpen }
+                                )}
+                            >
+                                <div className="card">
+                                    <div className="card-header d-flex align-items-center justify-content-between">
+                                        <h4 className="card-title mb-0">Quick launch</h4>
+                                        <span className="text-secondary">Stay connected</span>
+                                    </div>
+                                    <div className="card-body">
+                                        {appCollections.map((collection, index) => (
+                                            <div
+                                                key={collection.id}
+                                                className={classNames('mb-4', { 'mb-0': index === appCollections.length - 1 })}
                                             >
-                                                <span className="nav-link-icon d-md-none d-lg-inline-block">
-                                                    <item.icon className="icon" aria-hidden />
-                                                </span>
-                                                <span className="nav-link-title">{item.label}</span>
-                                            </Link>
-                                        </li>
-                                    );
-                                })}
-                            </ul>
-                            <div className="mt-auto pt-4">
-                                <div className="alert alert-primary" role="status">
-                                    <div className="fw-semibold text-uppercase small text-primary mb-1">Workspace tips</div>
-                                    <div className="text-secondary">
-                                        Collapse the navigation on smaller screens or pin your favourite modules for a focused review.
+                                                <div className="crm-dropdown-label">{collection.label}</div>
+                                                <div className="crm-app-grid">
+                                                    {collection.apps.map((app) => (
+                                                        <a
+                                                            key={app.id}
+                                                            href={app.href}
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                            className="crm-app-tile"
+                                                        >
+                                                            <span
+                                                                className="crm-app-icon"
+                                                                style={{
+                                                                    backgroundColor: app.color,
+                                                                    color: app.textColor ?? '#ffffff'
+                                                                }}
+                                                                aria-hidden
+                                                            >
+                                                                {app.initials}
+                                                            </span>
+                                                            <span className="crm-app-label">{app.name}</span>
+                                                            <span className="crm-app-description">{app.description}</span>
+                                                        </a>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        ))}
                                     </div>
                                 </div>
-                                <button type="button" className="btn w-100 btn-outline-primary" onClick={toggleTheme}>
-                                    {theme === 'dark' ? <SunIcon className="icon" aria-hidden /> : <MoonIcon className="icon" aria-hidden />} {theme === 'dark' ? 'Light mode' : 'Dark mode'}
-                                </button>
+                            </div>
+                        </div>
+                        <div
+                            className={classNames('nav-item dropdown', { show: isThemeMenuOpen })}
+                            ref={themeDropdownRef}
+                        >
+                            <button
+                                type="button"
+                                className="btn btn-outline-secondary d-none d-lg-inline-flex align-items-center gap-2"
+                                onClick={toggleThemeMenu}
+                                aria-expanded={isThemeMenuOpen}
+                            >
+                                <SparklesIcon className="icon" aria-hidden />
+                                Theme Settings
+                                <span className="badge bg-green-lt text-green fw-semibold text-uppercase">New</span>
+                            </button>
+                            <button
+                                type="button"
+                                className="btn btn-icon d-lg-none"
+                                onClick={toggleThemeMenu}
+                                aria-label="Open theme settings"
+                                aria-expanded={isThemeMenuOpen}
+                            >
+                                <SparklesIcon className="icon" aria-hidden />
+                            </button>
+                            <div
+                                className={classNames(
+                                    'dropdown-menu dropdown-menu-end dropdown-menu-card dropdown-menu-lg',
+                                    { show: isThemeMenuOpen }
+                                )}
+                            >
+                                <div className="card crm-theme-menu">
+                                    <div className="card-header">
+                                        <h4 className="card-title mb-0">Theme settings</h4>
+                                        <div className="text-secondary">Fine-tune your control center.</div>
+                                    </div>
+                                    <div className="card-body">
+                                        <div className="mb-4">
+                                            <div className="crm-dropdown-label">Color mode</div>
+                                            <div className="btn-list">
+                                                <button
+                                                    type="button"
+                                                    className={classNames('btn', {
+                                                        'btn-primary': theme === 'light',
+                                                        'btn-outline-secondary': theme !== 'light'
+                                                    })}
+                                                    onClick={() => setTheme('light')}
+                                                >
+                                                    <SunIcon className="icon" aria-hidden /> Light
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    className={classNames('btn', {
+                                                        'btn-primary': theme === 'dark',
+                                                        'btn-outline-secondary': theme !== 'dark'
+                                                    })}
+                                                    onClick={() => setTheme('dark')}
+                                                >
+                                                    <MoonIcon className="icon" aria-hidden /> Dark
+                                                </button>
+                                                <button type="button" className="btn btn-outline-secondary" onClick={toggleTheme}>
+                                                    Auto toggle
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div className="mb-4">
+                                            <div className="crm-dropdown-label">Accent color</div>
+                                            <div className="row g-2">
+                                                {accentOptions.map((option) => {
+                                                    const isActive = option.id === accent;
+                                                    return (
+                                                        <div className="col-4" key={option.id}>
+                                                            <button
+                                                                type="button"
+                                                                className={classNames('crm-color-choice w-100', {
+                                                                    active: isActive
+                                                                })}
+                                                                style={{
+                                                                    backgroundColor: option.swatch,
+                                                                    boxShadow: isActive
+                                                                        ? `0 0 0 4px ${option.soft}`
+                                                                        : undefined,
+                                                                    color: option.contrast ?? '#ffffff'
+                                                                }}
+                                                                onClick={() => handleSelectAccent(option.id)}
+                                                                aria-pressed={isActive}
+                                                            >
+                                                                <span className="crm-color-check" aria-hidden>
+                                                                    <CheckIcon className="icon" />
+                                                                </span>
+                                                                <span className="crm-color-label">{option.label}</span>
+                                                            </button>
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div className="crm-dropdown-label">Current selection</div>
+                                            <div className="d-flex align-items-center justify-content-between gap-3">
+                                                <div>
+                                                    <div className="fw-semibold">{theme === 'dark' ? 'Dark mode' : 'Light mode'}</div>
+                                                    <div className="text-secondary">Accent: {activeAccent.label}</div>
+                                                </div>
+                                                <span
+                                                    className="badge text-uppercase fw-semibold"
+                                                    style={{
+                                                        backgroundColor: activeAccent.soft,
+                                                        color: activeAccent.swatch
+                                                    }}
+                                                >
+                                                    Saved
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div
+                            className={classNames('nav-item dropdown', { show: isNotificationsOpen })}
+                            ref={notificationsDropdownRef}
+                        >
+                            <button
+                                type="button"
+                                className="btn btn-icon position-relative"
+                                aria-label="View notifications"
+                                aria-expanded={isNotificationsOpen}
+                                onClick={toggleNotifications}
+                            >
+                                <BellIcon className="icon" aria-hidden />
+                                <span className="crm-notification-indicator" aria-hidden />
+                            </button>
+                            <div
+                                className={classNames(
+                                    'dropdown-menu dropdown-menu-end dropdown-menu-card dropdown-menu-md',
+                                    { show: isNotificationsOpen }
+                                )}
+                            >
+                                <div className="card">
+                                    <div className="card-header d-flex align-items-center justify-content-between">
+                                        <h4 className="card-title mb-0">Notifications</h4>
+                                        <button type="button" className="btn btn-link p-0" onClick={closeNotifications}>
+                                            Mark all as read
+                                        </button>
+                                    </div>
+                                    <div className="list-group list-group-flush">
+                                        {notifications.map((item) => (
+                                            <div key={item.id} className="list-group-item">
+                                                <div className="d-flex align-items-start gap-3">
+                                                    <span className={classNames('badge rounded-pill', notificationToneBadge[item.tone])}>
+                                                        {item.tone === 'success' && 'Success'}
+                                                        {item.tone === 'info' && 'Update'}
+                                                        {item.tone === 'warning' && 'Action'}
+                                                    </span>
+                                                    <div>
+                                                        <div className="fw-semibold">{item.title}</div>
+                                                        <div className="text-secondary">{item.description}</div>
+                                                        <div className="text-secondary small mt-1">{item.time}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div
+                            className={classNames('nav-item dropdown', { show: isProfileOpen })}
+                            ref={profileDropdownRef}
+                        >
+                            <button
+                                type="button"
+                                className="btn d-flex align-items-center gap-2"
+                                aria-expanded={isProfileOpen}
+                                onClick={toggleProfile}
+                            >
+                                <span className="crm-avatar-wrapper">
+                                    <span className="avatar avatar-sm" style={{ backgroundImage: `url(${adminUser.avatar})` }} />
+                                    {adminUser.status ? <span className="crm-avatar-status" aria-hidden /> : null}
+                                </span>
+                                <span className="d-none d-xl-flex flex-column align-items-start">
+                                    <span className="fw-semibold">{adminUser.name}</span>
+                                    <span className="text-secondary small">{adminUser.role}</span>
+                                </span>
+                                <ChevronDownIcon className="icon d-none d-xl-inline" aria-hidden />
+                            </button>
+                            <div
+                                className={classNames(
+                                    'dropdown-menu dropdown-menu-end dropdown-menu-arrow dropdown-menu-card dropdown-menu-md',
+                                    { show: isProfileOpen }
+                                )}
+                            >
+                                <div className="card">
+                                    <div className="card-body">
+                                        <div className="d-flex align-items-center gap-3">
+                                            <span className="avatar avatar-lg" style={{ backgroundImage: `url(${adminUser.avatar})` }} />
+                                            <div>
+                                                <div className="fw-semibold">{adminUser.name}</div>
+                                                <div className="text-secondary">{adminUser.email}</div>
+                                                {adminUser.status ? (
+                                                    <span className="badge bg-success-lt text-success mt-2">{adminUser.status}</span>
+                                                ) : null}
+                                            </div>
+                                        </div>
+                                        <div className="mt-4 d-grid gap-2">
+                                            <Link href="/settings" className="btn btn-outline-secondary">
+                                                Manage profile
+                                            </Link>
+                                            <Link href="/" className="btn btn-outline-secondary">
+                                                View public site
+                                            </Link>
+                                            <button type="button" className="btn btn-primary">
+                                                Sign out
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </aside>
-                {isSidebarOpen ? (
-                    <div
-                        className="navbar-backdrop d-lg-none"
-                        role="presentation"
-                        onClick={() => setIsSidebarOpen(false)}
-                    />
-                ) : null}
-                <div className="page-wrapper">
-                    <header className="navbar navbar-expand-md d-print-none" data-bs-theme={theme}>
-                        <div className="container-xl">
-                            <div className="d-flex align-items-center">
-                                <button
-                                    type="button"
-                                    className="btn btn-icon me-2 d-lg-none"
-                                    aria-label="Open navigation"
-                                    onClick={() => setIsSidebarOpen(true)}
-                                >
-                                    <MenuIcon className="icon" aria-hidden />
-                                </button>
-                                <div className="d-none d-md-flex flex-column">
-                                    <span className="page-pretitle text-uppercase text-secondary fw-semibold">
-                                        {activeItem ? activeItem.label : 'Workspace'}
-                                    </span>
-                                    <span className="page-title fw-semibold">Command center</span>
+                </div>
+            </header>
+            <div className="page-wrapper" data-bs-theme={theme}>
+                <section className="crm-page-header">
+                    <div className="container-xl">
+                        <div className="crm-page-heading">
+                            <div className="crm-page-heading-text">
+                                <span className="crm-page-pretitle">{headingLabel}</span>
+                                <h1 className="crm-page-title">Command center</h1>
+                            </div>
+                            <div className="d-flex align-items-center gap-2">
+                                <div className="crm-status-pill">
+                                    <span className="crm-dot" aria-hidden />
+                                    {adminUser.status ?? 'Operational'}
                                 </div>
-                            </div>
-                            <div className="navbar-nav flex-row order-md-last gap-2 align-items-center ms-auto">
-                                <Link href="/bookings" className="btn btn-primary d-none d-md-inline-flex align-items-center gap-2">
+                                <Link href="/bookings" className="btn btn-primary d-inline-flex align-items-center gap-2">
                                     <CalendarIcon className="icon" aria-hidden />
-                                    New booking
+                                    Quick schedule
                                 </Link>
-                                <button type="button" className="btn btn-icon" onClick={toggleTheme} aria-label="Toggle theme">
-                                    {theme === 'dark' ? <SunIcon className="icon" aria-hidden /> : <MoonIcon className="icon" aria-hidden />}
-                                </button>
-                            </div>
-                            <div className="collapse navbar-collapse" id="crm-navbar">
-                                <form className="navbar-search d-none d-md-flex ms-md-4" role="search">
-                                    <div className="input-icon">
-                                        <span className="input-icon-addon">
-                                            <svg
-                                                viewBox="0 0 24 24"
-                                                fill="none"
-                                                stroke="currentColor"
-                                                strokeWidth="1.5"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                                className="icon"
-                                                aria-hidden
-                                            >
-                                                <circle cx="11" cy="11" r="7" />
-                                                <path d="m20 20-2.6-2.6" />
-                                            </svg>
-                                        </span>
-                                        <input
-                                            type="search"
-                                            className="form-control"
-                                            placeholder="Search clients, invoices, tasks"
-                                            aria-label="Search workspace"
-                                        />
-                                    </div>
-                                </form>
                             </div>
                         </div>
-                    </header>
-                    <main className="page-body">
-                        <div className="container-xl">{children}</div>
-                    </main>
-                </div>
+                    </div>
+                </section>
+                <main className="page-body">
+                    <div className="container-xl">{children}</div>
+                </main>
             </div>
-        </WorkspaceLayoutContext.Provider>
+        </div>
     );
 }
+
+export default WorkspaceLayout;

--- a/src/components/crm/icons.tsx
+++ b/src/components/crm/icons.tsx
@@ -13,6 +13,22 @@ export function CalendarIcon(props: IconProps) {
     );
 }
 
+export function AppsIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <rect x="3" y="3" width="4" height="4" rx="1" />
+            <rect x="10" y="3" width="4" height="4" rx="1" />
+            <rect x="17" y="3" width="4" height="4" rx="1" />
+            <rect x="3" y="10" width="4" height="4" rx="1" />
+            <rect x="10" y="10" width="4" height="4" rx="1" />
+            <rect x="17" y="10" width="4" height="4" rx="1" />
+            <rect x="3" y="17" width="4" height="4" rx="1" />
+            <rect x="10" y="17" width="4" height="4" rx="1" />
+            <rect x="17" y="17" width="4" height="4" rx="1" />
+        </svg>
+    );
+}
+
 export function InvoiceIcon(props: IconProps) {
     return (
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
@@ -63,6 +79,14 @@ export function ChevronDownIcon(props: IconProps) {
     return (
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
             <path d="M6 9l6 6 6-6" />
+        </svg>
+    );
+}
+
+export function CheckIcon(props: IconProps) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <polyline points="20 6 9 17 4 12" />
         </svg>
     );
 }

--- a/src/components/crm/index.ts
+++ b/src/components/crm/index.ts
@@ -16,4 +16,4 @@ export { OverviewChart } from './OverviewChart';
 export type { ChartPoint, Timeframe } from './OverviewChart';
 export { ApertureMark } from './ApertureMark';
 export { CrmAuthGuard, useCrmAuth } from './CrmAuthGuard';
-export { WorkspaceLayout, useWorkspaceLayout } from './WorkspaceLayout';
+export { WorkspaceLayout } from './WorkspaceLayout';

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -413,6 +413,371 @@
     }
 }
 
+:root {
+    --crm-accent: #6366f1;
+    --crm-accent-soft: rgba(99, 102, 241, 0.22);
+    --crm-accent-contrast: #ffffff;
+}
+
+.crm-top-nav {
+    position: sticky;
+    top: 0;
+    z-index: 1030;
+    backdrop-filter: blur(12px);
+    background-color: rgba(255, 255, 255, 0.88);
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.theme-dark .crm-top-nav {
+    background-color: rgba(15, 23, 42, 0.88);
+}
+
+.crm-top-nav .navbar-brand .crm-brand-name {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+}
+
+.crm-brand-accent {
+    color: var(--crm-accent);
+}
+
+.crm-top-nav .nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.crm-top-nav .nav-link .icon {
+    width: 1rem;
+    height: 1rem;
+}
+
+.crm-top-nav .nav-link.active,
+.crm-top-nav .nav-link:hover,
+.crm-top-nav .nav-link:focus {
+    color: var(--crm-accent);
+}
+
+.crm-dropdown-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: var(--tblr-secondary-color, #64748b);
+}
+
+.crm-app-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 0.75rem;
+}
+
+.crm-app-tile {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background-color: var(--tblr-bg-surface, #ffffff);
+    color: inherit;
+    text-decoration: none;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-dark .crm-app-tile {
+    border-color: rgba(71, 85, 105, 0.45);
+    background-color: rgba(30, 41, 59, 0.85);
+}
+
+.crm-app-tile:hover,
+.crm-app-tile:focus {
+    transform: translateY(-3px);
+    border-color: var(--crm-accent);
+    box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.55);
+}
+
+.crm-app-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.crm-app-label {
+    font-weight: 600;
+}
+
+.crm-app-description {
+    font-size: 0.75rem;
+    color: var(--tblr-secondary-color, #64748b);
+}
+
+.crm-theme-menu .btn-list .btn {
+    gap: 0.5rem;
+}
+
+.crm-color-choice {
+    border: none;
+    border-radius: 0.75rem;
+    padding: 0.5rem;
+    height: 3rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.crm-color-choice .icon {
+    width: 1rem;
+    height: 1rem;
+}
+
+.crm-color-choice .crm-color-check {
+    display: none;
+}
+
+.crm-color-choice.active .crm-color-check {
+    display: inline-flex;
+}
+
+.crm-color-choice.active {
+    transform: translateY(-2px);
+}
+
+.crm-color-choice:focus-visible {
+    outline: 2px solid var(--crm-accent-contrast);
+    outline-offset: 2px;
+}
+
+.crm-color-label {
+    font-size: 0.65rem;
+}
+
+.crm-notification-indicator {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 9999px;
+    background-color: #f43f5e;
+    border: 2px solid var(--tblr-bg-surface, #ffffff);
+}
+
+.theme-dark .crm-notification-indicator {
+    border-color: rgba(15, 23, 42, 0.88);
+}
+
+.crm-avatar-wrapper {
+    position: relative;
+    display: inline-flex;
+}
+
+.crm-avatar-status {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 9999px;
+    background-color: #22c55e;
+    border: 2px solid var(--tblr-bg-surface, #ffffff);
+}
+
+.theme-dark .crm-avatar-status {
+    border-color: rgba(15, 23, 42, 0.88);
+}
+
+.crm-page-header {
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    padding: 1.5rem 0;
+    background: linear-gradient(120deg, rgba(99, 102, 241, 0.08), rgba(15, 118, 110, 0.05));
+}
+
+.theme-dark .crm-page-header {
+    border-color: rgba(71, 85, 105, 0.45);
+    background: linear-gradient(120deg, rgba(99, 102, 241, 0.14), rgba(15, 118, 110, 0.12));
+}
+
+.crm-page-heading {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.25rem;
+}
+
+.crm-page-heading-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.crm-page-pretitle {
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--tblr-secondary-color, #64748b);
+}
+
+.crm-page-title {
+    margin: 0;
+    font-weight: 600;
+}
+
+.crm-status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    background-color: var(--crm-accent-soft);
+    color: var(--crm-accent);
+}
+
+.crm-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 9999px;
+    background-color: currentColor;
+}
+
+.crm-project-timeline {
+    position: relative;
+    padding-left: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.crm-project-timeline::before {
+    content: '';
+    position: absolute;
+    left: 0.55rem;
+    top: 0.2rem;
+    bottom: 0.2rem;
+    width: 2px;
+    background: rgba(148, 163, 184, 0.35);
+}
+
+.theme-dark .crm-project-timeline::before {
+    background: rgba(71, 85, 105, 0.55);
+}
+
+.crm-project-milestone {
+    position: relative;
+    display: flex;
+    gap: 0.75rem;
+}
+
+.crm-project-milestone-indicator {
+    position: absolute;
+    left: -1.05rem;
+    top: 0.4rem;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 9999px;
+    background-color: var(--crm-accent);
+    box-shadow: 0 0 0 4px var(--crm-accent-soft);
+}
+
+.crm-progress-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--crm-accent);
+}
+
+.crm-progress-label {
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.crm-project-invoices .badge {
+    margin-top: 0.25rem;
+    display: inline-flex;
+}
+
+.crm-settings-toggle {
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background-color: var(--tblr-bg-surface, #ffffff);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.crm-settings-toggle:hover {
+    border-color: var(--crm-accent);
+    box-shadow: 0 14px 32px -24px rgba(15, 23, 42, 0.45);
+}
+
+.theme-dark .crm-settings-toggle {
+    border-color: rgba(71, 85, 105, 0.5);
+    background-color: rgba(30, 41, 59, 0.85);
+}
+
+.crm-settings-toggle .form-check-input {
+    width: 3rem;
+    height: 1.5rem;
+    margin-right: 1rem;
+}
+
+.crm-settings-toggle .form-check-label {
+    cursor: pointer;
+}
+
+.crm-integration-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.85rem 1rem;
+    border-radius: 0.85rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background-color: var(--tblr-bg-surface, #ffffff);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.crm-integration-item:hover {
+    border-color: var(--crm-accent);
+    box-shadow: 0 16px 32px -24px rgba(15, 23, 42, 0.45);
+}
+
+.theme-dark .crm-integration-item {
+    border-color: rgba(71, 85, 105, 0.5);
+    background-color: rgba(30, 41, 59, 0.85);
+}
+
+.crm-integration-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    color: #ffffff;
+}
+
 @layer utilities {
     .underline-line-through {
         text-decoration-line: underline line-through

--- a/src/pages/accounts-payable/index.tsx
+++ b/src/pages/accounts-payable/index.tsx
@@ -1,0 +1,2 @@
+export { getStaticProps } from '../invoices';
+export { default } from '../invoices';

--- a/src/pages/bookings/index.tsx
+++ b/src/pages/bookings/index.tsx
@@ -95,14 +95,6 @@ function BookingCalendarWorkspace({ bookings: initialBookings }: BookingsPagePro
     const [isSyncing, setIsSyncing] = React.useState(false);
     const [lastSyncedAt, setLastSyncedAt] = React.useState<string | null>(null);
     const calendarRef = React.useRef<FullCalendarRef | null>(null);
-    const handleSidebarChange = React.useCallback(() => {
-        if (!calendarRef.current) {
-            return;
-        }
-
-        const api = calendarRef.current.getApi();
-        window.setTimeout(() => api.updateSize(), 160);
-    }, []);
 
     const calendarEvents = React.useMemo<CalendarEvent[]>(
         () => bookings.map((booking) => createCalendarEvent(booking)),
@@ -421,7 +413,7 @@ function BookingCalendarWorkspace({ bookings: initialBookings }: BookingsPagePro
             <Head>
                 <title>Studio bookings calendar</title>
             </Head>
-            <WorkspaceLayout onSidebarChange={handleSidebarChange}>
+            <WorkspaceLayout>
                 <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-10">
                     <header className="flex flex-wrap items-start justify-between gap-6">
                         <div className="space-y-3">

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+import Head from 'next/head';
+import dayjs from 'dayjs';
+
+import { StatusPill, WorkspaceLayout } from '../../components/crm';
+import type { StatusTone } from '../../components/crm/StatusPill';
+import type { ProjectRecord } from '../../data/crm';
+import { projectPipeline } from '../../data/crm';
+import type { BookingStatus } from '../../components/crm';
+import type { InvoiceStatus } from '../../types/invoice';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+});
+
+const bookingStatusTone: Record<BookingStatus, StatusTone> = {
+    Confirmed: 'success',
+    Pending: 'warning',
+    Editing: 'info'
+};
+
+const invoiceStatusTone: Record<InvoiceStatus, StatusTone> = {
+    Draft: 'neutral',
+    Sent: 'info',
+    Paid: 'success',
+    Overdue: 'danger'
+};
+
+function resolveProjectStatus(progress: number): { label: string; tone: StatusTone } {
+    if (progress >= 0.95) {
+        return { label: 'Completed', tone: 'success' };
+    }
+    if (progress >= 0.6) {
+        return { label: 'In progress', tone: 'info' };
+    }
+    return { label: 'Planning', tone: 'warning' };
+}
+
+function formatDate(value: string) {
+    return dayjs(value).format('MMM D, YYYY');
+}
+
+function ProjectsContent({ projects }: { projects: ProjectRecord[] }) {
+    return (
+        <div className="row row-cards">
+            {projects.map((project) => {
+                const progressValue = Math.round(project.progress * 100);
+                const projectStatus = resolveProjectStatus(project.progress);
+
+                return (
+                    <div key={project.id} className="col-md-6 col-xl-4">
+                        <div className="card h-100">
+                            <div className="card-body d-flex flex-column">
+                                <div className="d-flex align-items-start justify-content-between gap-3">
+                                    <div>
+                                        <StatusPill tone={projectStatus.tone}>{projectStatus.label}</StatusPill>
+                                        <h2 className="card-title mt-3 mb-1">{project.name}</h2>
+                                        <div className="text-secondary">Client: {project.client}</div>
+                                    </div>
+                                    <div className="text-end">
+                                        <span className="crm-progress-value">{progressValue}%</span>
+                                        <div className="crm-progress-label text-secondary small">completion</div>
+                                    </div>
+                                </div>
+                                <p className="text-secondary mt-3 flex-grow-0">{project.description}</p>
+                                <div className="mt-4">
+                                    <div className="crm-dropdown-label">Timeline</div>
+                                    <ul className="list-unstyled crm-project-timeline mb-0">
+                                        {project.shoots.map((milestone) => (
+                                            <li key={milestone.id} className="crm-project-milestone">
+                                                <span className="crm-project-milestone-indicator" aria-hidden />
+                                                <div className="flex-grow-1">
+                                                    <div className="d-flex align-items-center justify-content-between gap-2">
+                                                        <div className="fw-semibold">{milestone.label}</div>
+                                                        <StatusPill tone={bookingStatusTone[milestone.status]}>
+                                                            {milestone.status}
+                                                        </StatusPill>
+                                                    </div>
+                                                    <div className="text-secondary small mt-1">
+                                                        {formatDate(milestone.date)}
+                                                        {milestone.location ? ` · ${milestone.location}` : ''}
+                                                    </div>
+                                                </div>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                                <div className="mt-4">
+                                    <div className="crm-dropdown-label">Accounts</div>
+                                    <div className="crm-project-invoices d-flex flex-column gap-3">
+                                        {project.invoices.map((invoice) => (
+                                            <div key={invoice.id} className="d-flex align-items-center justify-content-between gap-3">
+                                                <div>
+                                                    <div className="fw-semibold">Invoice #{invoice.id}</div>
+                                                    <div className="text-secondary small">
+                                                        Due {formatDate(invoice.dueDate)}
+                                                    </div>
+                                                </div>
+                                                <div className="text-end">
+                                                    <div className="fw-semibold">{currencyFormatter.format(invoice.amount)}</div>
+                                                    <StatusPill tone={invoiceStatusTone[invoice.status]}>{invoice.status}</StatusPill>
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                                <div className="mt-4">
+                                    <div className="progress progress-sm">
+                                        <div className="progress-bar" role="progressbar" style={{ width: `${progressValue}%` }} />
+                                    </div>
+                                    <div className="d-flex align-items-center justify-content-between text-secondary small mt-2">
+                                        <span>{dayjs(project.startDate).format('MMM D')}</span>
+                                        <span>{dayjs(project.endDate).format('MMM D')}</span>
+                                    </div>
+                                </div>
+                                <div className="mt-4 d-flex flex-wrap gap-2">
+                                    {project.tags.map((tag) => (
+                                        <span
+                                            key={tag}
+                                            className="badge bg-primary-lt text-primary fw-semibold text-uppercase"
+                                        >
+                                            {tag}
+                                        </span>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+export default function ProjectsPage() {
+    return (
+        <>
+            <Head>
+                <title>Projects · Aperture Studio CRM</title>
+            </Head>
+            <WorkspaceLayout>
+                <ProjectsContent projects={projectPipeline} />
+            </WorkspaceLayout>
+        </>
+    );
+}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import Head from 'next/head';
+
+import { WorkspaceLayout } from '../../components/crm';
+import { adminUser } from '../../data/crm';
+
+const notificationPreferences = [
+    {
+        id: 'booking-alerts',
+        label: 'New booking requests',
+        description: 'Get notified when a lead selects a session date or completes the inquiry form.',
+        defaultChecked: true
+    },
+    {
+        id: 'payment-status',
+        label: 'Payment activity',
+        description: 'Alerts when invoices are paid, overdue, or require manual follow-up.',
+        defaultChecked: true
+    },
+    {
+        id: 'gallery-delivery',
+        label: 'Gallery delivery',
+        description: 'Send a confirmation when new galleries finish uploading to client portals.',
+        defaultChecked: false
+    },
+    {
+        id: 'weekly-digest',
+        label: 'Weekly digest',
+        description: 'A Monday morning summary of open tasks, upcoming shoots, and invoices.',
+        defaultChecked: true
+    }
+];
+
+const integrations = [
+    {
+        id: 'google-drive',
+        name: 'Google Drive',
+        initials: 'GD',
+        status: 'Connected',
+        description: 'Sync project folders and delivery files automatically.',
+        color: '#10b981'
+    },
+    {
+        id: 'google-calendar',
+        name: 'Google Calendar',
+        initials: 'GC',
+        status: 'Connected',
+        description: 'Push confirmed shoots and reminders to your personal calendar.',
+        color: '#6366f1'
+    },
+    {
+        id: 'instagram',
+        name: 'Instagram Business',
+        initials: 'IG',
+        status: 'Syncing',
+        description: 'Schedule reels and carousels directly from project galleries.',
+        color: '#f472b6'
+    }
+];
+
+export default function SettingsPage() {
+    return (
+        <>
+            <Head>
+                <title>Settings · Aperture Studio CRM</title>
+            </Head>
+            <WorkspaceLayout>
+                <div className="row row-cards">
+                    <div className="col-xl-6">
+                        <div className="card h-100">
+                            <div className="card-header d-flex align-items-center justify-content-between">
+                                <div>
+                                    <h2 className="card-title mb-0">Studio profile</h2>
+                                    <div className="text-secondary">Update contact details and booking hand-offs.</div>
+                                </div>
+                                <span className="badge bg-success-lt text-success">Live</span>
+                            </div>
+                            <div className="card-body">
+                                <form className="row g-3">
+                                    <div className="col-12">
+                                        <label className="form-label" htmlFor="studio-name">
+                                            Studio name
+                                        </label>
+                                        <input id="studio-name" type="text" className="form-control" defaultValue="Aperture Studio" />
+                                    </div>
+                                    <div className="col-md-6">
+                                        <label className="form-label" htmlFor="profile-name">
+                                            Primary contact
+                                        </label>
+                                        <input id="profile-name" type="text" className="form-control" defaultValue={adminUser.name} />
+                                    </div>
+                                    <div className="col-md-6">
+                                        <label className="form-label" htmlFor="profile-role">
+                                            Role
+                                        </label>
+                                        <input id="profile-role" type="text" className="form-control" defaultValue={adminUser.role} />
+                                    </div>
+                                    <div className="col-md-6">
+                                        <label className="form-label" htmlFor="profile-email">
+                                            Email
+                                        </label>
+                                        <input id="profile-email" type="email" className="form-control" defaultValue={adminUser.email} />
+                                    </div>
+                                    <div className="col-md-6">
+                                        <label className="form-label" htmlFor="profile-phone">
+                                            Phone
+                                        </label>
+                                        <input id="profile-phone" type="tel" className="form-control" defaultValue={adminUser.phone ?? ''} />
+                                    </div>
+                                    <div className="col-12">
+                                        <label className="form-label" htmlFor="profile-welcome">
+                                            Client welcome message
+                                        </label>
+                                        <textarea
+                                            id="profile-welcome"
+                                            className="form-control"
+                                            rows={3}
+                                            defaultValue="We can’t wait to collaborate. Share any mood boards, location inspiration, or must-have shots and we’ll add them to the project brief."
+                                        />
+                                    </div>
+                                    <div className="col-12 d-flex flex-wrap gap-2">
+                                        <button type="button" className="btn btn-primary">
+                                            Save profile
+                                        </button>
+                                        <button type="button" className="btn btn-outline-secondary">
+                                            Send preview invite
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="col-xl-6">
+                        <div className="card h-100">
+                            <div className="card-header">
+                                <h2 className="card-title mb-0">Notification preferences</h2>
+                                <div className="text-secondary">Choose how the studio stays in sync.</div>
+                            </div>
+                            <div className="card-body d-flex flex-column gap-3">
+                                {notificationPreferences.map((preference) => (
+                                    <div key={preference.id} className="form-check form-switch crm-settings-toggle">
+                                        <input
+                                            className="form-check-input"
+                                            type="checkbox"
+                                            role="switch"
+                                            id={preference.id}
+                                            defaultChecked={preference.defaultChecked}
+                                        />
+                                        <label className="form-check-label" htmlFor={preference.id}>
+                                            <span className="fw-semibold d-block">{preference.label}</span>
+                                            <span className="text-secondary">{preference.description}</span>
+                                        </label>
+                                    </div>
+                                ))}
+                                <div className="mt-2">
+                                    <button type="button" className="btn btn-outline-secondary">
+                                        Update notifications
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="col-12">
+                        <div className="card">
+                            <div className="card-header d-flex align-items-center justify-content-between">
+                                <div>
+                                    <h2 className="card-title mb-0">Connected integrations</h2>
+                                    <div className="text-secondary">Bring your favorite tools into the workflow.</div>
+                                </div>
+                                <button type="button" className="btn btn-outline-secondary">
+                                    Add integration
+                                </button>
+                            </div>
+                            <div className="card-body d-grid gap-3">
+                                {integrations.map((integration) => (
+                                    <div key={integration.id} className="crm-integration-item">
+                                        <div className="d-flex align-items-center gap-3">
+                                            <span
+                                                className="crm-integration-icon"
+                                                style={{ backgroundColor: integration.color }}
+                                                aria-hidden
+                                            >
+                                                {integration.initials}
+                                            </span>
+                                            <div>
+                                                <div className="fw-semibold">{integration.name}</div>
+                                                <div className="text-secondary small">{integration.description}</div>
+                                            </div>
+                                        </div>
+                                        <div className="text-end">
+                                            <span className="badge bg-success-lt text-success d-block mb-2">{integration.status}</span>
+                                            <button type="button" className="btn btn-link p-0">
+                                                Manage
+                                            </button>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </WorkspaceLayout>
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- restyle the CRM workspace with a Tabler-inspired top navigation bar, quick launch app grid, theme controls, notifications, and profile dropdown
- wire up accent color persistence and new hero header styling, and expose additional icons for the navigation set
- add dedicated Projects and Settings pages plus an accounts payable alias to round out the navigation targets

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb735a2b3c8329a81e4efd35ee8e46