### PR TITLE
Refactor contacts UI with table layout and modal details

### DIFF
--- a/src/components/crm/ContactModal.tsx
+++ b/src/components/crm/ContactModal.tsx
@@ -1,0 +1,296 @@
+import * as React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+
+import type { ContactRecord } from '../../types/contact';
+import { getContactName } from '../../types/contact';
+
+type ContactModalProps = {
+    contactId: string | null;
+    open: boolean;
+    onClose: () => void;
+    onEdit: (contact: ContactRecord) => void;
+    onConvert: (contact: ContactRecord) => Promise<void> | void;
+    onDelete: (contact: ContactRecord) => Promise<void> | void;
+    isConverting?: boolean;
+};
+
+type ContactDetailResponse = {
+    data?: ContactRecord;
+    error?: string;
+};
+
+const STATUS_LABELS: Record<NonNullable<ContactRecord['status']>, string> = {
+    lead: 'Lead',
+    active: 'Active',
+    client: 'Client'
+};
+
+const STATUS_STYLES: Record<NonNullable<ContactRecord['status']>, string> = {
+    lead: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200',
+    active: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200',
+    client: 'bg-purple-100 text-purple-600 dark:bg-purple-500/20 dark:text-purple-200'
+};
+
+function getStatusBadge(status: ContactRecord['status']): { label: string; className: string } {
+    const normalized = status ?? 'lead';
+    return {
+        label: STATUS_LABELS[normalized],
+        className: `inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${STATUS_STYLES[normalized]}`
+    };
+}
+
+export function ContactModal({ contactId, open, onClose, onEdit, onConvert, onDelete, isConverting = false }: ContactModalProps) {
+    const [contact, setContact] = React.useState<ContactRecord | null>(null);
+    const [isLoading, setIsLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const [isDeleting, setIsDeleting] = React.useState(false);
+    const [isConvertPending, setIsConvertPending] = React.useState(false);
+
+    React.useEffect(() => {
+        if (!open || !contactId) {
+            setContact(null);
+            setError(null);
+            setIsLoading(false);
+            return;
+        }
+
+        let isMounted = true;
+        const controller = new AbortController();
+
+        async function loadContact() {
+            setIsLoading(true);
+            setError(null);
+
+            try {
+                const response = await fetch(`/api/contacts/${contactId}`, {
+                    signal: controller.signal
+                });
+                const payload = (await response.json()) as ContactDetailResponse;
+
+                if (!response.ok || !payload.data) {
+                    throw new Error(payload.error ?? 'Unable to load contact');
+                }
+
+                if (isMounted) {
+                    setContact({
+                        ...payload.data,
+                        status: payload.data.status ?? 'lead'
+                    });
+                }
+            } catch (requestError) {
+                if (!isMounted || (requestError instanceof DOMException && requestError.name === 'AbortError')) {
+                    return;
+                }
+
+                console.error('Failed to load contact details', requestError);
+                setError(requestError instanceof Error ? requestError.message : 'Unable to load contact');
+                setContact(null);
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        }
+
+        void loadContact();
+
+        return () => {
+            isMounted = false;
+            controller.abort();
+        };
+    }, [contactId, open]);
+
+    const handleConvert = React.useCallback(async () => {
+        if (!contact || isConverting || isConvertPending) {
+            return;
+        }
+
+        try {
+            setIsConvertPending(true);
+            await onConvert(contact);
+        } catch (error) {
+            console.error('Convert action failed', error);
+        } finally {
+            setIsConvertPending(false);
+        }
+    }, [contact, isConverting, isConvertPending, onConvert]);
+
+    const handleDelete = React.useCallback(async () => {
+        if (!contact || isDeleting) {
+            return;
+        }
+
+        try {
+            setIsDeleting(true);
+            await onDelete(contact);
+        } catch (error) {
+            console.error('Delete action failed', error);
+        } finally {
+            setIsDeleting(false);
+        }
+    }, [contact, isDeleting, onDelete]);
+
+    const handleEdit = React.useCallback(() => {
+        if (!contact) {
+            return;
+        }
+        onEdit(contact);
+    }, [contact, onEdit]);
+
+    const statusBadge = contact ? getStatusBadge(contact.status) : null;
+    const isClient = contact?.status === 'client';
+    const disableConvert = isClient || isConverting || isConvertPending;
+
+    return (
+        <Dialog.Root
+            open={open}
+            onOpenChange={(value) => {
+                if (!value) {
+                    onClose();
+                }
+            }}
+        >
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 z-40 bg-slate-900/60 backdrop-blur-sm" />
+                <Dialog.Content className="fixed inset-0 z-50 mx-auto my-12 flex h-fit w-full max-w-3xl flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-2xl focus:outline-none dark:border-slate-800 dark:bg-slate-950">
+                    <div className="flex items-start justify-between gap-4 border-b border-slate-200 px-8 py-6 dark:border-slate-800">
+                        <div className="flex flex-col gap-2">
+                            <Dialog.Title className="text-2xl font-semibold text-slate-900 dark:text-white">
+                                {contact ? getContactName(contact) : 'Contact details'}
+                            </Dialog.Title>
+                            {contact?.business ? (
+                                <p className="text-sm text-slate-500 dark:text-slate-400">{contact.business}</p>
+                            ) : null}
+                            {contact ? (
+                                <div className="flex items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+                                    {statusBadge ? (
+                                        <span className={statusBadge.className}>{statusBadge.label}</span>
+                                    ) : null}
+                                    {contact.updated_at ? (
+                                        <span>Updated {new Date(contact.updated_at).toLocaleDateString()}</span>
+                                    ) : null}
+                                </div>
+                            ) : null}
+                        </div>
+                        <Dialog.Close asChild>
+                            <button
+                                type="button"
+                                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-950"
+                                aria-label="Close"
+                            >
+                                ×
+                            </button>
+                        </Dialog.Close>
+                    </div>
+
+                    <div className="flex-1 space-y-6 overflow-y-auto px-8 py-6">
+                        {isLoading ? (
+                            <div className="flex h-40 items-center justify-center text-sm text-slate-500 dark:text-slate-400">
+                                Loading contact…
+                            </div>
+                        ) : error ? (
+                            <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300">
+                                {error}
+                            </div>
+                        ) : contact ? (
+                            <div className="space-y-6">
+                                <dl className="grid gap-4 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2">
+                                    <div>
+                                        <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Email</dt>
+                                        <dd className="mt-1 break-all">{contact.email ?? '—'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Phone</dt>
+                                        <dd className="mt-1">{contact.phone ?? '—'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Location</dt>
+                                        <dd className="mt-1">{[contact.city, contact.state].filter(Boolean).join(', ') || '—'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Address</dt>
+                                        <dd className="mt-1">{contact.address ?? '—'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Status</dt>
+                                        <dd className="mt-1">
+                                            {statusBadge ? <span className={statusBadge.className}>{statusBadge.label}</span> : 'Lead'}
+                                        </dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Owner</dt>
+                                        <dd className="mt-1">{contact.owner_user_id ?? 'Unassigned'}</dd>
+                                    </div>
+                                </dl>
+                                {contact.notes ? (
+                                    <div>
+                                        <h4 className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Notes</h4>
+                                        <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                                            {contact.notes}
+                                        </p>
+                                    </div>
+                                ) : null}
+                                <div className="grid gap-3 text-xs text-slate-400 md:grid-cols-2">
+                                    {contact.created_at ? (
+                                        <div>
+                                            <span className="font-semibold text-slate-500 dark:text-slate-300">Created</span>
+                                            <p className="mt-1 text-sm text-slate-500 dark:text-slate-300">
+                                                {new Date(contact.created_at).toLocaleString()}
+                                            </p>
+                                        </div>
+                                    ) : null}
+                                    {contact.updated_at ? (
+                                        <div>
+                                            <span className="font-semibold text-slate-500 dark:text-slate-300">Updated</span>
+                                            <p className="mt-1 text-sm text-slate-500 dark:text-slate-300">
+                                                {new Date(contact.updated_at).toLocaleString()}
+                                            </p>
+                                        </div>
+                                    ) : null}
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="flex h-40 items-center justify-center text-sm text-slate-500 dark:text-slate-400">
+                                Select a contact to view details.
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="flex flex-col gap-3 border-t border-slate-200 bg-slate-50 px-8 py-6 dark:border-slate-800 dark:bg-slate-900/60 md:flex-row md:items-center md:justify-between">
+                        <div className="text-xs text-slate-500 dark:text-slate-400">
+                            {contact?.email ? `Ready to follow up with ${contact.email}` : 'Track interactions and convert when the timing is right.'}
+                        </div>
+                        <div className="flex flex-col gap-3 md:flex-row">
+                            <button
+                                type="button"
+                                onClick={handleEdit}
+                                disabled={!contact}
+                                className="inline-flex items-center justify-center rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:opacity-60 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-950"
+                            >
+                                Edit contact
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleConvert}
+                                disabled={!contact || disableConvert}
+                                className="inline-flex items-center justify-center rounded-2xl border border-transparent bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:opacity-60 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:ring-offset-slate-950"
+                            >
+                                {isConverting || isConvertPending ? 'Converting…' : isClient ? 'Already a client' : 'Convert to client'}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleDelete}
+                                disabled={!contact || isDeleting}
+                                className="inline-flex items-center justify-center rounded-2xl border border-rose-200 px-4 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:opacity-60 dark:border-rose-500/40 dark:text-rose-300 dark:hover:bg-rose-500/10 dark:focus-visible:ring-offset-slate-950"
+                            >
+                                {isDeleting ? 'Deleting…' : 'Delete contact'}
+                            </button>
+                        </div>
+                    </div>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}
+
+export default ContactModal;

--- a/src/components/crm/ContactsTable.tsx
+++ b/src/components/crm/ContactsTable.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react';
+
+import type { ContactRecord } from '../../types/contact';
+import { getContactName } from '../../types/contact';
+
+type ContactsTableProps = {
+    contacts: ContactRecord[];
+    onSelect: (contactId: string) => void;
+    isLoading?: boolean;
+};
+
+const STATUS_LABELS: Record<NonNullable<ContactRecord['status']>, string> = {
+    lead: 'Lead',
+    active: 'Active',
+    client: 'Client'
+};
+
+const STATUS_STYLES: Record<NonNullable<ContactRecord['status']>, string> = {
+    lead: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200',
+    active: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200',
+    client: 'bg-purple-100 text-purple-600 dark:bg-purple-500/20 dark:text-purple-200'
+};
+
+function getStatusDisplay(status: ContactRecord['status']): { label: string; className: string } {
+    const normalized = status ?? 'lead';
+    return {
+        label: STATUS_LABELS[normalized],
+        className: `inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${STATUS_STYLES[normalized]}`
+    };
+}
+
+export function ContactsTable({ contacts, onSelect, isLoading = false }: ContactsTableProps) {
+    return (
+        <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950">
+            {isLoading ? (
+                <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-end bg-gradient-to-b from-indigo-500/10 via-indigo-500/5 to-transparent px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-indigo-500 dark:text-indigo-300">
+                    Refreshing…
+                </div>
+            ) : null}
+            <div className="hidden md:block">
+                <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+                    <thead className="bg-slate-50 dark:bg-slate-900/60">
+                        <tr>
+                            <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.28em] text-slate-500 dark:text-slate-400">
+                                Name
+                            </th>
+                            <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.28em] text-slate-500 dark:text-slate-400">
+                                Email
+                            </th>
+                            <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.28em] text-slate-500 dark:text-slate-400">
+                                Phone
+                            </th>
+                            <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.28em] text-slate-500 dark:text-slate-400">
+                                Status
+                            </th>
+                            <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.28em] text-slate-500 dark:text-slate-400">
+                                Location
+                            </th>
+                            <th scope="col" className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-[0.28em] text-slate-500 dark:text-slate-400">
+                                Actions
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-200 text-sm dark:divide-slate-800">
+                        {contacts.map((contact) => {
+                            const name = getContactName(contact);
+                            const statusDisplay = getStatusDisplay(contact.status);
+                            const location = [contact.city, contact.state].filter(Boolean).join(', ');
+
+                            return (
+                                <tr key={contact.id} className="transition hover:bg-slate-50 dark:hover:bg-slate-900/60">
+                                    <td className="px-6 py-4 text-sm font-medium text-slate-900 dark:text-white">
+                                        <div className="flex flex-col">
+                                            <span>{name}</span>
+                                            {contact.business ? (
+                                                <span className="text-xs font-normal text-slate-500 dark:text-slate-400">{contact.business}</span>
+                                            ) : null}
+                                        </div>
+                                    </td>
+                                    <td className="px-6 py-4 text-sm text-slate-600 dark:text-slate-300">
+                                        {contact.email ? <span className="break-all">{contact.email}</span> : <span className="text-slate-400 dark:text-slate-500">—</span>}
+                                    </td>
+                                    <td className="px-6 py-4 text-sm text-slate-600 dark:text-slate-300">
+                                        {contact.phone ? contact.phone : <span className="text-slate-400 dark:text-slate-500">—</span>}
+                                    </td>
+                                    <td className="px-6 py-4 text-sm text-slate-600 dark:text-slate-300">
+                                        <span className={statusDisplay.className}>{statusDisplay.label}</span>
+                                    </td>
+                                    <td className="px-6 py-4 text-sm text-slate-600 dark:text-slate-300">
+                                        {location || <span className="text-slate-400 dark:text-slate-500">—</span>}
+                                    </td>
+                                    <td className="px-6 py-4 text-right">
+                                        <button
+                                            type="button"
+                                            onClick={() => onSelect(contact.id)}
+                                            className="inline-flex items-center justify-center rounded-2xl border border-indigo-200 bg-indigo-50 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200 dark:hover:bg-indigo-500/20 dark:focus-visible:ring-offset-slate-950"
+                                        >
+                                            View details
+                                        </button>
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+
+            <div className="grid gap-4 p-4 md:hidden">
+                {contacts.map((contact) => {
+                    const name = getContactName(contact);
+                    const statusDisplay = getStatusDisplay(contact.status);
+                    const location = [contact.city, contact.state].filter(Boolean).join(', ');
+
+                    return (
+                        <article
+                            key={contact.id}
+                            className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+                        >
+                            <div className="flex items-start justify-between gap-4">
+                                <div>
+                                    <h3 className="text-base font-semibold text-slate-900 dark:text-white">{name}</h3>
+                                    {contact.business ? (
+                                        <p className="text-xs text-slate-500 dark:text-slate-400">{contact.business}</p>
+                                    ) : null}
+                                    {location ? (
+                                        <p className="mt-1 text-xs text-slate-400">{location}</p>
+                                    ) : null}
+                                </div>
+                                <span className={statusDisplay.className}>{statusDisplay.label}</span>
+                            </div>
+                            <dl className="grid gap-2 text-sm text-slate-600 dark:text-slate-300">
+                                <div>
+                                    <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Email</dt>
+                                    <dd className="mt-1 break-all">{contact.email || <span className="text-slate-400 dark:text-slate-500">—</span>}</dd>
+                                </div>
+                                <div>
+                                    <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Phone</dt>
+                                    <dd className="mt-1">{contact.phone || <span className="text-slate-400 dark:text-slate-500">—</span>}</dd>
+                                </div>
+                                {contact.notes ? (
+                                    <div>
+                                        <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Notes</dt>
+                                        <dd className="mt-1 text-sm text-slate-500 dark:text-slate-400 line-clamp-2">{contact.notes}</dd>
+                                    </div>
+                                ) : null}
+                            </dl>
+                            <button
+                                type="button"
+                                onClick={() => onSelect(contact.id)}
+                                className="inline-flex items-center justify-center rounded-2xl border border-indigo-200 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200 dark:hover:bg-indigo-500/20 dark:focus-visible:ring-offset-slate-950"
+                            >
+                                View details
+                            </button>
+                        </article>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+export default ContactsTable;

--- a/src/components/crm/index.ts
+++ b/src/components/crm/index.ts
@@ -5,6 +5,8 @@ export type { StatusTone } from './StatusPill';
 export { ClientTable } from './ClientTable';
 export type { ClientRecord, ClientStatus } from './ClientTable';
 export { ContactCard } from './ContactCard';
+export { ContactsTable } from './ContactsTable';
+export { ContactModal } from './ContactModal';
 export { BookingList } from './BookingList';
 export type { BookingRecord, BookingStatus } from './BookingList';
 export { InvoiceTable } from './InvoiceTable';

--- a/src/pages/api/contacts/[id].ts
+++ b/src/pages/api/contacts/[id].ts
@@ -1,0 +1,1 @@
+export { default } from './index';

--- a/src/pages/api/contacts/[id]/convert.ts
+++ b/src/pages/api/contacts/[id]/convert.ts
@@ -1,0 +1,1 @@
+export { default } from '../convert';

--- a/src/pages/api/contacts/convert.ts
+++ b/src/pages/api/contacts/convert.ts
@@ -116,13 +116,34 @@ function parseContactId(body: unknown): string | null {
     return null;
 }
 
+function parseContactIdFromQuery(query: NextApiRequest['query']): string | null {
+    const candidates = [query.id, query.contactId, query.contact_id];
+
+    for (const candidate of candidates) {
+        if (Array.isArray(candidate)) {
+            for (const entry of candidate) {
+                if (typeof entry === 'string' && entry.trim()) {
+                    return entry.trim();
+                }
+            }
+        } else if (typeof candidate === 'string') {
+            const trimmed = candidate.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return null;
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ConvertResponse>) {
     if (req.method !== 'POST') {
         res.setHeader('Allow', 'POST');
         return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
     }
 
-    const contactId = parseContactId(req.body);
+    const contactId = parseContactIdFromQuery(req.query) ?? parseContactId(req.body);
 
     if (!contactId) {
         return res.status(400).json({ error: 'contactId is required' });

--- a/src/server/contacts/express-routes.ts
+++ b/src/server/contacts/express-routes.ts
@@ -1,0 +1,323 @@
+import { randomUUID } from 'crypto';
+
+import type { ContactRecord, ConvertContactResponse } from '../../types/contact';
+import { getContactName } from '../../types/contact';
+import { readContactsFromDisk, writeContactsToDisk } from './local-store';
+
+type ExpressLikeRequest = {
+    params: Record<string, string>;
+    body?: Record<string, unknown> | null;
+};
+
+type ExpressLikeResponse = {
+    status: (code: number) => ExpressLikeResponse;
+    json: (body: unknown) => ExpressLikeResponse;
+};
+
+type ExpressLikeRouter = {
+    get: (path: string, handler: (req: ExpressLikeRequest, res: ExpressLikeResponse) => void | Promise<void>) => ExpressLikeRouter;
+    post: (path: string, handler: (req: ExpressLikeRequest, res: ExpressLikeResponse) => void | Promise<void>) => ExpressLikeRouter;
+    put: (path: string, handler: (req: ExpressLikeRequest, res: ExpressLikeResponse) => void | Promise<void>) => ExpressLikeRouter;
+    delete: (path: string, handler: (req: ExpressLikeRequest, res: ExpressLikeResponse) => void | Promise<void>) => ExpressLikeRouter;
+};
+
+type ContactsApiResponse = { data?: ContactRecord | ContactRecord[] | ConvertContactResponse; error?: string };
+
+const STATUS_VALUES: ContactRecord['status'][] = ['lead', 'active', 'client'];
+
+const DEFAULT_PORTAL_TABS: ConvertContactResponse['portal']['tabs'] = [
+    {
+        id: 'gallery',
+        label: 'Gallery',
+        description: 'Curated selects, downloads, and hero imagery ready to share.'
+    },
+    {
+        id: 'billing',
+        label: 'Billing',
+        description: 'Keep payment details, preferences, and history organised.'
+    },
+    {
+        id: 'invoices',
+        label: 'Invoices',
+        description: 'Review open balances, receipts, and downloadable PDFs.'
+    },
+    {
+        id: 'calendar',
+        label: 'Calendar',
+        description: 'Sync upcoming shoots, post-production checkpoints, and releases.'
+    }
+];
+
+function toNullableString(value: unknown): string | null {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed ? trimmed : null;
+    }
+
+    return String(value);
+}
+
+function toIsoString(value: unknown): string | undefined {
+    if (value === null || value === undefined) {
+        return undefined;
+    }
+
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+        return value.toISOString();
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return undefined;
+        }
+
+        const parsed = new Date(trimmed);
+        if (!Number.isNaN(parsed.getTime())) {
+            return parsed.toISOString();
+        }
+    }
+
+    return undefined;
+}
+
+function normalizeStatus(value: unknown): ContactRecord['status'] {
+    if (value === null) {
+        return null;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (STATUS_VALUES.includes(normalized as ContactRecord['status'])) {
+            return normalized as ContactRecord['status'];
+        }
+    }
+
+    return 'lead';
+}
+
+function createPortalSlug(contact: ContactRecord): string {
+    const base = getContactName(contact) || contact.business || contact.id;
+    return base
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)+/g, '')
+        .replace(/-{2,}/g, '-')
+        .slice(0, 64);
+}
+
+function buildContactRecord(input: Record<string, unknown>, nowIso: string): ContactRecord {
+    const record: ContactRecord = {
+        id:
+            typeof input.id === 'string' && input.id.trim()
+                ? input.id.trim()
+                : randomUUID(),
+        owner_user_id: toNullableString(input.owner_user_id),
+        first_name: toNullableString(input.first_name),
+        last_name: toNullableString(input.last_name),
+        email: toNullableString(input.email),
+        phone: toNullableString(input.phone),
+        notes: toNullableString(input.notes),
+        address: toNullableString(input.address),
+        city: toNullableString(input.city),
+        state: toNullableString(input.state),
+        business: toNullableString(input.business),
+        status: normalizeStatus(input.status),
+        created_at: toIsoString(input.created_at) ?? nowIso,
+        updated_at: toIsoString(input.updated_at) ?? nowIso
+    };
+
+    return record;
+}
+
+async function saveContacts(contacts: ContactRecord[], res: ExpressLikeResponse, successCode = 200, data?: ContactsApiResponse['data']) {
+    await writeContactsToDisk(contacts);
+    res.status(successCode).json({ data: data ?? contacts });
+}
+
+async function handleConvertContact(contact: ContactRecord): Promise<ConvertContactResponse> {
+    const nowIso = new Date().toISOString();
+    const slug = createPortalSlug(contact);
+    const clientId = `express-client-${contact.id}`;
+
+    return {
+        message: `${getContactName(contact)} converted to a client`,
+        client: {
+            id: clientId,
+            first_name: contact.first_name,
+            last_name: contact.last_name,
+            email: contact.email,
+            phone: contact.phone,
+            address: contact.address,
+            city: contact.city,
+            state: contact.state,
+            notes: contact.notes,
+            business: contact.business,
+            created_at: nowIso,
+            updated_at: nowIso
+        },
+        gallery: {
+            id: `express-gallery-${slug || contact.id}`,
+            client_id: clientId,
+            gallery_name: `${getContactName(contact)} Gallery`,
+            gallery_url: null,
+            status: 'draft',
+            created_at: nowIso
+        },
+        billing_account: {
+            id: `express-billing-${slug || contact.id}`,
+            client_id: clientId,
+            payment_terms: 'Due on receipt',
+            invoice_history: [],
+            created_at: nowIso
+        },
+        portal: {
+            url: `/gallery-portal/${slug || contact.id}`,
+            tabs: DEFAULT_PORTAL_TABS
+        }
+    };
+}
+
+export function registerContactsRoutes(router: ExpressLikeRouter): ExpressLikeRouter {
+    router.get('/contacts', async (_req, res) => {
+        const contacts = await readContactsFromDisk();
+        const sorted = contacts.sort((a, b) => {
+            const getTime = (value?: string | null) => {
+                if (!value) {
+                    return 0;
+                }
+                const timestamp = new Date(value).getTime();
+                return Number.isNaN(timestamp) ? 0 : timestamp;
+            };
+            return getTime(b.updated_at ?? b.created_at) - getTime(a.updated_at ?? a.created_at);
+        });
+
+        res.status(200).json({ data: sorted });
+    });
+
+    router.get('/contacts/:id', async (req, res) => {
+        const contacts = await readContactsFromDisk();
+        const record = contacts.find((entry) => entry.id === req.params.id);
+
+        if (!record) {
+            res.status(404).json({ error: 'Contact not found' });
+            return;
+        }
+
+        res.status(200).json({ data: record });
+    });
+
+    router.post('/contacts', async (req, res) => {
+        const payload = req.body ?? {};
+        const nowIso = new Date().toISOString();
+        const record = buildContactRecord(payload ?? {}, nowIso);
+
+        const hasIdentity = Boolean(
+            record.first_name?.trim() ||
+                record.last_name?.trim() ||
+                record.business?.trim() ||
+                record.email?.trim()
+        );
+
+        if (!hasIdentity) {
+            res.status(400).json({ error: 'Provide at least a name, business, or email for the contact' });
+            return;
+        }
+
+        const contacts = await readContactsFromDisk();
+        if (contacts.some((existing) => existing.id === record.id)) {
+            res.status(409).json({ error: 'A contact with this id already exists' });
+            return;
+        }
+
+        contacts.push(record);
+        await saveContacts(contacts, res, 201, record);
+    });
+
+    router.put('/contacts/:id', async (req, res) => {
+        const contacts = await readContactsFromDisk();
+        const index = contacts.findIndex((entry) => entry.id === req.params.id);
+
+        if (index === -1) {
+            res.status(404).json({ error: 'Contact not found' });
+            return;
+        }
+
+        const existing = contacts[index];
+        const payload = req.body ?? {};
+
+        const fields: Array<
+            Exclude<
+                keyof ContactRecord,
+                'status' | 'created_at' | 'updated_at'
+            >
+        > = [
+            'owner_user_id',
+            'first_name',
+            'last_name',
+            'email',
+            'phone',
+            'notes',
+            'address',
+            'city',
+            'state',
+            'business'
+        ];
+
+        fields.forEach((field) => {
+            if (Object.prototype.hasOwnProperty.call(payload, field)) {
+                existing[field] = toNullableString(payload[field]);
+            }
+        });
+
+        if (Object.prototype.hasOwnProperty.call(payload, 'status')) {
+            existing.status = normalizeStatus(payload.status);
+        }
+
+        if (Object.prototype.hasOwnProperty.call(payload, 'created_at')) {
+            existing.created_at = toIsoString(payload.created_at) ?? existing.created_at;
+        }
+
+        existing.updated_at = toIsoString(payload.updated_at) ?? new Date().toISOString();
+
+        contacts[index] = existing;
+        await saveContacts(contacts, res, 200, existing);
+    });
+
+    router.delete('/contacts/:id', async (req, res) => {
+        const contacts = await readContactsFromDisk();
+        const index = contacts.findIndex((entry) => entry.id === req.params.id);
+
+        if (index === -1) {
+            res.status(404).json({ error: 'Contact not found' });
+            return;
+        }
+
+        const [removed] = contacts.splice(index, 1);
+        await saveContacts(contacts, res, 200, removed);
+    });
+
+    router.post('/contacts/:id/convert', async (req, res) => {
+        const contacts = await readContactsFromDisk();
+        const index = contacts.findIndex((entry) => entry.id === req.params.id);
+
+        if (index === -1) {
+            res.status(404).json({ error: 'Contact not found' });
+            return;
+        }
+
+        const [contact] = contacts.splice(index, 1);
+        await writeContactsToDisk(contacts);
+
+        const conversion = await handleConvertContact(contact);
+        res.status(200).json({ data: conversion });
+    });
+
+    return router;
+}
+
+export default registerContactsRoutes;

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -12,6 +12,7 @@ export type ContactRecord = {
     city: string | null;
     state: string | null;
     business: string | null;
+    status: 'lead' | 'active' | 'client' | null;
 };
 
 export type ConvertContactResponse = {


### PR DESCRIPTION
## Summary
- replace the contacts card grid with a responsive table view and hook the page up to a reusable Radix-based details modal
- add a status field to contact records, support editing through the existing form, and wire the modal actions into convert/delete/update flows
- expose new REST-style `/api/contacts/:id` and `/api/contacts/:id/convert` routes (with an Express router example) so the UI can fetch per-contact details on demand

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc985248b48329a9e6759b62874ee4