### PR TITLE
Realign CRM header controls

### DIFF
--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -420,13 +420,6 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                         </form>
                     </div>
                     <div className="navbar-nav flex-row order-md-last align-items-center gap-2 ms-3">
-                        <Link
-                            href="/bookings"
-                            className="btn btn-primary d-none d-xl-inline-flex align-items-center gap-2"
-                        >
-                            <CalendarIcon className="icon" aria-hidden />
-                            New booking
-                        </Link>
                         <div
                             className={classNames('nav-item dropdown', { show: isAppsOpen })}
                             ref={appsDropdownRef}
@@ -489,123 +482,6 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                             </div>
                         </div>
                         <div
-                            className={classNames('nav-item dropdown', { show: isThemeMenuOpen })}
-                            ref={themeDropdownRef}
-                        >
-                            <button
-                                type="button"
-                                className="btn btn-outline-secondary d-none d-lg-inline-flex align-items-center gap-2"
-                                onClick={toggleThemeMenu}
-                                aria-expanded={isThemeMenuOpen}
-                            >
-                                <SparklesIcon className="icon" aria-hidden />
-                                Theme Settings
-                                <span className="badge bg-green-lt text-green fw-semibold text-uppercase">New</span>
-                            </button>
-                            <button
-                                type="button"
-                                className="btn btn-icon d-lg-none"
-                                onClick={toggleThemeMenu}
-                                aria-label="Open theme settings"
-                                aria-expanded={isThemeMenuOpen}
-                            >
-                                <SparklesIcon className="icon" aria-hidden />
-                            </button>
-                            <div
-                                className={classNames(
-                                    'dropdown-menu dropdown-menu-end dropdown-menu-card dropdown-menu-lg',
-                                    { show: isThemeMenuOpen }
-                                )}
-                            >
-                                <div className="card crm-theme-menu">
-                                    <div className="card-header">
-                                        <h4 className="card-title mb-0">Theme settings</h4>
-                                        <div className="text-secondary">Fine-tune your control center.</div>
-                                    </div>
-                                    <div className="card-body">
-                                        <div className="mb-4">
-                                            <div className="crm-dropdown-label">Color mode</div>
-                                            <div className="btn-list">
-                                                <button
-                                                    type="button"
-                                                    className={classNames('btn', {
-                                                        'btn-primary': theme === 'light',
-                                                        'btn-outline-secondary': theme !== 'light'
-                                                    })}
-                                                    onClick={() => setTheme('light')}
-                                                >
-                                                    <SunIcon className="icon" aria-hidden /> Light
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    className={classNames('btn', {
-                                                        'btn-primary': theme === 'dark',
-                                                        'btn-outline-secondary': theme !== 'dark'
-                                                    })}
-                                                    onClick={() => setTheme('dark')}
-                                                >
-                                                    <MoonIcon className="icon" aria-hidden /> Dark
-                                                </button>
-                                                <button type="button" className="btn btn-outline-secondary" onClick={toggleTheme}>
-                                                    Auto toggle
-                                                </button>
-                                            </div>
-                                        </div>
-                                        <div className="mb-4">
-                                            <div className="crm-dropdown-label">Accent color</div>
-                                            <div className="row g-2">
-                                                {accentOptions.map((option) => {
-                                                    const isActive = option.id === accent;
-                                                    return (
-                                                        <div className="col-4" key={option.id}>
-                                                            <button
-                                                                type="button"
-                                                                className={classNames('crm-color-choice w-100', {
-                                                                    active: isActive
-                                                                })}
-                                                                style={{
-                                                                    backgroundColor: option.swatch,
-                                                                    boxShadow: isActive
-                                                                        ? `0 0 0 4px ${option.soft}`
-                                                                        : undefined,
-                                                                    color: option.contrast ?? '#ffffff'
-                                                                }}
-                                                                onClick={() => handleSelectAccent(option.id)}
-                                                                aria-pressed={isActive}
-                                                            >
-                                                                <span className="crm-color-check" aria-hidden>
-                                                                    <CheckIcon className="icon" />
-                                                                </span>
-                                                                <span className="crm-color-label">{option.label}</span>
-                                                            </button>
-                                                        </div>
-                                                    );
-                                                })}
-                                            </div>
-                                        </div>
-                                        <div>
-                                            <div className="crm-dropdown-label">Current selection</div>
-                                            <div className="d-flex align-items-center justify-content-between gap-3">
-                                                <div>
-                                                    <div className="fw-semibold">{theme === 'dark' ? 'Dark mode' : 'Light mode'}</div>
-                                                    <div className="text-secondary">Accent: {activeAccent.label}</div>
-                                                </div>
-                                                <span
-                                                    className="badge text-uppercase fw-semibold"
-                                                    style={{
-                                                        backgroundColor: activeAccent.soft,
-                                                        color: activeAccent.swatch
-                                                    }}
-                                                >
-                                                    Saved
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div
                             className={classNames('nav-item dropdown', { show: isNotificationsOpen })}
                             ref={notificationsDropdownRef}
                         >
