### PR TITLE
Add guide for normalizing cross-browser layouts

### DIFF
--- a/content/pages/blog/normalize-cross-browser-layouts.md
+++ b/content/pages/blog/normalize-cross-browser-layouts.md
@@ -1,0 +1,132 @@
+---
+title: Normalize Cross-Browser Layouts in Minutes
+slug: normalize-cross-browser-layouts
+date: '2024-02-20'
+excerpt: >-
+  Stop guessing why Chrome, Safari, and Firefox render your header differently. Use this quick checklist to normalize spacing,
+  alignment, and viewport sizing across browsers.
+featuredImage:
+  url: /images/abstract-feature2.svg
+  altText: Thumbnail
+  type: ImageBlock
+  styles:
+    self:
+      borderRadius: medium
+bottomSections: []
+isFeatured: false
+isDraft: false
+seo:
+  metaTitle: Normalize Cross-Browser Layouts in Minutes
+  metaDescription: Learn how to reset browser defaults, enforce a consistent box model, and align Flexbox layouts so your UI
+    renders the same in Chrome, Safari, and Firefox.
+  socialImage: /images/abstract-feature2.svg
+  type: Seo
+colors: bg-light-fg-dark
+styles:
+  self:
+    flexDirection: col
+author: content/data/person3.json
+type: PostLayout
+---
+
+Every browser ships with its own default stylesheet, and those tiny differences in margin, padding, or box-sizing can wreck the
+pixel-perfect layout you built in one engine when it lands in another. If your header looks snug in Chrome but the widgets
+slide off the canvas in Safari, start by normalizing the playing field before chasing down component bugs.
+
+## 1. Reset the Box Model
+
+Browsers still default to `content-box`, which calculates element width without padding or border. When you mix padding and
+percentage-based widths, the math diverges across engines. Opt in to `border-box` everywhere so padding is included inside the
+box:
+
+```css
+/* Apply consistent box model */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+```
+
+This single rule eliminates most mysterious overflow because every element now measures itself the same way in Chrome, Safari,
+and Firefox.
+
+## 2. Clear Out User-Agent Margins
+
+The `<body>`, headings, and lists pick up default spacing that varies by browser. Remove it so you can control spacing from your
+component styles:
+
+```css
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+```
+
+Do the same for other structural elements if they keep nudging layouts out of alignment.
+
+## 3. Constrain and Center Your Container
+
+Without explicit widths, flex or grid wrappers can stretch differently across browsers. Give your main container predictable
+bounds and consistent breathing room:
+
+```css
+.container {
+  max-width: 1200px; /* swap in your breakpoint */
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 16px;
+}
+```
+
+`auto` margins center the wrapper, while side padding prevents content from hugging the viewport edges on small screens.
+
+## 4. Align Flexbox Headers the Same Way Everywhere
+
+Safari can appear to "lose" widgets when flex children are free to grow. Lock down the alignment logic and give each region a
+role so both desktop and mobile stay organized:
+
+```css
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+}
+
+.header .left {
+  flex: 1;
+}
+
+.header .right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+```
+
+Setting `gap` instead of manual margins keeps spacing uniform, and `flex: 1` on the left block ensures the right-side widgets
+have room without forcing them off-screen.
+
+## 5. Nail the Viewport Meta Tag
+
+Safari in particular treats viewport units differently if the meta tag is missing or configured oddly. Make sure your HTML head
+contains the baseline responsive directive:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+```
+
+This tells mobile browsers to match the layout viewport to the device width, preventing unexpected zooming or scaling.
+
+## Debug Like a Pro
+
+* In DevTools, inspect the box model for the misbehaving element in each browser. Chrome and Firefox will show you if an extra
+  margin or scroll width is creeping in.
+* If a child keeps overflowing its flex parent, give it `flex: 0 0 auto` or set an explicit `max-width` to stop runaway growth.
+* Compare computed styles side-by-side. When fonts or widgets "shoot off to the right," it's almost always a width calculation
+  difference or leftover padding you forgot to reset.
+
+Normalize once, and you can spend the rest of your debugging time on actual product behavior instead of chasing inconsistent
+browser defaults.


### PR DESCRIPTION
## Summary
- add a new blog post that walks through normalizing margins, box sizing, and flex alignment across browsers
- document debugging tips for identifying layout drift in Chrome, Safari, and Firefox

## Testing
- no automated tests were run (content-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cec1becb34832980ea4df4c4488fa6