### PR TITLE
Add multi-user CRM metrics and roles

### DIFF
--- a/content/data/crm-bookings.json
+++ b/content/data/crm-bookings.json
@@ -7,7 +7,8 @@
             "time": "3:00 PM – 5:00 PM",
             "location": "Golden Gate Park",
             "shoot_type": "Engagement Session",
-            "status": "Confirmed"
+            "status": "Confirmed",
+            "owner": "avery-logan"
         },
         {
             "client": "Harrison & June",
@@ -15,7 +16,8 @@
             "time": "11:00 AM – 8:00 PM",
             "location": "Terranea Resort",
             "shoot_type": "Wedding Weekend",
-            "status": "Pending"
+            "status": "Pending",
+            "owner": "jordan-lee"
         },
         {
             "client": "Sona Patel",
@@ -23,7 +25,8 @@
             "time": "9:00 AM – 12:00 PM",
             "location": "Downtown Studio",
             "shoot_type": "Brand Lifestyle",
-            "status": "Editing"
+            "status": "Editing",
+            "owner": "avery-logan"
         },
         {
             "client": "Fern & Pine Studio",
@@ -31,7 +34,8 @@
             "time": "10:00 AM – 2:00 PM",
             "location": "Mission District Loft",
             "shoot_type": "Lookbook Launch",
-            "status": "Pending"
+            "status": "Pending",
+            "owner": "jordan-lee"
         },
         {
             "client": "Evergreen Architects",
@@ -39,7 +43,8 @@
             "time": "1:00 PM – 4:00 PM",
             "location": "Financial District HQ",
             "shoot_type": "Team Headshots",
-            "status": "Confirmed"
+            "status": "Confirmed",
+            "owner": "avery-logan"
         },
         {
             "client": "Evergreen Architects",
@@ -47,7 +52,8 @@
             "time": "8:00 AM – 11:00 AM",
             "location": "Oakland Waterfront",
             "shoot_type": "Site Progress",
-            "status": "Confirmed"
+            "status": "Confirmed",
+            "owner": "avery-logan"
         },
         {
             "client": "Atlas Fitness",
@@ -55,7 +61,8 @@
             "time": "7:00 AM – 10:00 AM",
             "location": "SOMA Studio",
             "shoot_type": "Campaign Refresh",
-            "status": "Editing"
+            "status": "Editing",
+            "owner": "jordan-lee"
         },
         {
             "client": "Violet & Thread",
@@ -63,7 +70,8 @@
             "time": "9:00 AM – 1:00 PM",
             "location": "Dogpatch Warehouse",
             "shoot_type": "Spring Collection",
-            "status": "Confirmed"
+            "status": "Confirmed",
+            "owner": "avery-logan"
         },
         {
             "client": "Harbor & Co",
@@ -71,7 +79,8 @@
             "time": "10:00 AM – 12:00 PM",
             "location": "Sausalito Studio",
             "shoot_type": "Product Launch",
-            "status": "Confirmed"
+            "status": "Confirmed",
+            "owner": "jordan-lee"
         },
         {
             "client": "Lumen Studio",
@@ -79,7 +88,8 @@
             "time": "1:00 PM – 5:00 PM",
             "location": "North Beach Loft",
             "shoot_type": "Agency Portfolio",
-            "status": "Editing"
+            "status": "Editing",
+            "owner": "jordan-lee"
         },
         {
             "client": "Beacon Realty",
@@ -87,7 +97,8 @@
             "time": "9:30 AM – 12:30 PM",
             "location": "Pacific Heights Residence",
             "shoot_type": "Property Showcase",
-            "status": "Confirmed"
+            "status": "Confirmed",
+            "owner": "avery-logan"
         },
         {
             "client": "Sona Patel",
@@ -95,7 +106,8 @@
             "time": "2:00 PM – 6:00 PM",
             "location": "Marin Headlands",
             "shoot_type": "Holiday Campaign",
-            "status": "Confirmed"
+            "status": "Confirmed",
+            "owner": "jordan-lee"
         }
     ]
 }

--- a/content/data/crm-clients.json
+++ b/content/data/crm-clients.json
@@ -10,7 +10,8 @@
             "related_projects": [
                 "Engagement Session",
                 "Wedding Weekend"
-            ]
+            ],
+            "owner": "avery-logan"
         },
         {
             "name": "Evergreen Architects",
@@ -21,7 +22,8 @@
             "related_projects": [
                 "Team Headshots",
                 "Site Progress"
-            ]
+            ],
+            "owner": "avery-logan"
         },
         {
             "name": "Sona Patel",
@@ -32,7 +34,8 @@
             "related_projects": [
                 "Brand Lifestyle",
                 "Campaign Phase 2"
-            ]
+            ],
+            "owner": "avery-logan"
         },
         {
             "name": "Harbor & Co",
@@ -43,7 +46,8 @@
             "related_projects": [
                 "Product Launch",
                 "Holiday Campaign"
-            ]
+            ],
+            "owner": "jordan-lee"
         },
         {
             "name": "Atlas Fitness",
@@ -54,7 +58,8 @@
             "related_projects": [
                 "Campaign Refresh",
                 "Brand Campaign"
-            ]
+            ],
+            "owner": "jordan-lee"
         }
     ]
 }

