### PR TITLE
Update quick launch to use brand icons and fit viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "pdfkit": "^0.17.2",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
+                "react-icons": "^5.5.0",
                 "react-redux": "^9.2.0",
                 "recharts": "^3.2.1",
                 "stripe": "^18.5.0",
@@ -8341,6 +8342,15 @@
             },
             "peerDependencies": {
                 "react": "^19.1.1"
+            }
+        },
+        "node_modules/react-icons": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+            "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "*"
             }
         },
         "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "pdfkit": "^0.17.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
         "recharts": "^3.2.1",
         "stripe": "^18.5.0",

--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -2,6 +2,15 @@ import * as React from 'react';
 import classNames from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import type { IconType } from 'react-icons';
+import {
+    SiGoogleanalytics,
+    SiGoogledrive,
+    SiGooglemeet,
+    SiGooglephotos,
+    SiTiktok
+} from 'react-icons/si';
+import { FaFacebookF, FaInstagram, FaPinterestP } from 'react-icons/fa6';
 
 import { adminUser } from '../../data/crm';
 import { useThemeMode } from '../../utils/use-theme-mode';
@@ -89,10 +98,10 @@ type QuickAccessApp = {
     id: string;
     name: string;
     href: string;
-    initials: string;
     description: string;
-    color: string;
-    textColor?: string;
+    icon: IconType;
+    background: string;
+    iconColor?: string;
 };
 
 type AppCollection = {
@@ -143,35 +152,38 @@ const appCollections: AppCollection[] = [
             {
                 id: 'analytics',
                 name: 'Google Analytics',
-                initials: 'GA',
                 description: 'Monitor marketing funnels and site traffic.',
                 href: 'https://analytics.google.com',
-                color: '#6366f1'
+                icon: SiGoogleanalytics,
+                background: 'linear-gradient(135deg, #fef3c7 0%, #fde68a 100%)',
+                iconColor: '#c2410c'
             },
             {
                 id: 'drive',
                 name: 'Google Drive',
-                initials: 'GD',
                 description: 'Browse shared folders and deliverables.',
                 href: 'https://drive.google.com',
-                color: '#10b981'
+                icon: SiGoogledrive,
+                background: 'linear-gradient(135deg, #e0f2f1 0%, #e0f7fa 100%)',
+                iconColor: '#0f9d58'
             },
             {
                 id: 'meet',
                 name: 'Google Meet',
-                initials: 'GM',
                 description: 'Launch virtual consultations and reviews.',
                 href: 'https://meet.google.com',
-                color: '#f59e0b',
-                textColor: '#111827'
+                icon: SiGooglemeet,
+                background: 'linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%)',
+                iconColor: '#047857'
             },
             {
                 id: 'photos',
                 name: 'Google Photos',
-                initials: 'GP',
                 description: 'Reference archived shoots and mood boards.',
                 href: 'https://photos.google.com',
-                color: '#ec4899'
+                icon: SiGooglephotos,
+                background: 'linear-gradient(135deg, #ffe4e6 0%, #fce7f3 100%)',
+                iconColor: '#db2777'
             }
         ]
     },
