### PR TITLE
Adjust CRM header layout for narrow viewports

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -589,6 +589,24 @@ a.link-primary:hover {
     color: var(--crm-accent);
 }
 
+@media (min-width: 768px) and (max-width: 1199.98px) {
+    .crm-top-nav .navbar-collapse {
+        flex-wrap: wrap;
+        gap: 0.75rem;
+    }
+
+    .crm-top-nav .navbar-collapse .navbar-nav {
+        flex-wrap: wrap;
+        row-gap: 0.5rem;
+    }
+
+    .crm-top-nav .navbar-search {
+        flex-basis: 100%;
+        margin-left: 0 !important;
+        margin-top: 1rem !important;
+    }
+}
+
 .crm-dropdown-label {
     font-size: 0.75rem;
     text-transform: uppercase;
@@ -848,12 +866,20 @@ a.link-primary:hover {
     position: relative;
 }
 
-@media (max-width: 767.98px) {
+@media (max-width: 1199.98px) {
+    .crm-page-heading {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
     .crm-page-heading-actions {
+        width: 100%;
+        margin-left: 0;
         align-items: stretch;
     }
 
     .crm-page-action-grid {
+        width: 100%;
         grid-template-columns: 1fr;
     }
 


### PR DESCRIPTION
## Summary
- stack the CRM page heading content vertically below 1200px to remove the horizontal overflow on the action panel
- expand the quick action grid to use the full width when stacked so login and widget controls stay visible
- allow the CRM top navigation links and search to wrap on mid-sized screens so the control cluster stays aligned with the action grid and no longer requires horizontal scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc3ac593808329b3ded0bd573e06fa