--- a/content/data/crm-invoices.json
+++ b/content/data/crm-invoices.json
@@ -6,42 +6,48 @@
             "amount": 2100,
             "due_date": "2025-05-31",
             "status": "Sent",
-            "pdf_url": "/invoices/invoice-1036.pdf"
+            "pdf_url": "/invoices/invoice-1036.pdf",
+            "owner": "avery-logan"
         },
         {
             "client": "Sona Patel",
             "amount": 2750,
             "due_date": "2025-06-09",
             "status": "Sent",
-            "pdf_url": "/invoices/invoice-1035.pdf"
+            "pdf_url": "/invoices/invoice-1035.pdf",
+            "owner": "avery-logan"
         },
         {
             "client": "Harrison & June",
             "amount": 1800,
             "due_date": "2025-05-25",
             "status": "Draft",
-            "pdf_url": "/invoices/invoice-1034.pdf"
+            "pdf_url": "/invoices/invoice-1034.pdf",
+            "owner": "jordan-lee"
         },
         {
             "client": "Harbor & Co",
             "amount": 2600,
             "due_date": "2024-12-12",
             "status": "Paid",
-            "pdf_url": "/invoices/invoice-1024.pdf"
+            "pdf_url": "/invoices/invoice-1024.pdf",
+            "owner": "jordan-lee"
         },
         {
             "client": "Lumen Studio",
             "amount": 3400,
             "due_date": "2024-11-16",
             "status": "Paid",
-            "pdf_url": "/invoices/invoice-1023.pdf"
+            "pdf_url": "/invoices/invoice-1023.pdf",
+            "owner": "jordan-lee"
         },
         {
             "client": "Beacon Realty",
             "amount": 1750,
             "due_date": "2024-10-05",
             "status": "Paid",
-            "pdf_url": "/invoices/invoice-1022.pdf"
+            "pdf_url": "/invoices/invoice-1022.pdf",
+            "owner": "avery-logan"
         }
     ]
 }

--- a/content/data/crm-users.json
+++ b/content/data/crm-users.json
@@ -1,0 +1,17 @@
+{
+    "type": "CrmUsers",
+    "items": [
+        {
+            "id": "avery-logan",
+            "name": "Avery Logan",
+            "email": "avery@codex.studio",
+            "role": "admin"
+        },
+        {
+            "id": "jordan-lee",
+            "name": "Jordan Lee",
+            "email": "jordan@codex.studio",
+            "role": "member"
+        }
+    ]
+}

--- a/src/components/auth/NetlifyIdentityProvider.tsx
+++ b/src/components/auth/NetlifyIdentityProvider.tsx
@@ -12,6 +12,7 @@ type IdentityContextValue = {
     roles: string[];
     isPhotographer: boolean;
     isClient: boolean;
+    isAdmin: boolean;
     open: (view?: IdentityView) => void;
     logout: () => void;
     refresh: () => Promise<void>;
@@ -28,6 +29,7 @@ const NetlifyIdentityContext = React.createContext<IdentityContextValue>({
     roles: [],
     isPhotographer: false,
     isClient: false,
+    isAdmin: false,
     open: () => undefined,
     logout: () => undefined,
     refresh: async () => undefined,
@@ -219,6 +221,7 @@ export function NetlifyIdentityProvider({ children }: NetlifyIdentityProviderPro
             roles,
             isPhotographer: normalizedRoles.includes('photographer'),
             isClient: normalizedRoles.includes('client'),
+            isAdmin: normalizedRoles.includes('admin'),
             open,
             logout,
             refresh,

--- a/src/components/crm/BookingList.tsx
+++ b/src/components/crm/BookingList.tsx
@@ -15,6 +15,8 @@ export type BookingRecord = {
     location: string;
     status: BookingStatus;
     customFields?: Record<string, string | boolean>;
+    ownerId?: string;
+    ownerName?: string;
 };
 
 const statusToneMap: Record<BookingStatus, StatusTone> = {

--- a/src/components/crm/ClientTable.tsx
+++ b/src/components/crm/ClientTable.tsx
@@ -15,6 +15,8 @@ export type ClientRecord = {
     lastShoot: string;
     upcomingShoot?: string;
     status: ClientStatus;
+    ownerId?: string;
+    ownerName?: string;
 };
 
 const statusToneMap: Record<ClientStatus, StatusTone> = {

--- a/src/types/invoice.ts
+++ b/src/types/invoice.ts
@@ -36,6 +36,8 @@ export type InvoiceRecord = {
     paymentLink?: string;
     lastSentAt?: string;
     customFields?: Record<string, string | boolean>;
+    ownerId?: string;
+    ownerName?: string;
 };
 
 export const DEFAULT_INVOICE_CURRENCY = 'USD';


### PR DESCRIPTION
## Summary
- add CRM user dataset and extend bookings/clients/invoices with owner metadata
- resolve CMS entries to studio users and compute per-user metric snapshots on the dashboard
- surface admin-only controls and metrics table while exposing admin role flag via Netlify Identity

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cc0ef43c088329ae84d921c50527d9