@@ -182,34 +194,38 @@ const appCollections: AppCollection[] = [
             {
                 id: 'instagram',
                 name: 'Instagram',
-                initials: 'IG',
                 description: 'Share teasers and behind-the-scenes reels.',
                 href: 'https://www.instagram.com',
-                color: '#f472b6'
+                icon: FaInstagram,
+                background: 'linear-gradient(135deg, #f97316 0%, #ec4899 50%, #6366f1 100%)',
+                iconColor: '#ffffff'
             },
             {
                 id: 'facebook',
                 name: 'Facebook',
-                initials: 'FB',
                 description: 'Connect with leads and publish announcements.',
                 href: 'https://www.facebook.com',
-                color: '#3b82f6'
+                icon: FaFacebookF,
+                background: 'linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%)',
+                iconColor: '#ffffff'
             },
             {
                 id: 'pinterest',
                 name: 'Pinterest',
-                initials: 'PN',
                 description: 'Curate inspiration boards for upcoming shoots.',
                 href: 'https://www.pinterest.com',
-                color: '#ef4444'
+                icon: FaPinterestP,
+                background: 'linear-gradient(135deg, #f87171 0%, #ef4444 100%)',
+                iconColor: '#ffffff'
             },
             {
                 id: 'tiktok',
                 name: 'TikTok',
-                initials: 'TT',
                 description: 'Publish highlight reels and client testimonials.',
                 href: 'https://www.tiktok.com',
-                color: '#0ea5e9'
+                icon: SiTiktok,
+                background: 'linear-gradient(135deg, #0ea5e9 0%, #f43f5e 100%)',
+                iconColor: '#0f172a'
             }
         ]
     }
@@ -545,41 +561,46 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                     { show: isAppsOpen }
                                 )}
                             >
-                                <div className="card">
+                                <div className="card crm-quick-launch-card">
                                     <div className="card-header d-flex align-items-center justify-content-between">
                                         <h4 className="card-title mb-0">Quick launch</h4>
                                         <span className="text-secondary">Stay connected</span>
                                     </div>
