### PR TITLE
Align CRM header actions and navigation

### DIFF
--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -35,6 +35,12 @@ type NavItem = {
     icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 };
 
+type QuickAction = {
+    href: string;
+    label: string;
+    icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+};
+
 type AccentOption = {
     id: string;
     label: string;
@@ -122,6 +128,13 @@ const navItems: NavItem[] = [
     { href: '/projects', label: 'Projects', icon: FolderIcon },
     { href: '/accounts-payable', label: 'Accounts Payable', icon: ReceiptIcon },
     { href: '/settings', label: 'Settings', icon: SettingsIcon }
+];
+
+const quickActions: QuickAction[] = [
+    { href: '/bookings', label: 'New booking', icon: CalendarIcon },
+    { href: '/bookings', label: 'Quick set up', icon: CheckIcon },
+    { href: '/bookings', label: 'Plan a shoot', icon: PhotoIcon },
+    { href: '/invoices', label: 'Review billing', icon: ReceiptIcon }
 ];
 
 const ACCENT_STORAGE_KEY = 'crm-accent-preference';
@@ -652,7 +665,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                             </div>
                         </form>
                     </div>
-                    <div className="navbar-nav flex-row order-md-last align-items-center gap-2 ms-3">
+                    <div className="navbar-nav flex-row order-md-last align-items-center gap-2 ms-3 crm-top-nav-actions">
                         <div
                             className={classNames('nav-item dropdown', { show: isAppsOpen })}
                             ref={appsDropdownRef}
@@ -1028,7 +1041,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                             <div className="crm-page-heading-text">
                                 <span className="crm-page-pretitle">{headingLabel}</span>
                                 <h1 className="crm-page-title">Command center</h1>
-                                <nav className="crm-page-nav" aria-label="Workspace pages">
+                                <nav className="crm-page-nav" aria-label="Workspace pages and quick actions">
                                     {navItems.map((item) => {
                                         const isActive = matchPath(router.pathname, item.href);
                                         return (
@@ -1045,43 +1058,22 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
                                             </Link>
                                         );
                                     })}
+                                    {quickActions.map((action) => {
+                                        const ActionIcon = action.icon;
+                                        return (
+                                            <Link
+                                                key={`quick-action-${action.href}-${action.label}`}
+                                                href={action.href}
+                                                className="crm-page-nav-link"
+                                            >
+                                                <span className="crm-page-nav-icon" aria-hidden>
+                                                    <ActionIcon className="icon" />
+                                                </span>
+                                                <span>{action.label}</span>
+                                            </Link>
+                                        );
+                                    })}
                                 </nav>
-                            </div>
-                            <div className="crm-page-heading-actions">
-                                <div
-                                    className="crm-page-action-grid"
-                                    role="group"
-                                    aria-label="Command center quick actions"
-                                >
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <CalendarIcon className="icon" aria-hidden />
-                                        New booking
-                                    </Link>
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-outline-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <CheckIcon className="icon" aria-hidden />
-                                        Quick set up
-                                    </Link>
-                                    <Link
-                                        href="/bookings"
-                                        className="btn btn-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <PhotoIcon className="icon" aria-hidden />
-                                        Plan a shoot
-                                    </Link>
-                                    <Link
-                                        href="/invoices"
-                                        className="btn btn-outline-primary d-inline-flex align-items-center gap-2"
-                                    >
-                                        <ReceiptIcon className="icon" aria-hidden />
-                                        Review billing
-                                    </Link>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -421,6 +421,7 @@
 }
 
 :root {
+    --content-margin: clamp(1.25rem, 4vw, 1.75rem);
     --crm-accent: #6366f1;
     --crm-accent-soft: rgba(99, 102, 241, 0.22);
     --crm-accent-contrast: #ffffff;
@@ -581,6 +582,10 @@ a.link-primary:hover {
 .crm-top-nav .nav-link .icon {
     width: 1rem;
     height: 1rem;
+}
+
+.crm-top-nav-actions {
+    margin-right: var(--content-margin, 1.5rem);
 }
 
 .crm-top-nav .nav-link.active,
@@ -831,37 +836,6 @@ a.link-primary:hover {
     gap: 1.25rem;
 }
 
-.crm-page-heading-actions {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 1rem;
-    margin-left: auto;
-}
-
-.crm-page-action-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
-}
-
-.crm-page-action-grid .btn {
-    width: 100%;
-    justify-content: center;
-}
-
-.crm-page-action-row {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 0.75rem;
-}
-
-.crm-page-action-row .btn {
-    white-space: nowrap;
-}
-
 .crm-action-dropdown {
     position: relative;
 }
@@ -872,20 +846,6 @@ a.link-primary:hover {
         align-items: stretch;
     }
 
-    .crm-page-heading-actions {
-        width: 100%;
-        margin-left: 0;
-        align-items: stretch;
-    }
-
-    .crm-page-action-grid {
-        width: 100%;
-        grid-template-columns: 1fr;
-    }
-
-    .crm-page-action-row {
-        justify-content: flex-start;
-    }
 }
 
 .crm-page-heading-text {
@@ -910,8 +870,10 @@ a.link-primary:hover {
 .crm-page-nav {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.75rem;
     margin-top: 0.75rem;
+    align-items: center;
+    justify-content: center;
 }
 
 .crm-page-nav-link {
@@ -924,6 +886,9 @@ a.link-primary:hover {
     color: var(--tblr-secondary-color, #64748b);
     background-color: rgba(var(--crm-accent-rgb), 0.08);
     transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    justify-content: center;
+    text-align: center;
+    flex: 0 1 11rem;
 }
 
 .crm-page-nav-link:hover,
@@ -950,10 +915,18 @@ a.link-primary:hover {
     height: 1rem;
 }
 
+@media (max-width: 991.98px) {
+    .crm-page-nav {
+        justify-content: center;
+        text-align: center;
+    }
+}
+
 @media (max-width: 767.98px) {
     .crm-page-nav-link {
         width: 100%;
         justify-content: center;
+        flex: 1 1 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- align the CRM header utility controls with the main content margin using a shared spacing custom property
- fold the command center quick actions into the workspace navigation and style them identically to the other workspace links with centered, even spacing

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc833e68a48329be16706d77a705bd