@@ -653,59 +529,6 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                 </div>
                             </div>
                         </div>
-                        <div
-                            className={classNames('nav-item dropdown', { show: isProfileOpen })}
-                            ref={profileDropdownRef}
-                        >
-                            <button
-                                type="button"
-                                className="btn d-flex align-items-center gap-2"
-                                aria-expanded={isProfileOpen}
-                                onClick={toggleProfile}
-                            >
-                                <span className="crm-avatar-wrapper">
-                                    <span className="avatar avatar-sm" style={{ backgroundImage: `url(${adminUser.avatar})` }} />
-                                    {adminUser.status ? <span className="crm-avatar-status" aria-hidden /> : null}
-                                </span>
-                                <span className="d-none d-xl-flex flex-column align-items-start">
-                                    <span className="fw-semibold">{adminUser.name}</span>
-                                    <span className="text-secondary small">{adminUser.role}</span>
-                                </span>
-                                <ChevronDownIcon className="icon d-none d-xl-inline" aria-hidden />
-                            </button>
-                            <div
-                                className={classNames(
-                                    'dropdown-menu dropdown-menu-end dropdown-menu-arrow dropdown-menu-card dropdown-menu-md',
-                                    { show: isProfileOpen }
-                                )}
-                            >
-                                <div className="card">
-                                    <div className="card-body">
-                                        <div className="d-flex align-items-center gap-3">
-                                            <span className="avatar avatar-lg" style={{ backgroundImage: `url(${adminUser.avatar})` }} />
-                                            <div>
-                                                <div className="fw-semibold">{adminUser.name}</div>
-                                                <div className="text-secondary">{adminUser.email}</div>
-                                                {adminUser.status ? (
-                                                    <span className="badge bg-success-lt text-success mt-2">{adminUser.status}</span>
-                                                ) : null}
-                                            </div>
-                                        </div>
-                                        <div className="mt-4 d-grid gap-2">
-                                            <Link href="/settings" className="btn btn-outline-secondary">
-                                                Manage profile
-                                            </Link>
-                                            <Link href="/" className="btn btn-outline-secondary">
-                                                View public site
-                                            </Link>
-                                            <button type="button" className="btn btn-primary">
-                                                Sign out
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </header>
@@ -717,15 +540,204 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                 <span className="crm-page-pretitle">{headingLabel}</span>
                                 <h1 className="crm-page-title">Command center</h1>
                             </div>