-                                    <div className="card-body">
-                                        {appCollections.map((collection, index) => (
-                                            <div
-                                                key={collection.id}
-                                                className={classNames('mb-4', { 'mb-0': index === appCollections.length - 1 })}
-                                            >
+                                    <div className="card-body crm-quick-launch-body">
+                                        {appCollections.map((collection) => (
+                                            <div key={collection.id} className="crm-quick-launch-group">
                                                 <div className="crm-dropdown-label">{collection.label}</div>
                                                 <div className="crm-app-grid">
-                                                    {collection.apps.map((app) => (
-                                                        <a
-                                                            key={app.id}
-                                                            href={app.href}
-                                                            target="_blank"
-                                                            rel="noreferrer"
-                                                            className="crm-app-tile"
-                                                        >
-                                                            <span
-                                                                className="crm-app-icon"
-                                                                style={{
-                                                                    backgroundColor: app.color,
-                                                                    color: app.textColor ?? '#ffffff'
-                                                                }}
-                                                                aria-hidden
+                                                    {collection.apps.map((app) => {
+                                                        const Icon = app.icon;
+                                                        const buttonStyle: React.CSSProperties = {
+                                                            background: app.background
+                                                        };
+                                                        if (app.iconColor) {
+                                                            buttonStyle.color = app.iconColor;
+                                                        }
+
+                                                        return (
+                                                            <a
+                                                                key={app.id}
+                                                                href={app.href}
+                                                                target="_blank"
+                                                                rel="noreferrer"
+                                                                className="crm-app-button"
+                                                                style={buttonStyle}
+                                                                aria-label={app.name}
+                                                                title={`${app.name} – ${app.description}`}
                                                             >
-                                                                {app.initials}
-                                                            </span>
-                                                            <span className="crm-app-label">{app.name}</span>
-                                                            <span className="crm-app-description">{app.description}</span>
-                                                        </a>
-                                                    ))}
+                                                                <Icon
+                                                                    className="crm-app-button-icon"
+                                                                    size={20}
+                                                                    aria-hidden="true"
+                                                                    focusable="false"
+                                                                />
+                                                                <span className="visually-hidden">{app.name}</span>
+                                                            </a>
+                                                        );
+                                                    })}
                                                 </div>
                                             </div>
                                         ))}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -600,53 +600,59 @@ a.link-primary:hover {
 
 .crm-app-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(3.25rem, 1fr));
     gap: 0.75rem;
 }
 
-.crm-app-tile {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: 0.75rem;
-    border-radius: 0.75rem;
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    background-color: var(--tblr-bg-surface, #ffffff);
-    color: inherit;
-    text-decoration: none;
-    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.theme-dark .crm-app-tile {
-    border-color: rgba(71, 85, 105, 0.45);
-    background-color: rgba(30, 41, 59, 0.85);
-}
-
-.crm-app-tile:hover,
-.crm-app-tile:focus {
-    transform: translateY(-3px);
-    border-color: var(--crm-accent);
-    box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.55);
-}
-
-.crm-app-icon {
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 0.75rem;
+.crm-app-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-weight: 600;
-    font-size: 0.95rem;
+    min-height: 3.5rem;
+    border-radius: 0.9rem;
+    border: 1px solid transparent;
+    background: var(--tblr-bg-surface, #ffffff);
+    color: var(--tblr-body-color, #0f172a);
+    text-decoration: none;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 14px 28px -26px rgba(15, 23, 42, 0.55);
 }
 
-.crm-app-label {
-    font-weight: 600;
+.crm-app-button:hover,
+.crm-app-button:focus-visible {
+    transform: translateY(-2px);
+    border-color: var(--crm-accent);
+    box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.55);
 }
 
-.crm-app-description {
-    font-size: 0.75rem;
-    color: var(--tblr-secondary-color, #64748b);
+.crm-app-button:focus-visible {
+    outline: 0;
+}
+
+.theme-dark .crm-app-button {
+    box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.8);
+}
+
+.crm-app-button-icon {
+    display: block;
+}
+
+.crm-quick-launch-card {
+    width: min(22rem, calc(100vw - 2rem));
+}
+
+.crm-quick-launch-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-height: min(70vh, 22rem);
+    overflow-y: auto;
+    padding-right: 0.25rem;
+    scrollbar-gutter: stable both-edges;
+}
+
+.crm-quick-launch-group:last-child {
+    margin-bottom: 0;
 }
 
 .crm-theme-menu .btn-list .btn {
@@ -948,7 +954,7 @@ body.crm-outline-mode {
 }
 
 body.crm-outline-mode .card,
-body.crm-outline-mode .crm-app-tile,
+body.crm-outline-mode .crm-app-button,
 body.crm-outline-mode .crm-settings-toggle,
 body.crm-outline-mode .crm-integration-item {
     border-color: var(--crm-outline-border) !important;
@@ -958,8 +964,8 @@ body.crm-outline-mode .crm-integration-item {
 
 body.crm-outline-mode .card:hover,
 body.crm-outline-mode .card:focus-within,
-body.crm-outline-mode .crm-app-tile:hover,
-body.crm-outline-mode .crm-app-tile:focus,
+body.crm-outline-mode .crm-app-button:hover,
+body.crm-outline-mode .crm-app-button:focus,
 body.crm-outline-mode .crm-settings-toggle:hover,
 body.crm-outline-mode .crm-integration-item:hover {
     box-shadow: 0 0 0 2px rgba(var(--crm-accent-rgb), 0.8), 0 0 42px var(--crm-accent-glow-strong) !important;
@@ -1001,7 +1007,7 @@ body.crm-outline-mode .crm-status-pill .crm-dot {
 }
 
 body.crm-outline-mode .crm-avatar-wrapper .avatar,
-body.crm-outline-mode .crm-app-icon {
+body.crm-outline-mode .crm-app-button {
     box-shadow: 0 0 12px rgba(var(--crm-accent-rgb), 0.35) !important;
 }
 


### PR DESCRIPTION
## Summary
- replace quick launch initials with brand icons sourced from `react-icons` and branded backgrounds
- restyle the quick launch dropdown to use compact icon buttons with accessible labels
- constrain the quick launch menu so it stays within the viewport and scrolls when needed

## Testing
- CI=1 npm run build *(fails: Failed to collect page data for /galleries because `.next/server/pages/galleries.js` is missing in the existing project)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf9f8ff8083298cff348d9c2920d9