### PR TITLE
Fix Zapier API imports and signature verification

### DIFF
--- a/src/pages/api/integrations/zapier/events.ts
+++ b/src/pages/api/integrations/zapier/events.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { getSupabaseClient } from '../../../../../utils/supabase-client';
+import { getSupabaseClient } from '../../../../utils/supabase-client';
 
 const ALLOWED_METHODS = ['GET'] as const;
 

--- a/src/pages/api/integrations/zapier/webhook.ts
+++ b/src/pages/api/integrations/zapier/webhook.ts
@@ -1,8 +1,8 @@
 import crypto from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { getSupabaseClient } from '../../../../../utils/supabase-client';
-import type { ZapierWebhookPayload } from '../../../../../types/zapier';
+import { getSupabaseClient } from '../../../../utils/supabase-client';
+import type { ZapierWebhookPayload } from '../../../../types/zapier';
 
 export const config = {
     api: {
@@ -38,7 +38,17 @@ function verifySignature(secret: string | null, rawBody: string, signatureHeader
     if (signatureBuffer.length !== expectedBuffer.length) {
         return false;
     }
-    return crypto.timingSafeEqual(signatureBuffer, expectedBuffer);
+    const signatureView = new Uint8Array(
+        signatureBuffer.buffer,
+        signatureBuffer.byteOffset,
+        signatureBuffer.byteLength
+    );
+    const expectedView = new Uint8Array(
+        expectedBuffer.buffer,
+        expectedBuffer.byteOffset,
+        expectedBuffer.byteLength
+    );
+    return crypto.timingSafeEqual(signatureView, expectedView);
 }
 
 type ZapierWebhookResponse = {


### PR DESCRIPTION
## Summary
- point the Zapier integration API handlers at the Supabase client and Zapier types within `src/utils` and `src/types`
- update the webhook signature comparison to pass `Uint8Array` views to `crypto.timingSafeEqual` for TypeScript compatibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce94ca351c8329b5233282877e4651