-                            <div className="d-flex align-items-center gap-2">
-                                <div className="crm-status-pill">
-                                    <span className="crm-dot" aria-hidden />
-                                    {adminUser.status ?? 'Operational'}
+                            <div className="crm-page-heading-actions">
+                                <div className="crm-page-action-row">
+                                    <Link
+                                        href="/bookings"
+                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
+                                    >
+                                        <CalendarIcon className="icon" aria-hidden />
+                                        New booking
+                                    </Link>
+                                    <div
+                                        className={classNames('dropdown crm-action-dropdown', { show: isThemeMenuOpen })}
+                                        ref={themeDropdownRef}
+                                    >
+                                        <button
+                                            type="button"
+                                            className="btn btn-outline-secondary d-inline-flex align-items-center gap-2"
+                                            onClick={toggleThemeMenu}
+                                            aria-expanded={isThemeMenuOpen}
+                                        >
+                                            <SparklesIcon className="icon" aria-hidden />
+                                            Theme Settings
+                                            <span className="badge bg-green-lt text-green fw-semibold text-uppercase">New</span>
+                                        </button>
+                                        <div
+                                            className={classNames(
+                                                'dropdown-menu dropdown-menu-end dropdown-menu-card dropdown-menu-lg',
+                                                { show: isThemeMenuOpen }
+                                            )}
+                                        >
+                                            <div className="card crm-theme-menu">
+                                                <div className="card-header">
+                                                    <h4 className="card-title mb-0">Theme settings</h4>
+                                                    <div className="text-secondary">Fine-tune your control center.</div>
+                                                </div>
+                                                <div className="card-body">
+                                                    <div className="mb-4">
+                                                        <div className="crm-dropdown-label">Color mode</div>
+                                                        <div className="btn-list">
+                                                            <button
+                                                                type="button"
+                                                                className={classNames('btn', {
+                                                                    'btn-primary': theme === 'light',
+                                                                    'btn-outline-secondary': theme !== 'light'
+                                                                })}
+                                                                onClick={() => setTheme('light')}
+                                                            >
+                                                                <SunIcon className="icon" aria-hidden /> Light
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                className={classNames('btn', {
+                                                                    'btn-primary': theme === 'dark',
+                                                                    'btn-outline-secondary': theme !== 'dark'
+                                                                })}
+                                                                onClick={() => setTheme('dark')}
+                                                            >
+                                                                <MoonIcon className="icon" aria-hidden /> Dark
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                className="btn btn-outline-secondary"
+                                                                onClick={toggleTheme}
+                                                            >
+                                                                Auto toggle
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                    <div className="mb-4">
+                                                        <div className="crm-dropdown-label">Accent color</div>
+                                                        <div className="row g-2">
+                                                            {accentOptions.map((option) => {
+                                                                const isActive = option.id === accent;
+                                                                return (
+                                                                    <div className="col-4" key={option.id}>
+                                                                        <button
+                                                                            type="button"
+                                                                            className={classNames('crm-color-choice w-100', {
+                                                                                active: isActive
+                                                                            })}
+                                                                            style={{
+                                                                                backgroundColor: option.swatch,
+                                                                                boxShadow: isActive
+                                                                                    ? `0 0 0 4px ${option.soft}`
+                                                                                    : undefined,
+                                                                                color: option.contrast ?? '#ffffff'
+                                                                            }}
+                                                                            onClick={() => handleSelectAccent(option.id)}
+                                                                            aria-pressed={isActive}
+                                                                        >
+                                                                            <span className="crm-color-check" aria-hidden>
+                                                                                <CheckIcon className="icon" />
+                                                                            </span>
+                                                                            <span className="crm-color-label">{option.label}</span>
+                                                                        </button>
+                                                                    </div>
+                                                                );
+                                                            })}
+                                                        </div>
+                                                    </div>
+                                                    <div>
+                                                        <div className="crm-dropdown-label">Current selection</div>
+                                                        <div className="d-flex align-items-center justify-content-between gap-3">
+                                                            <div>
+                                                                <div className="fw-semibold">
+                                                                    {theme === 'dark' ? 'Dark mode' : 'Light mode'}
+                                                                </div>
+                                                                <div className="text-secondary">Accent: {activeAccent.label}</div>
+                                                            </div>
+                                                            <span
+                                                                className="badge text-uppercase fw-semibold"
+                                                                style={{
+                                                                    backgroundColor: activeAccent.soft,
+                                                                    color: activeAccent.swatch
+                                                                }}
+                                                            >
+                                                                Saved
+                                                            </span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div
+                                        className={classNames('dropdown crm-action-dropdown', { show: isProfileOpen })}
+                                        ref={profileDropdownRef}
+                                    >
+                                        <button
+                                            type="button"
+                                            className="btn d-flex align-items-center gap-2"
+                                            aria-expanded={isProfileOpen}
+                                            onClick={toggleProfile}
+                                        >
+                                            <span className="crm-avatar-wrapper">
+                                                <span
+                                                    className="avatar avatar-sm"
+                                                    style={{ backgroundImage: `url(${adminUser.avatar})` }}
+                                                />
+                                                {adminUser.status ? <span className="crm-avatar-status" aria-hidden /> : null}
+                                            </span>
+                                            <span className="d-flex flex-column align-items-start">
+                                                <span className="fw-semibold">{adminUser.name}</span>
+                                                <span className="text-secondary small">{adminUser.role}</span>
+                                            </span>
+                                            <ChevronDownIcon className="icon" aria-hidden />
+                                        </button>
+                                        <div
+                                            className={classNames(
+                                                'dropdown-menu dropdown-menu-end dropdown-menu-arrow dropdown-menu-card dropdown-menu-md',
+                                                { show: isProfileOpen }
+                                            )}
+                                        >
+                                            <div className="card">
+                                                <div className="card-body">
+                                                    <div className="d-flex align-items-center gap-3">
+                                                        <span
+                                                            className="avatar avatar-lg"
+                                                            style={{ backgroundImage: `url(${adminUser.avatar})` }}
+                                                        />
+                                                        <div>
+                                                            <div className="fw-semibold">{adminUser.name}</div>
+                                                            <div className="text-secondary">{adminUser.email}</div>
+                                                            {adminUser.status ? (
+                                                                <span className="badge bg-success-lt text-success mt-2">
+                                                                    {adminUser.status}
+                                                                </span>
+                                                            ) : null}
+                                                        </div>
+                                                    </div>
+                                                    <div className="mt-4 d-grid gap-2">
+                                                        <Link href="/settings" className="btn btn-outline-secondary">
+                                                            Manage profile
+                                                        </Link>
+                                                        <Link href="/" className="btn btn-outline-secondary">
+                                                            View public site
+                                                        </Link>
+                                                        <button type="button" className="btn btn-primary">
+                                                            Sign out
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
-                                <Link href="/bookings" className="btn btn-primary d-inline-flex align-items-center gap-2">
-                                    <CalendarIcon className="icon" aria-hidden />
-                                    Quick schedule
-                                </Link>
+                                <div className="crm-page-action-row">
+                                    <div className="crm-status-pill">
+                                        <span className="crm-dot" aria-hidden />
+                                        {adminUser.status ?? 'Operational'}
+                                    </div>
+                                    <Link
+                                        href="/bookings"
+                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
+                                    >
+                                        <CalendarIcon className="icon" aria-hidden />
+                                        Quick schedule
+                                    </Link>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -623,6 +623,44 @@
     gap: 1.25rem;
 }
 
