### PR TITLE
Adjust command center actions and profile card

### DIFF
--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -804,17 +804,28 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                         >
                             <button
                                 type="button"
-                                className="btn p-0 border-0 bg-transparent"
+                                className="btn p-0 border-0 bg-transparent crm-profile-trigger"
                                 aria-label="Open profile menu"
                                 aria-expanded={isProfileOpen}
                                 onClick={toggleProfile}
                             >
-                                <span className="crm-avatar-wrapper">
-                                    <span
-                                        className="avatar avatar-sm"
-                                        style={{ backgroundImage: `url(${adminUser.avatar})` }}
-                                    />
-                                    {adminUser.status ? <span className="crm-avatar-status" aria-hidden /> : null}
+                                <span className="crm-profile-card">
+                                    <span className="crm-avatar-wrapper">
+                                        <span
+                                            className="avatar avatar-sm"
+                                            style={{ backgroundImage: `url(${adminUser.avatar})` }}
+                                        />
+                                        {adminUser.status ? <span className="crm-avatar-status" aria-hidden /> : null}
+                                    </span>
+                                    <span className="crm-profile-card-details">
+                                        <span className="crm-profile-card-name">{adminUser.name}</span>
+                                        {adminUser.status ? (
+                                            <span className="crm-profile-card-status">
+                                                <span className="crm-dot" aria-hidden />
+                                                {adminUser.status}
+                                            </span>
+                                        ) : null}
+                                    </span>
                                 </span>
                             </button>
                             <div
@@ -885,7 +896,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                 </nav>
                             </div>
                             <div className="crm-page-heading-actions">
-                                <div className="crm-page-action-row">
+                                <div className="crm-page-action-grid">
                                     <Link
                                         href="/bookings"
                                         className="btn btn-primary d-inline-flex align-items-center gap-2"
@@ -893,18 +904,24 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                         <CalendarIcon className="icon" aria-hidden />
                                         New booking
                                     </Link>
-                                </div>
-                                <div className="crm-page-action-row">
-                                    <div className="crm-status-pill">
-                                        <span className="crm-dot" aria-hidden />
-                                        {adminUser.status ?? 'Operational'}
-                                    </div>
                                     <Link
                                         href="/bookings"
                                         className="btn btn-primary d-inline-flex align-items-center gap-2"
                                     >
                                         <CalendarIcon className="icon" aria-hidden />
                                         Quick schedule
+                                    </Link>
+                                    <Link
+                                        href="/bookings"
+                                        className="btn btn-primary d-inline-flex align-items-center justify-content-center"
+                                    >
+                                        Plan a shoot
+                                    </Link>
+                                    <Link
+                                        href="/invoices"
+                                        className="btn btn-outline-primary d-inline-flex align-items-center justify-content-center"
+                                    >
+                                        Review billing
                                     </Link>
                                 </div>
                             </div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -722,6 +722,63 @@ a.link-primary:hover {
     display: inline-flex;
 }
 
+.crm-profile-trigger {
+    display: inline-flex;
+    padding: 0;
+}
+
+.crm-profile-card {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.35rem 0.85rem 0.35rem 0.4rem;
+    border-radius: 9999px;
+    background-color: rgba(var(--crm-accent-rgb), 0.12);
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.theme-dark .crm-profile-card {
+    background-color: rgba(var(--crm-accent-rgb), 0.22);
+}
+
+.crm-profile-card:hover {
+    background-color: rgba(var(--crm-accent-rgb), 0.18);
+    transform: translateY(-1px);
+}
+
+.crm-profile-trigger:focus-visible .crm-profile-card {
+    outline: none;
+    box-shadow: 0 0 0 0.25rem rgba(var(--crm-accent-rgb), 0.3);
+}
+
+.crm-profile-card-details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    line-height: 1.2;
+}
+
+.crm-profile-card-name {
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.crm-profile-card-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+    color: var(--crm-accent);
+}
+
+.theme-dark .crm-profile-card-status {
+    color: var(--crm-accent-bright, var(--crm-accent));
+}
+
 .crm-avatar-status {
     position: absolute;
     bottom: 0;
@@ -764,6 +821,17 @@ a.link-primary:hover {
     margin-left: auto;
 }
 
+.crm-page-action-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.crm-page-action-grid .btn {
+    width: 100%;
+    justify-content: center;
+}
+
 .crm-page-action-row {
     display: flex;
     flex-wrap: wrap;
@@ -787,6 +855,10 @@ a.link-primary:hover {
 @media (max-width: 767.98px) {
     .crm-page-heading-actions {
         align-items: stretch;
+    }
+
+    .crm-page-action-grid {
+        grid-template-columns: 1fr;
     }
 
     .crm-page-action-row {

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -781,19 +781,13 @@ function CrmDashboardWorkspace({
                             <div className="text-secondary mt-2">
                                 Monitor bookings, revenue momentum, and client health with a refreshed Tabler-inspired layout.
                             </div>
-                            <div className="mt-3 d-flex flex-wrap gap-2">
-                                <Link href="/bookings" className="btn btn-primary">
-                                    Plan a shoot
-                                </Link>
-                                <Link href="/invoices" className="btn btn-outline-primary">
-                                    Review billing
-                                </Link>
-                                {guardEnabled ? (
+                            {guardEnabled ? (
+                                <div className="mt-3 d-flex flex-wrap gap-2">
                                     <button type="button" onClick={signOut} className="btn btn-outline-secondary">
                                         Sign out
                                     </button>
-                                ) : null}
-                            </div>
+                                </div>
+                            ) : null}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- move the Plan a shoot and Review billing actions into the command center header, arranging all four quick actions in a 2x2 grid
- remove the redundant status pill and surface the operator name and online indicator inside the Aperture studio bar profile card
- update the workspace snapshot header to only display the sign-out control when the guard is enabled

## Testing
- npm run build *(fails: Type error: Cannot find module 'react-icons' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0fc494dc8329be0b775b0d5804d3