### PR TITLE
Add Dropbox API helper and update import workflow

### DIFF
--- a/src/components/crm/DropboxImportPanel.tsx
+++ b/src/components/crm/DropboxImportPanel.tsx
@@ -1,23 +1,11 @@
 import * as React from 'react';
 
 import type { GalleryRecord } from '../../data/crm';
-import { DropboxChooserButton, type DropboxChooserFile } from './DropboxChooserButton';
+import type { DropboxFileMetadata } from '../../types/dropbox';
 
 type DropboxImportPanelProps = {
     galleries: GalleryRecord[];
     onImportComplete?: (result: { imported: number; skipped: number }) => void;
-};
-
-type ImportAsset = {
-    dropboxFileId: string;
-    dropboxPath: string;
-    fileName: string;
-    sizeInBytes: number;
-    previewUrl?: string | null;
-    thumbnailUrl?: string | null;
-    link?: string | null;
-    clientModified?: string | null;
-    serverModified?: string | null;
 };
 
 type ImportResponse = {
@@ -25,19 +13,16 @@ type ImportResponse = {
     error?: string;
 };
 
-function normalizeChooserFile(file: DropboxChooserFile): ImportAsset {
-    return {
-        dropboxFileId: String(file.id),
-        dropboxPath: typeof file.path_display === 'string' ? file.path_display : file.link,
-        fileName: file.name,
-        sizeInBytes: typeof file.bytes === 'number' ? file.bytes : 0,
-        previewUrl: typeof file.link === 'string' ? file.link : undefined,
-        thumbnailUrl: typeof file.thumbnailLink === 'string' ? file.thumbnailLink : undefined,
-        link: typeof file.link === 'string' ? file.link : undefined,
-        clientModified: typeof file.client_modified === 'string' ? file.client_modified : undefined,
-        serverModified: typeof file.server_modified === 'string' ? file.server_modified : undefined
-    };
-}
+type ListFolderResponse = {
+    data?: { entries: DropboxFileMetadata[] };
+    error?: string;
+};
+
+const PRIMARY_BUTTON_CLASS =
+    'inline-flex items-center justify-center rounded-full bg-[#4DE5FF] px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#4DE5FF]/80 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:bg-[#3D7CFF] dark:text-white dark:focus:ring-offset-slate-950';
+
+const SECONDARY_BUTTON_CLASS =
+    'inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-[#4DE5FF]/60 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-900/40 dark:focus:ring-offset-slate-900';
 
 function findDefaultGalleryId(galleries: GalleryRecord[]): string | '' {
     if (!Array.isArray(galleries) || galleries.length === 0) {
@@ -50,6 +35,86 @@ function findDefaultGalleryId(galleries: GalleryRecord[]): string | '' {
     }
 
     return galleries[0]?.id ?? '';
+}
+
+function normalizeFolderInput(path: string): string {
+    const trimmed = path.trim();
+
+    if (!trimmed) {
+        return '';
+    }
+
+    if (trimmed === '/') {
+        return '/';
+    }
+
+    return trimmed.replace(/\/+$/, '');
+}
+
+function resolveAssetPath(asset: DropboxFileMetadata, fallbackFolder: string | null): string {
+    if (asset.pathDisplay) {
+        return asset.pathDisplay;
+    }
+
+    if (asset.pathLower) {
+        return asset.pathLower;
+    }
+
+    if (!fallbackFolder) {
+        return asset.name;
+    }
+
+    const normalizedFolder = normalizeFolderInput(fallbackFolder);
+
+    if (!normalizedFolder || normalizedFolder === '/') {
+        return `/${asset.name}`;
+    }
+
+    return `${normalizedFolder}/${asset.name}`;
+}
+
+function formatBytes(size: number | null): string {
+    if (typeof size !== 'number' || Number.isNaN(size)) {
+        return '—';
+    }
+
+    if (size < 1024) {
+        return `${size} B`;
+    }
+
+    const units = ['KB', 'MB', 'GB', 'TB'];
+    let value = size / 1024;
+    let unitIndex = 0;
+
+    while (value >= 1024 && unitIndex < units.length - 1) {
+        value /= 1024;
+        unitIndex += 1;
+    }
+
+    const precision = value >= 10 ? 0 : 1;
+    return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function formatModifiedDate(value: string | null): string {
+    if (!value) {
+        return '—';
+    }
+
+    try {
+        const date = new Date(value);
+
+        if (Number.isNaN(date.getTime())) {
+            return '—';
+        }
+
+        return new Intl.DateTimeFormat('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric'
+        }).format(date);
+    } catch (error) {
+        return '—';
+    }
 }
 
 export function DropboxImportPanel({ galleries, onImportComplete }: DropboxImportPanelProps) {
@@ -65,10 +130,13 @@ export function DropboxImportPanel({ galleries, onImportComplete }: DropboxImpor
 
     const [selectedGalleryId, setSelectedGalleryId] = React.useState<string>(() => findDefaultGalleryId(galleries));
     const [importing, setImporting] = React.useState(false);
+    const [loadingFolder, setLoadingFolder] = React.useState(false);
     const [resultMessage, setResultMessage] = React.useState<string | null>(null);
     const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
     const [folderPath, setFolderPath] = React.useState('');
     const [triggerZapier, setTriggerZapier] = React.useState(true);
+    const [folderEntries, setFolderEntries] = React.useState<DropboxFileMetadata[]>([]);
+    const [selectedAssetIds, setSelectedAssetIds] = React.useState<Set<string>>(() => new Set());
 
     React.useEffect(() => {
         if (!selectedGalleryId && galleryOptions.length > 0) {
@@ -76,69 +144,162 @@ export function DropboxImportPanel({ galleries, onImportComplete }: DropboxImpor
         }
     }, [galleryOptions, selectedGalleryId]);
 
+    React.useEffect(() => {
+        setSelectedAssetIds(new Set(folderEntries.map((entry) => entry.id)));
+    }, [folderEntries]);
+
     const selectedGallery = React.useMemo(
         () => galleryOptions.find((option) => option.value === selectedGalleryId) ?? null,
         [galleryOptions, selectedGalleryId]
     );
 
-    const handleImport = React.useCallback(
-        async (files: DropboxChooserFile[]) => {
-            if (!selectedGalleryId) {
-                setErrorMessage('Choose a gallery before importing Dropbox assets.');
+    const toggleAsset = React.useCallback((assetId: string) => {
+        setSelectedAssetIds((previous) => {
+            const next = new Set(previous);
+
+            if (next.has(assetId)) {
+                next.delete(assetId);
+            } else {
+                next.add(assetId);
+            }
+
+            return next;
+        });
+    }, []);
+
+    const toggleAllAssets = React.useCallback(() => {
+        setSelectedAssetIds((previous) => {
+            if (folderEntries.length === 0) {
+                return previous;
+            }
+
+            const allSelected = previous.size === folderEntries.length;
+
+            if (allSelected) {
+                return new Set();
+            }
+
+            return new Set(folderEntries.map((entry) => entry.id));
+        });
+    }, [folderEntries]);
+
+    const handleLoadFolder = React.useCallback(async () => {
+        setLoadingFolder(true);
+        setErrorMessage(null);
+        setResultMessage(null);
+
+        try {
+            const response = await fetch('/api/dropbox/list-folder', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path: folderPath })
+            });
+
+            const payload = (await response.json()) as ListFolderResponse;
+
+            if (!response.ok) {
+                setFolderEntries([]);
+                setErrorMessage(payload.error || 'Unable to load Dropbox folder contents.');
                 return;
             }
 
-            if (!files || files.length === 0) {
+            const entries = Array.isArray(payload.data?.entries) ? payload.data?.entries ?? [] : [];
+            setFolderEntries(entries);
+
+            if (entries.length === 0) {
+                setResultMessage('No files were found in the selected Dropbox folder.');
+            } else {
+                setResultMessage(`Loaded ${entries.length} Dropbox file${entries.length === 1 ? '' : 's'} for review.`);
+            }
+        } catch (error) {
+            console.error('Failed to list Dropbox folder', error);
+            setFolderEntries([]);
+            setErrorMessage('Unexpected error while loading the Dropbox folder. Check console for details.');
+        } finally {
+            setLoadingFolder(false);
+        }
+    }, [folderPath]);
+
+    const handleImport = React.useCallback(async () => {
+        if (!selectedGalleryId) {
+            setErrorMessage('Choose a gallery before importing Dropbox assets.');
+            return;
+        }
+
+        if (selectedAssetIds.size === 0) {
+            setErrorMessage('Select at least one Dropbox file to import.');
+            return;
+        }
+
+        const selectedAssets = folderEntries.filter((entry) => selectedAssetIds.has(entry.id));
+
+        if (selectedAssets.length === 0) {
+            setErrorMessage('Selected files are no longer available. Reload the folder and try again.');
+            return;
+        }
+
+        setImporting(true);
+        setErrorMessage(null);
+        setResultMessage(null);
+
+        const fallbackFolder = folderPath || null;
+        const assets = selectedAssets.map((asset) => ({
+            dropboxFileId: asset.id,
+            dropboxPath: resolveAssetPath(asset, fallbackFolder),
+            fileName: asset.name
+        }));
+
+        try {
+            const response = await fetch('/api/galleries/import', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    galleryId: selectedGalleryId,
+                    galleryName: selectedGallery?.label,
+                    clientName: selectedGallery?.clientName,
+                    folderPath: fallbackFolder,
+                    triggerZapier,
+                    assets
+                })
+            });
+
+            const payload = (await response.json()) as ImportResponse;
+
+            if (!response.ok) {
+                setErrorMessage(payload.error || 'Failed to import Dropbox assets.');
                 return;
             }
 
-            setImporting(true);
-            setErrorMessage(null);
-            setResultMessage(null);
+            const imported = payload.data?.imported ?? assets.length;
+            const skipped = payload.data?.skipped ?? 0;
+            const unresolved = Math.max(selectedAssets.length - imported - skipped, 0);
 
-            const assets = files.map((file) => normalizeChooserFile(file));
+            setResultMessage(
+                `Imported ${imported} file${imported === 1 ? '' : 's'} from Dropbox${
+                    skipped > 0 || unresolved > 0
+                        ? ` (${[
+                              skipped > 0 ? `${skipped} duplicate${skipped === 1 ? '' : 's'}` : null,
+                              unresolved > 0 ? `${unresolved} unresolved` : null
+                          ]
+                              .filter(Boolean)
+                              .join(', ')}).`
+                        : '.'
+                }`
+            );
 
-            try {
-                const response = await fetch('/api/galleries/import', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        galleryId: selectedGalleryId,
-                        galleryName: selectedGallery?.label,
-                        clientName: selectedGallery?.clientName,
-                        folderPath: folderPath || null,
-                        triggerZapier,
-                        assets
-                    })
-                });
-
-                const payload = (await response.json()) as ImportResponse;
-
-                if (!response.ok) {
-                    setErrorMessage(payload.error || 'Failed to import Dropbox assets.');
-                    return;
-                }
-
-                const imported = payload.data?.imported ?? assets.length;
-                const skipped = payload.data?.skipped ?? 0;
-                setResultMessage(
-                    `Imported ${imported} file${imported === 1 ? '' : 's'} from Dropbox${
-                        skipped > 0 ? ` (${skipped} skipped as duplicates).` : '.'
-                    }`
-                );
-
-                if (onImportComplete) {
-                    onImportComplete({ imported, skipped });
-                }
-            } catch (error) {
-                console.error('Dropbox import failed', error);
-                setErrorMessage('Unexpected error while importing from Dropbox. Check console for details.');
-            } finally {
-                setImporting(false);
+            if (onImportComplete) {
+                onImportComplete({ imported, skipped });
             }
-        },
-        [folderPath, onImportComplete, selectedGallery, selectedGalleryId, triggerZapier]
-    );
+        } catch (error) {
+            console.error('Dropbox import failed', error);
+            setErrorMessage('Unexpected error while importing from Dropbox. Check console for details.');
+        } finally {
+            setImporting(false);
+        }
+    }, [folderEntries, folderPath, onImportComplete, selectedAssetIds, selectedGallery, selectedGalleryId, triggerZapier]);
+
+    const allSelected = folderEntries.length > 0 && selectedAssetIds.size === folderEntries.length;
+    const selectedCount = selectedAssetIds.size;
 
     return (
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
@@ -159,42 +320,117 @@ export function DropboxImportPanel({ galleries, onImportComplete }: DropboxImpor
                     </select>
                 </label>
                 <label className="flex flex-col gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
-                    Destination folder (optional)
+                    Dropbox folder path
                     <input
                         type="text"
                         value={folderPath}
                         onChange={(event) => setFolderPath(event.target.value)}
-                        placeholder="/Clients/2025-05-14-sanders/"
+                        placeholder="/Clients/2025-05-14-sanders"
                         className="rounded-xl border border-slate-300 bg-white/70 px-4 py-2 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-[#4DE5FF] dark:border-slate-700 dark:bg-slate-900/70 dark:text-white"
                     />
                 </label>
-                <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
-                    <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-slate-300 text-[#4DE5FF] focus:ring-[#4DE5FF] dark:border-slate-600"
-                        checked={triggerZapier}
-                        onChange={(event) => setTriggerZapier(event.target.checked)}
-                    />
-                    Trigger Zapier webhook for new imports
-                </label>
+                <div className="flex flex-wrap items-center gap-3">
+                    <button
+                        type="button"
+                        onClick={handleLoadFolder}
+                        className={SECONDARY_BUTTON_CLASS}
+                        disabled={loadingFolder}
+                    >
+                        {loadingFolder ? 'Loading…' : 'Preview folder'}
+                    </button>
+                    <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+                        <input
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-slate-300 text-[#4DE5FF] focus:ring-[#4DE5FF] dark:border-slate-600"
+                            checked={triggerZapier}
+                            onChange={(event) => setTriggerZapier(event.target.checked)}
+                        />
+                        Trigger Zapier webhook for new imports
+                    </label>
+                </div>
                 <p className="text-sm text-slate-500 dark:text-slate-400">
-                    Launch the Dropbox Chooser to select hero images or proofing assets. Files are written to the Supabase
-                    <code className="ml-1 rounded bg-slate-100 px-1 text-xs dark:bg-slate-800">dropbox_assets</code> table with
-                    duplicate detection and optional Zapier notifications.
+                    Preview Dropbox folders through the authenticated API, select the files you need, and import them directly into the
+                    <code className="ml-1 rounded bg-slate-100 px-1 text-xs dark:bg-slate-800">dropbox_assets</code> table. Server-side token exchange keeps access tokens secure while the CRM records duplicate-resistant metadata.
                 </p>
             </div>
             <div className="flex flex-col gap-4">
-                <DropboxChooserButton onSelect={handleImport} disabled={importing}>
-                    {importing ? 'Importing…' : 'Import from Dropbox'}
-                </DropboxChooserButton>
+                <div className="flex items-center justify-between">
+                    <button
+                        type="button"
+                        onClick={handleImport}
+                        disabled={importing || selectedCount === 0}
+                        className={PRIMARY_BUTTON_CLASS}
+                    >
+                        {importing
+                            ? 'Importing…'
+                            : selectedCount > 0
+                              ? `Import ${selectedCount} file${selectedCount === 1 ? '' : 's'}`
+                              : 'Import selected files'}
+                    </button>
+                    {folderEntries.length > 0 ? (
+                        <button
+                            type="button"
+                            onClick={toggleAllAssets}
+                            className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 transition hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
+                        >
+                            {allSelected ? 'Clear selection' : 'Select all'}
+                        </button>
+                    ) : null}
+                </div>
                 {resultMessage ? <p className="text-sm text-emerald-500">{resultMessage}</p> : null}
                 {errorMessage ? <p className="text-sm text-rose-500">{errorMessage}</p> : null}
+                <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+                    <div className="flex items-center justify-between">
+                        <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">Dropbox folder preview</p>
+                        {folderEntries.length > 0 ? (
+                            <span className="text-xs font-medium uppercase tracking-[0.25em] text-slate-400 dark:text-slate-500">
+                                {selectedCount}/{folderEntries.length} selected
+                            </span>
+                        ) : null}
+                    </div>
+                    <div className="mt-3 max-h-80 overflow-y-auto">
+                        {loadingFolder ? (
+                            <p className="text-sm text-slate-500 dark:text-slate-400">Loading Dropbox files…</p>
+                        ) : folderEntries.length === 0 ? (
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                                Load a Dropbox folder to review its contents before importing files.
+                            </p>
+                        ) : (
+                            <ul className="divide-y divide-slate-200 text-sm dark:divide-slate-700">
+                                {folderEntries.map((entry) => {
+                                    const modified = entry.clientModified ?? entry.serverModified ?? null;
+                                    const sizeLabel = formatBytes(entry.size ?? null);
+
+                                    return (
+                                        <li key={entry.id} className="flex items-start gap-3 py-2">
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedAssetIds.has(entry.id)}
+                                                onChange={() => toggleAsset(entry.id)}
+                                                className="mt-1 h-4 w-4 rounded border-slate-300 text-[#4DE5FF] focus:ring-[#4DE5FF] dark:border-slate-600"
+                                            />
+                                            <div className="min-w-0 flex-1">
+                                                <p className="truncate font-semibold text-slate-700 dark:text-slate-100">{entry.name}</p>
+                                                <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+                                                    {entry.pathDisplay ?? entry.pathLower ?? 'Path unavailable'}
+                                                </p>
+                                                <p className="text-xs text-slate-400 dark:text-slate-500">
+                                                    {sizeLabel} · Modified {formatModifiedDate(modified)}
+                                                </p>
+                                            </div>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        )}
+                    </div>
+                </div>
                 <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 p-4 text-xs leading-relaxed text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
-                    <p className="font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">Dropbox chooser tips</p>
+                    <p className="font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">Dropbox API tips</p>
                     <ul className="mt-2 list-disc space-y-1 pl-5">
-                        <li>Shift-click within the chooser to grab an entire gallery drop folder.</li>
-                        <li>Use the direct link option when you want clients to download the original file.</li>
-                        <li>Preview URLs expire after a short period—Supabase stores them so the CRM can refresh as needed.</li>
+                        <li>Use refresh-token credentials (`DROPBOX_APP_SECRET`, `DROPBOX_REFRESH_TOKEN`) to keep imports private.</li>
+                        <li>Preview folders before importing to confirm Dropbox automations delivered the right files.</li>
+                        <li>Zapier events include resolved metadata, making downstream notifications and audits accurate.</li>
                     </ul>
                 </div>
             </div>

--- a/src/pages/api/dropbox/list-folder.ts
+++ b/src/pages/api/dropbox/list-folder.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { getDropboxClient } from '../../../server/dropbox/client';
+import type { DropboxFileMetadata } from '../../../types/dropbox';
+
+type ListFolderResponse = {
+    data?: { entries: DropboxFileMetadata[] };
+    error?: string;
+};
+
+const ALLOWED_METHODS = ['POST'] as const;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ListFolderResponse>) {
+    if (!ALLOWED_METHODS.includes(req.method as (typeof ALLOWED_METHODS)[number])) {
+        res.setHeader('Allow', ALLOWED_METHODS);
+        res.status(405).json({ error: `Method ${req.method} Not Allowed` });
+        return;
+    }
+
+    try {
+        const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+        const rawPath = typeof body?.path === 'string' ? body.path : '';
+        const trimmedPath = rawPath.trim();
+        const path = trimmedPath === '/' ? '' : trimmedPath;
+
+        const client = getDropboxClient();
+        const entries = await client.listFolder(path);
+
+        res.status(200).json({ data: { entries } });
+    } catch (error) {
+        console.error('Dropbox list-folder error', error);
+
+        if (error instanceof Error) {
+            res.status(500).json({ error: error.message });
+            return;
+        }
+
+        res.status(500).json({ error: 'Unable to list Dropbox folder.' });
+    }
+}

--- a/src/pages/api/galleries/import.ts
+++ b/src/pages/api/galleries/import.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import dayjs from 'dayjs';
 
+import { getDropboxClient, type DropboxClient } from '../../../server/dropbox/client';
+import type { DropboxFileMetadata } from '../../../types/dropbox';
 import { getSupabaseClient } from '../../../utils/supabase-client';
 
 const ALLOWED_METHODS = ['POST'] as const;
@@ -31,7 +33,7 @@ type ImportBody = {
     clientName?: string | null;
     folderPath?: string | null;
     triggerZapier?: boolean;
-    assets?: ImportAsset[];
+    assets?: ImportAssetRequest[];
 };
 
 type ImportResponse = {
@@ -39,11 +41,189 @@ type ImportResponse = {
     error?: string;
 };
 
+type ImportAssetRequest = {
+    dropboxFileId?: string;
+    dropboxPath?: string;
+    fileName?: string;
+};
+
+type ResolvedDropboxAsset = {
+    dropboxFileId: string;
+    dropboxPath: string;
+    folderPath: string | null;
+    fileName: string;
+    sizeInBytes: number;
+    clientModified: string | null;
+    serverModified: string | null;
+    contentHash: string | null;
+};
+
 function ensureArray<T>(value: unknown): T[] {
     if (!Array.isArray(value)) {
         return [];
     }
     return value as T[];
+}
+
+function normalizePath(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function normalizeFolderPath(path: string | null | undefined): string | null {
+    if (typeof path !== 'string') {
+        return null;
+    }
+
+    const trimmed = path.trim();
+
+    if (!trimmed) {
+        return null;
+    }
+
+    if (trimmed === '/') {
+        return '/';
+    }
+
+    return trimmed.replace(/\/+$/, '');
+}
+
+function getFolderFromPath(path: string | null | undefined): string | null {
+    if (typeof path !== 'string') {
+        return null;
+    }
+
+    const trimmed = path.trim();
+
+    if (!trimmed) {
+        return null;
+    }
+
+    const lastSlash = trimmed.lastIndexOf('/');
+
+    if (lastSlash === -1) {
+        return null;
+    }
+
+    if (lastSlash === 0) {
+        return '/';
+    }
+
+    return normalizeFolderPath(trimmed.slice(0, lastSlash));
+}
+
+function buildPath(folderPath: string | null, fileName: string): string {
+    const normalizedFolder = normalizeFolderPath(folderPath);
+
+    if (!normalizedFolder || normalizedFolder === '/') {
+        return `/${fileName}`;
+    }
+
+    return `${normalizedFolder}/${fileName}`;
+}
+
+function mapMetadataToAsset(metadata: DropboxFileMetadata, fallbackFolder: string | null): ResolvedDropboxAsset {
+    const normalizedFallback = normalizeFolderPath(fallbackFolder);
+    const canonicalPath =
+        metadata.pathDisplay ?? metadata.pathLower ?? buildPath(normalizedFallback, metadata.name);
+
+    const folderPath = getFolderFromPath(canonicalPath) ?? normalizedFallback;
+
+    return {
+        dropboxFileId: metadata.id,
+        dropboxPath: canonicalPath,
+        folderPath,
+        fileName: metadata.name,
+        sizeInBytes: typeof metadata.size === 'number' ? metadata.size : 0,
+        clientModified: metadata.clientModified ?? null,
+        serverModified: metadata.serverModified ?? null,
+        contentHash: metadata.contentHash ?? null
+    } satisfies ResolvedDropboxAsset;
+}
+
+function toDropboxListPath(folderPath: string | null): string {
+    if (!folderPath || folderPath === '/') {
+        return '';
+    }
+
+    return folderPath;
+}
+
+async function resolveDropboxAssets(
+    dropbox: DropboxClient,
+    requestedAssets: ImportAssetRequest[],
+    fallbackFolderPath: string | null
+): Promise<ResolvedDropboxAsset[]> {
+    const normalizedFallback = normalizeFolderPath(fallbackFolderPath);
+    const assets = Array.isArray(requestedAssets) ? requestedAssets : [];
+
+    if (assets.length === 0) {
+        if (!normalizedFallback) {
+            return [];
+        }
+
+        const entries = await dropbox.listFolder(toDropboxListPath(normalizedFallback));
+        return entries.map((entry) => mapMetadataToAsset(entry, normalizedFallback));
+    }
+
+    const grouped = new Map<string | null, ImportAssetRequest[]>();
+
+    for (const asset of assets) {
+        const folder = getFolderFromPath(asset.dropboxPath) ?? normalizedFallback;
+        const existing = grouped.get(folder ?? null) ?? [];
+        existing.push(asset);
+        grouped.set(folder ?? null, existing);
+    }
+
+    const resolved: ResolvedDropboxAsset[] = [];
+
+    for (const [folder, requests] of grouped.entries()) {
+        const normalizedFolder = normalizeFolderPath(folder) ?? null;
+        const entries = await dropbox.listFolder(toDropboxListPath(normalizedFolder));
+
+        for (const asset of requests) {
+            const byId = asset.dropboxFileId;
+            const byPath = normalizePath(asset.dropboxPath);
+
+            const entry = entries.find((item) => {
+                if (byId && item.id === byId) {
+                    return true;
+                }
+
+                if (byPath) {
+                    const entryPath = normalizePath(item.pathLower) ?? normalizePath(item.pathDisplay);
+
+                    if (entryPath === byPath) {
+                        return true;
+                    }
+                }
+
+                if (asset.fileName && item.name === asset.fileName) {
+                    return true;
+                }
+
+                return false;
+            });
+
+            if (!entry) {
+                continue;
+            }
+
+            resolved.push(mapMetadataToAsset(entry, normalizedFolder ?? normalizedFallback ?? null));
+        }
+    }
+
+    const uniqueById = new Map<string, ResolvedDropboxAsset>();
+
+    for (const asset of resolved) {
+        uniqueById.set(asset.dropboxFileId, asset);
+    }
+
+    return Array.from(uniqueById.values());
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ImportResponse>) {
@@ -60,29 +240,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         const clientName = typeof body.clientName === 'string' ? body.clientName : null;
         const folderPath = typeof body.folderPath === 'string' ? body.folderPath : null;
         const triggerZapier = body.triggerZapier !== false;
-        const assets = ensureArray<ImportAsset>(body.assets).filter((asset) => typeof asset?.dropboxFileId === 'string');
+        const requestedAssets = ensureArray<ImportAssetRequest>(body.assets);
 
         if (!galleryId) {
             res.status(400).json({ error: 'galleryId is required to import Dropbox assets.' });
             return;
         }
 
-        if (assets.length === 0) {
-            res.status(400).json({ error: 'Provide at least one Dropbox asset to import.' });
+        const dropbox = getDropboxClient();
+        const resolvedAssets = await resolveDropboxAssets(dropbox, requestedAssets, folderPath);
+
+        if (resolvedAssets.length === 0) {
+            res.status(400).json({ error: 'Unable to resolve Dropbox files for import. Confirm the folder path and try again.' });
             return;
         }
 
         const supabase = getSupabaseClient();
         const timestamp = dayjs().toISOString();
 
-        const records = assets.map((asset) => ({
+        const records = resolvedAssets.map((asset) => ({
             dropbox_file_id: asset.dropboxFileId,
             dropbox_path: asset.dropboxPath,
-            folder_path: folderPath,
+            folder_path: asset.folderPath ?? folderPath,
             file_name: asset.fileName,
             size_in_bytes: asset.sizeInBytes,
-            preview_url: asset.previewUrl ?? asset.link ?? null,
-            thumbnail_url: asset.thumbnailUrl ?? null,
+            preview_url: null,
+            thumbnail_url: null,
             client_name: clientName,
             gallery_id: galleryId,
             gallery_name: galleryName,
@@ -104,7 +287,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         }
 
         const imported = data?.length ?? 0;
-        const skipped = assets.length - imported;
+        const skipped = resolvedAssets.length - imported;
 
         if (triggerZapier) {
             await supabase.from('zapier_webhook_events').insert({
@@ -116,13 +299,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                     galleryName,
                     clientName,
                     importedAt: timestamp,
-                    assets: assets.map((asset) => ({
+                    requestedAssetCount: requestedAssets.length,
+                    resolvedAssetCount: resolvedAssets.length,
+                    assets: resolvedAssets.map((asset) => ({
                         dropboxFileId: asset.dropboxFileId,
                         dropboxPath: asset.dropboxPath,
                         fileName: asset.fileName,
                         sizeInBytes: asset.sizeInBytes,
-                        previewUrl: asset.previewUrl ?? asset.link ?? null,
-                        thumbnailUrl: asset.thumbnailUrl ?? null
+                        clientModified: asset.clientModified,
+                        serverModified: asset.serverModified,
+                        contentHash: asset.contentHash
                     }))
                 },
                 received_at: timestamp

--- a/src/server/dropbox/client.ts
+++ b/src/server/dropbox/client.ts
@@ -1,0 +1,233 @@
+import { Buffer } from 'node:buffer';
+
+import type { DropboxFileMetadata } from '../../types/dropbox';
+
+const DROPBOX_API_BASE_URL = 'https://api.dropboxapi.com/2';
+const DROPBOX_CONTENT_BASE_URL = 'https://content.dropboxapi.com/2';
+
+const TOKEN_REFRESH_BUFFER_MS = 60_000; // refresh tokens one minute before expiry
+
+type DropboxOAuthConfig = {
+    appKey: string;
+    appSecret: string;
+    refreshToken: string;
+};
+
+type DropboxAccessTokenCache = {
+    accessToken: string;
+    expiresAt: number;
+};
+
+type DropboxListFolderEntry = {
+    '.tag': 'file' | 'folder' | 'deleted';
+    id: string;
+    name: string;
+    path_display?: string;
+    path_lower?: string;
+    client_modified?: string;
+    server_modified?: string;
+    size?: number;
+    is_downloadable?: boolean;
+    content_hash?: string;
+};
+
+type DropboxListFolderResponse = {
+    entries: DropboxListFolderEntry[];
+    cursor?: string;
+    has_more?: boolean;
+};
+
+type DropboxDownloadResult = {
+    metadata: DropboxFileMetadata | null;
+    file: Buffer;
+    contentType: string | null;
+};
+
+export type DropboxClient = {
+    listFolder: (path: string) => Promise<DropboxFileMetadata[]>;
+    downloadFile: (input: { path?: string; id?: string }) => Promise<DropboxDownloadResult>;
+};
+
+let cachedToken: DropboxAccessTokenCache | null = null;
+let inflightTokenRequest: Promise<string> | null = null;
+
+function getOAuthConfig(): DropboxOAuthConfig {
+    const appKey = process.env.NEXT_PUBLIC_DROPBOX_APP_KEY;
+    const appSecret = process.env.DROPBOX_APP_SECRET;
+    const refreshToken = process.env.DROPBOX_REFRESH_TOKEN;
+
+    if (!appKey || !appSecret || !refreshToken) {
+        throw new Error('Dropbox OAuth environment variables are not configured.');
+    }
+
+    return { appKey, appSecret, refreshToken };
+}
+
+async function fetchAccessToken(): Promise<string> {
+    const now = Date.now();
+
+    if (cachedToken && cachedToken.expiresAt - TOKEN_REFRESH_BUFFER_MS > now) {
+        return cachedToken.accessToken;
+    }
+
+    if (inflightTokenRequest) {
+        return inflightTokenRequest;
+    }
+
+    inflightTokenRequest = (async () => {
+        const { appKey, appSecret, refreshToken } = getOAuthConfig();
+        const payload = new URLSearchParams();
+        payload.set('grant_type', 'refresh_token');
+        payload.set('refresh_token', refreshToken);
+
+        const basicAuth = Buffer.from(`${appKey}:${appSecret}`).toString('base64');
+
+        const response = await fetch(`${DROPBOX_API_BASE_URL}/oauth2/token`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Basic ${basicAuth}`,
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: payload.toString()
+        });
+
+        if (!response.ok) {
+            inflightTokenRequest = null;
+            throw new Error(`Dropbox OAuth token exchange failed: ${response.statusText}`);
+        }
+
+        const data = (await response.json()) as { access_token?: string; expires_in?: number };
+        const accessToken = data.access_token;
+        const expiresIn = typeof data.expires_in === 'number' ? data.expires_in * 1000 : 0;
+
+        if (!accessToken) {
+            inflightTokenRequest = null;
+            throw new Error('Dropbox OAuth response missing access_token.');
+        }
+
+        cachedToken = {
+            accessToken,
+            expiresAt: Date.now() + (expiresIn || 5 * 60 * 1000)
+        } satisfies DropboxAccessTokenCache;
+
+        inflightTokenRequest = null;
+        return accessToken;
+    })();
+
+    try {
+        return await inflightTokenRequest;
+    } finally {
+        inflightTokenRequest = null;
+    }
+}
+
+function mapEntry(entry: DropboxListFolderEntry): DropboxFileMetadata | null {
+    if (entry['.tag'] !== 'file') {
+        return null;
+    }
+
+    return {
+        id: entry.id,
+        name: entry.name,
+        pathDisplay: entry.path_display ?? null,
+        pathLower: entry.path_lower ?? null,
+        clientModified: entry.client_modified ?? null,
+        serverModified: entry.server_modified ?? null,
+        size: typeof entry.size === 'number' ? entry.size : null,
+        isDownloadable: entry.is_downloadable !== false,
+        contentHash: entry.content_hash ?? null
+    } satisfies DropboxFileMetadata;
+}
+
+async function listFolder(path: string): Promise<DropboxFileMetadata[]> {
+    const token = await fetchAccessToken();
+    const entries: DropboxFileMetadata[] = [];
+    let cursor: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+        const endpoint = cursor ? `${DROPBOX_API_BASE_URL}/files/list_folder/continue` : `${DROPBOX_API_BASE_URL}/files/list_folder`;
+        const body = cursor ? { cursor } : { path, recursive: false, include_media_info: false, include_deleted: false, include_non_downloadable_files: true };
+
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(body)
+        });
+
+        if (!response.ok) {
+            throw new Error(`Dropbox list_folder failed with status ${response.status}`);
+        }
+
+        const data = (await response.json()) as DropboxListFolderResponse;
+        const mappedEntries = (data.entries ?? []).map(mapEntry).filter((entry): entry is DropboxFileMetadata => Boolean(entry));
+        entries.push(...mappedEntries);
+
+        cursor = data.cursor;
+        hasMore = Boolean(data.has_more && cursor);
+    }
+
+    return entries;
+}
+
+async function downloadFile(input: { path?: string; id?: string }): Promise<DropboxDownloadResult> {
+    const token = await fetchAccessToken();
+    const selector = input.id || input.path;
+
+    if (!selector) {
+        throw new Error('Dropbox downloadFile requires either a file id or path.');
+    }
+
+    const response = await fetch(`${DROPBOX_CONTENT_BASE_URL}/files/download`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Dropbox-API-Arg': JSON.stringify({ path: selector })
+        }
+    });
+
+    if (!response.ok) {
+        throw new Error(`Dropbox file download failed with status ${response.status}`);
+    }
+
+    const metadataHeader = response.headers.get('dropbox-api-result');
+    let metadata: DropboxFileMetadata | null = null;
+
+    if (metadataHeader) {
+        try {
+            const parsed = JSON.parse(metadataHeader) as DropboxListFolderEntry;
+            const mapped = mapEntry(parsed);
+            metadata = mapped ?? {
+                id: parsed.id,
+                name: parsed.name,
+                pathDisplay: parsed.path_display ?? null,
+                pathLower: parsed.path_lower ?? null,
+                clientModified: parsed.client_modified ?? null,
+                serverModified: parsed.server_modified ?? null,
+                size: typeof parsed.size === 'number' ? parsed.size : null,
+                isDownloadable: parsed.is_downloadable !== false,
+                contentHash: parsed.content_hash ?? null
+            } satisfies DropboxFileMetadata;
+        } catch (error) {
+            // Ignore metadata parsing errors and fall back to null.
+        }
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+
+    return {
+        metadata,
+        file: Buffer.from(arrayBuffer),
+        contentType: response.headers.get('Content-Type')
+    } satisfies DropboxDownloadResult;
+}
+
+export function getDropboxClient(): DropboxClient {
+    return {
+        listFolder,
+        downloadFile
+    } satisfies DropboxClient;
+}

--- a/src/types/dropbox.ts
+++ b/src/types/dropbox.ts
@@ -22,3 +22,15 @@ export type DropboxAssetRecord = {
     galleryId?: string | null;
     galleryName?: string | null;
 };
+
+export type DropboxFileMetadata = {
+    id: string;
+    name: string;
+    pathDisplay: string | null;
+    pathLower: string | null;
+    clientModified: string | null;
+    serverModified: string | null;
+    size: number | null;
+    isDownloadable: boolean;
+    contentHash: string | null;
+};


### PR DESCRIPTION
## Summary
- add a server-side Dropbox client that exchanges refresh tokens for access tokens and exposes list/download helpers
- expose a POST /api/dropbox/list-folder route and resolve Dropbox metadata server-side before importing galleries
- refresh the Dropbox import panel UI to preview folders via the authenticated API and document new environment variables

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea8a9fd6483299cd854495efa36f5