### PR TITLE
Refine command center action layout

### DIFF
--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -804,17 +804,28 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                         >
                             <button
                                 type="button"
-                                className="btn p-0 border-0 bg-transparent"
+                                className="btn p-0 border-0 bg-transparent crm-profile-trigger"
                                 aria-label="Open profile menu"
                                 aria-expanded={isProfileOpen}
                                 onClick={toggleProfile}
                             >
-                                <span className="crm-avatar-wrapper">
-                                    <span
-                                        className="avatar avatar-sm"
-                                        style={{ backgroundImage: `url(${adminUser.avatar})` }}
-                                    />
-                                    {adminUser.status ? <span className="crm-avatar-status" aria-hidden /> : null}
+                                <span className="crm-profile-card">
+                                    <span className="crm-avatar-wrapper">
+                                        <span
+                                            className="avatar avatar-sm"
+                                            style={{ backgroundImage: `url(${adminUser.avatar})` }}
+                                        />
+                                        {adminUser.status ? <span className="crm-avatar-status" aria-hidden /> : null}
+                                    </span>
+                                    <span className="crm-profile-card-details">
+                                        <span className="crm-profile-card-name">{adminUser.name}</span>
+                                        {adminUser.status ? (
+                                            <span className="crm-profile-card-status">
+                                                <span className="crm-dot" aria-hidden />
+                                                {adminUser.status}
+                                            </span>
+                                        ) : null}
+                                    </span>
                                 </span>
                             </button>
                             <div
@@ -883,29 +894,41 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                         );
                                     })}
                                 </nav>
-                            </div>
-                            <div className="crm-page-heading-actions">
-                                <div className="crm-page-action-row">
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <CalendarIcon className="icon" aria-hidden />
-                                        New booking
-                                    </Link>
-                                </div>
-                                <div className="crm-page-action-row">
-                                    <div className="crm-status-pill">
-                                        <span className="crm-dot" aria-hidden />
-                                        {adminUser.status ?? 'Operational'}
+                                <div
+                                    className="crm-page-quick-actions"
+                                    role="group"
+                                    aria-label="Command center quick actions"
+                                >
+                                    <div className="crm-page-action-grid">
+                                        <Link
+                                            href="/bookings"
+                                            className="btn btn-primary d-inline-flex align-items-center gap-2"
+                                        >
+                                            <CalendarIcon className="icon" aria-hidden />
+                                            New booking
+                                        </Link>
+                                        <Link
+                                            href="/bookings"
+                                            className="btn btn-outline-primary d-inline-flex align-items-center gap-2"
+                                        >
+                                            <CheckIcon className="icon" aria-hidden />
+                                            Quick set up
+                                        </Link>
+                                        <Link
+                                            href="/bookings"
+                                            className="btn btn-outline-primary d-inline-flex align-items-center gap-2"
+                                        >
+                                            <PhotoIcon className="icon" aria-hidden />
+                                            Plan a shoot
+                                        </Link>
+                                        <Link
+                                            href="/invoices"
+                                            className="btn btn-outline-primary d-inline-flex align-items-center gap-2"
+                                        >
+                                            <ReceiptIcon className="icon" aria-hidden />
+                                            Review billing
+                                        </Link>
                                     </div>
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <CalendarIcon className="icon" aria-hidden />
-                                        Quick schedule
-                                    </Link>
                                 </div>
                             </div>
                         </div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -722,6 +722,63 @@ a.link-primary:hover {
     display: inline-flex;
 }
 
+.crm-profile-trigger {
+    display: inline-flex;
+    padding: 0;
+}
+
+.crm-profile-card {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.35rem 0.85rem 0.35rem 0.4rem;
+    border-radius: 9999px;
+    background-color: rgba(var(--crm-accent-rgb), 0.12);
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.theme-dark .crm-profile-card {
+    background-color: rgba(var(--crm-accent-rgb), 0.22);
+}
+
+.crm-profile-card:hover {
+    background-color: rgba(var(--crm-accent-rgb), 0.18);
+    transform: translateY(-1px);
+}
+
+.crm-profile-trigger:focus-visible .crm-profile-card {
+    outline: none;
+    box-shadow: 0 0 0 0.25rem rgba(var(--crm-accent-rgb), 0.3);
+}
+
+.crm-profile-card-details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    line-height: 1.2;
+}
+
+.crm-profile-card-name {
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.crm-profile-card-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+    color: var(--crm-accent);
+}
+
+.theme-dark .crm-profile-card-status {
+    color: var(--crm-accent-bright, var(--crm-accent));
+}
+
 .crm-avatar-status {
     position: absolute;
     bottom: 0;
@@ -756,24 +813,31 @@ a.link-primary:hover {
     gap: 1.25rem;
 }
 
-.crm-page-heading-actions {
+.crm-page-quick-actions {
+    margin-top: 1.5rem;
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 1rem;
-    margin-left: auto;
+    justify-content: center;
+    width: 100%;
 }
 
-.crm-page-action-row {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    align-items: center;
+.crm-page-action-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.75rem;
+    width: min(100%, 24rem);
 }
 
-.crm-page-action-row .btn {
-    white-space: nowrap;
+.crm-page-action-grid .btn {
+    width: 100%;
+    justify-content: center;
+    padding: 0.6rem 0.85rem;
+    font-size: 0.8125rem;
+    line-height: 1.25;
+}
+
+.crm-page-action-grid .btn .icon {
+    width: 1rem;
+    height: 1rem;
 }
 
 .crm-action-dropdown {
@@ -785,12 +849,12 @@ a.link-primary:hover {
 }
 
 @media (max-width: 767.98px) {
-    .crm-page-heading-actions {
-        align-items: stretch;
+    .crm-page-quick-actions {
+        margin-top: 1.25rem;
     }
 
-    .crm-page-action-row {
-        justify-content: flex-start;
+    .crm-page-action-grid {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -781,19 +781,13 @@ function CrmDashboardWorkspace({
                             <div className="text-secondary mt-2">
                                 Monitor bookings, revenue momentum, and client health with a refreshed Tabler-inspired layout.
                             </div>
-                            <div className="mt-3 d-flex flex-wrap gap-2">
-                                <Link href="/bookings" className="btn btn-primary">
-                                    Plan a shoot
-                                </Link>
-                                <Link href="/invoices" className="btn btn-outline-primary">
-                                    Review billing
-                                </Link>
-                                {guardEnabled ? (
+                            {guardEnabled ? (
+                                <div className="mt-3 d-flex flex-wrap gap-2">
                                     <button type="button" onClick={signOut} className="btn btn-outline-secondary">
                                         Sign out
                                     </button>
-                                ) : null}
-                            </div>
+                                </div>
+                            ) : null}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- move the command center quick actions beneath the navigation and center them within the header
- retain the condensed 2×2 button grid with refreshed iconography for the relocated actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc0fc494dc8329be0b775b0d5804d3