+.crm-page-heading-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-left: auto;
+}
+
+.crm-page-action-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.crm-page-action-row .btn {
+    white-space: nowrap;
+}
+
+.crm-action-dropdown {
+    position: relative;
+}
+
+.crm-action-dropdown .dropdown-menu {
+    margin-top: 0.5rem;
+}
+
+@media (max-width: 767.98px) {
+    .crm-page-heading-actions {
+        align-items: stretch;
+    }
+
+    .crm-page-action-row {
+        justify-content: flex-start;
+    }
+}
+
 .crm-page-heading-text {
     display: flex;
     flex-direction: column;

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import type { GetStaticProps } from 'next';
 import Head from 'next/head';
-import Image from 'next/image';
 import Link from 'next/link';
 import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
@@ -29,7 +28,7 @@ import {
     type Timeframe
 } from '../../components/crm';
 import { useNetlifyIdentity } from '../../components/auth';
-import { adminUser, tasks as defaultTasks, type AdminUser } from '../../data/crm';
+import { tasks as defaultTasks } from '../../data/crm';
 import type { InvoiceStatus } from '../../types/invoice';
 import { readCmsCollection } from '../../utils/read-cms-collection';
 import { useAutoDismiss } from '../../utils/use-auto-dismiss';
@@ -796,9 +795,6 @@ function CrmDashboardWorkspace({
                                 ) : null}
                             </div>
                         </div>
-                        <div className="col-auto">
-                            <AdminProfileCard user={adminUser} />
-                        </div>
                     </div>
                 </div>
 
@@ -959,37 +955,6 @@ function CrmDashboardWorkspace({
                 </div>
             </WorkspaceLayout>
         </>
-    );
-}
-
-type AdminProfileCardProps = {
-    user: AdminUser;
-};
-
-function AdminProfileCard({ user }: AdminProfileCardProps) {
-    return (
-        <div className="card shadow-sm mb-0">
-            <div className="card-body d-flex align-items-center gap-3">
-                <span className="avatar avatar-lg rounded-3 overflow-hidden">
-                    <Image
-                        src={user.avatar}
-                        alt={`${user.name} avatar`}
-                        width={48}
-                        height={48}
-                        className="rounded-3"
-                    />
-                </span>
-                <div className="flex-grow-1">
-                    <div className="fw-semibold">{user.name}</div>
-                    <div className="text-secondary small">{user.role}</div>
-                    <div className="text-secondary small">{user.email}</div>
-                    {user.phone ? <div className="text-secondary small">{user.phone}</div> : null}
-                </div>
-                {user.status ? (
-                    <span className="badge bg-success-lt text-success text-uppercase fw-semibold">{user.status}</span>
-                ) : null}
-            </div>
-        </div>
     );
 }
 


### PR DESCRIPTION
## Summary
- remove the AdminProfileCard from the CRM dashboard hero
- move the New booking, Theme Settings, and profile dropdown into the command center header above Quick schedule
- add supporting layout styles so the controls align to the right edge

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb7b591b3083299fe66ce0924e9afe