### PR TITLE
Align CRM header actions and navigation

### DIFF
--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -35,6 +35,13 @@ type NavItem = {
     icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 };
 
+type QuickAction = {
+    href: string;
+    label: string;
+    icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    variant: 'primary' | 'outline';
+};
+
 type AccentOption = {
     id: string;
     label: string;
@@ -122,6 +129,13 @@ const navItems: NavItem[] = [
     { href: '/projects', label: 'Projects', icon: FolderIcon },
     { href: '/accounts-payable', label: 'Accounts Payable', icon: ReceiptIcon },
     { href: '/settings', label: 'Settings', icon: SettingsIcon }
+];
+
+const quickActions: QuickAction[] = [
+    { href: '/bookings', label: 'New booking', icon: CalendarIcon, variant: 'primary' },
+    { href: '/bookings', label: 'Quick set up', icon: CheckIcon, variant: 'outline' },
+    { href: '/bookings', label: 'Plan a shoot', icon: PhotoIcon, variant: 'primary' },
+    { href: '/invoices', label: 'Review billing', icon: ReceiptIcon, variant: 'outline' }
 ];
 
 const ACCENT_STORAGE_KEY = 'crm-accent-preference';
@@ -652,7 +666,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                             </div>
                         </form>
                     </div>
-                    <div className="navbar-nav flex-row order-md-last align-items-center gap-2 ms-3">
+                    <div className="navbar-nav flex-row order-md-last align-items-center gap-2 ms-3 crm-top-nav-actions">
                         <div
                             className={classNames('nav-item dropdown', { show: isAppsOpen })}
                             ref={appsDropdownRef}
@@ -1028,7 +1042,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                             <div className="crm-page-heading-text">
                                 <span className="crm-page-pretitle">{headingLabel}</span>
                                 <h1 className="crm-page-title">Command center</h1>
-                                <nav className="crm-page-nav" aria-label="Workspace pages">
+                                <nav className="crm-page-nav" aria-label="Workspace pages and quick actions">
                                     {navItems.map((item) => {
                                         const isActive = matchPath(router.pathname, item.href);
                                         return (
@@ -1045,43 +1059,24 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                             </Link>
                                         );
                                     })}
+                                    {quickActions.map((action) => {
+                                        const actionClassName = classNames(
+                                            'btn d-inline-flex align-items-center gap-2 crm-page-nav-action',
+                                            action.variant === 'primary' ? 'btn-primary' : 'btn-outline-primary'
+                                        );
+                                        const ActionIcon = action.icon;
+                                        return (
+                                            <Link
+                                                key={`quick-action-${action.href}-${action.label}`}
+                                                href={action.href}
+                                                className={actionClassName}
+                                            >
+                                                <ActionIcon className="icon" aria-hidden />
+                                                <span>{action.label}</span>
+                                            </Link>
+                                        );
+                                    })}
                                 </nav>
-                            </div>
-                            <div className="crm-page-heading-actions">
-                                <div
-                                    className="crm-page-action-grid"
-                                    role="group"
-                                    aria-label="Command center quick actions"
-                                >
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <CalendarIcon className="icon" aria-hidden />
-                                        New booking
-                                    </Link>
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-outline-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <CheckIcon className="icon" aria-hidden />
-                                        Quick set up
-                                    </Link>
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <PhotoIcon className="icon" aria-hidden />
-                                        Plan a shoot
-                                    </Link>
-                                    <Link
-                                        href="/invoices"
-                                        className="btn btn-outline-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <ReceiptIcon className="icon" aria-hidden />
-                                        Review billing
-                                    </Link>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -421,6 +421,7 @@
 }
 
 :root {
+    --content-margin: clamp(1.25rem, 4vw, 1.75rem);
     --crm-accent: #6366f1;
     --crm-accent-soft: rgba(99, 102, 241, 0.22);
     --crm-accent-contrast: #ffffff;
@@ -581,6 +582,10 @@ a.link-primary:hover {
 .crm-top-nav .nav-link .icon {
     width: 1rem;
     height: 1rem;
+}
+
+.crm-top-nav-actions {
+    margin-right: var(--content-margin, 1.5rem);
 }
 
 .crm-top-nav .nav-link.active,
@@ -831,37 +836,6 @@ a.link-primary:hover {
     gap: 1.25rem;
 }
 
-.crm-page-heading-actions {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 1rem;
-    margin-left: auto;
-}
-
-.crm-page-action-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
-}
-
-.crm-page-action-grid .btn {
-    width: 100%;
-    justify-content: center;
-}
-
-.crm-page-action-row {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 0.75rem;
-}
-
-.crm-page-action-row .btn {
-    white-space: nowrap;
-}
-
 .crm-action-dropdown {
     position: relative;
 }
@@ -872,20 +846,6 @@ a.link-primary:hover {
         align-items: stretch;
     }
 
-    .crm-page-heading-actions {
-        width: 100%;
-        margin-left: 0;
-        align-items: stretch;
-    }
-
-    .crm-page-action-grid {
-        width: 100%;
-        grid-template-columns: 1fr;
-    }
-
-    .crm-page-action-row {
-        justify-content: flex-start;
-    }
 }
 
 .crm-page-heading-text {
@@ -912,6 +872,8 @@ a.link-primary:hover {
     flex-wrap: wrap;
     gap: 0.5rem;
     margin-top: 0.75rem;
+    align-items: center;
+    justify-content: flex-start;
 }
 
 .crm-page-nav-link {
@@ -950,8 +912,29 @@ a.link-primary:hover {
     height: 1rem;
 }
 
+.crm-page-nav .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 9999px;
+    padding: 0.45rem 1rem;
+    font-weight: 600;
+}
+
+@media (max-width: 991.98px) {
+    .crm-page-nav {
+        justify-content: center;
+        text-align: center;
+    }
+}
+
 @media (max-width: 767.98px) {
     .crm-page-nav-link {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .crm-page-nav .btn {
         width: 100%;
         justify-content: center;
     }


### PR DESCRIPTION
## Summary
- align the CRM header utility controls with the main content margin using a shared spacing custom property
- fold the command center quick actions into the workspace navigation with consistent button styling and responsive centering

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc833e68a48329be16706d77a705bd