### PR TITLE
Align contacts workspace with dashboard layout

### DIFF
--- a/src/components/data/DataToolbar.tsx
+++ b/src/components/data/DataToolbar.tsx
@@ -177,7 +177,7 @@ export function DataToolbar({
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div className="flex flex-wrap items-center gap-2">
                     {filters.map((filter) => (
-                        <FilterPopover key={filter.id} filter={filter} />
+                        <ToolbarFilterChip key={filter.id} filter={filter} />
                     ))}
                     {hasActiveFilters && onResetFilters ? (
                         <button
@@ -219,7 +219,7 @@ export function DataToolbar({
     );
 }
 
-function FilterPopover({ filter }: { filter: ToolbarFilter }) {
+export function ToolbarFilterChip({ filter }: { filter: ToolbarFilter }) {
     const [open, setOpen] = React.useState(false);
     const containerRef = React.useRef<HTMLDivElement | null>(null);
 


### PR DESCRIPTION
## Summary
- export the shared toolbar filter chip so pages can reuse the dashboard filter UI
- rework the contacts page header, toolbar, and table spacing to match the dashboard shell while removing the KPI metrics block
- update the contacts metadata, search debounce, and empty-state handling to fit the streamlined layout

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cebd29f244832992e9d46d2258f348