### PR TITLE
feat: add Supabase-backed projects board

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
             "dependencies": {
                 "@algolia/autocomplete-js": "^1.17.1",
                 "@algolia/autocomplete-theme-classic": "^1.17.1",
+                "@dnd-kit/core": "^6.3.1",
+                "@dnd-kit/sortable": "^10.0.0",
                 "@fullcalendar/core": "^6.1.19",
                 "@fullcalendar/daygrid": "^6.1.19",
                 "@fullcalendar/interaction": "^6.1.19",
@@ -393,6 +395,59 @@
             "resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.2.tgz",
             "integrity": "sha512-rBha0UDfV7EmBRjWrGG7Cpwxg8WomPlo0q+R2so47ZFf9wy4YKJzLuHcVa0UGFjdcLZj/4F/1FNC46GIQhe7sA==",
             "dev": true
+        },
+        "node_modules/@dnd-kit/accessibility": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+            "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/core": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+            "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/accessibility": "^3.1.1",
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/sortable": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+            "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@dnd-kit/core": "^6.3.0",
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/utilities": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+            "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
         },
         "node_modules/@emnapi/runtime": {
             "version": "1.4.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dependencies": {
         "@algolia/autocomplete-js": "^1.17.1",
         "@algolia/autocomplete-theme-classic": "^1.17.1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@fullcalendar/core": "^6.1.19",
         "@fullcalendar/daygrid": "^6.1.19",
         "@fullcalendar/interaction": "^6.1.19",
@@ -41,8 +43,8 @@
         "next": "15.5.3",
         "pdfkit": "^0.17.2",
         "react": "^19.1.0",
-        "react-hook-form": "^7.63.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.63.0",
         "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
         "recharts": "^3.2.1",

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { PROJECT_STATUSES, type UpdateProjectPayload } from '../../../../types/project';
+import { deleteProject, updateProject } from '../../../../server/projects';
+
+const updateProjectSchema = z.object({
+    title: z.string().trim().min(1).optional(),
+    clientId: z.string().trim().min(1).optional(),
+    status: z.enum(PROJECT_STATUSES).optional(),
+    startDate: z.union([z.string().trim(), z.null()]).optional(),
+    endDate: z.union([z.string().trim(), z.null()]).optional(),
+    description: z.union([z.string(), z.null()]).optional(),
+    tags: z.array(z.string().trim()).optional(),
+    createdBy: z.union([z.string().trim(), z.null()]).optional()
+});
+
+function sanitizeUpdateInput(input: z.infer<typeof updateProjectSchema>): UpdateProjectPayload {
+    const payload: UpdateProjectPayload = {};
+
+    if (input.title !== undefined) {
+        payload.title = input.title.trim();
+    }
+    if (input.clientId !== undefined) {
+        payload.clientId = input.clientId.trim();
+    }
+    if (input.status !== undefined) {
+        payload.status = input.status;
+    }
+    if (input.startDate !== undefined) {
+        payload.startDate = input.startDate && input.startDate.length > 0 ? input.startDate : null;
+    }
+    if (input.endDate !== undefined) {
+        payload.endDate = input.endDate && input.endDate.length > 0 ? input.endDate : null;
+    }
+    if (input.description !== undefined) {
+        payload.description = input.description && input.description.trim().length > 0 ? input.description.trim() : null;
+    }
+    if (input.tags !== undefined) {
+        payload.tags = input.tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+    }
+    if (input.createdBy !== undefined) {
+        payload.createdBy = input.createdBy && input.createdBy.trim().length > 0 ? input.createdBy.trim() : null;
+    }
+
+    return payload;
+}
+
+export async function PATCH(
+    request: NextRequest,
+    context: { params: Promise<Record<string, string | string[] | undefined>> }
+) {
+    const params = await context.params;
+    const projectIdParam = params?.projectId;
+    const projectId = Array.isArray(projectIdParam) ? projectIdParam[0] : projectIdParam;
+    if (!projectId) {
+        return NextResponse.json({ error: 'Project ID is required.' }, { status: 400 });
+    }
+
+    try {
+        const payload = await request.json().catch(() => null);
+        const parsed = updateProjectSchema.safeParse(payload ?? {});
+
+        if (!parsed.success) {
+            const issue = parsed.error.issues[0];
+            const message = issue?.message ?? 'Invalid project update.';
+            return NextResponse.json({ error: message }, { status: 400 });
+        }
+
+        const project = await updateProject(projectId, sanitizeUpdateInput(parsed.data));
+        return NextResponse.json({ project });
+    } catch (error) {
+        console.error('Failed to update project', error);
+        return NextResponse.json({ error: 'Unable to update project.' }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    _request: NextRequest,
+    context: { params: Promise<Record<string, string | string[] | undefined>> }
+) {
+    const params = await context.params;
+    const projectIdParam = params?.projectId;
+    const projectId = Array.isArray(projectIdParam) ? projectIdParam[0] : projectIdParam;
+    if (!projectId) {
+        return NextResponse.json({ error: 'Project ID is required.' }, { status: 400 });
+    }
+
+    try {
+        await deleteProject(projectId);
+        return NextResponse.json({ success: true }, { status: 204 });
+    } catch (error) {
+        console.error('Failed to delete project', error);
+        return NextResponse.json({ error: 'Unable to delete project.' }, { status: 500 });
+    }
+}

--- a/src/app/api/projects/[projectId]/tasks/[taskId]/route.ts
+++ b/src/app/api/projects/[projectId]/tasks/[taskId]/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { PROJECT_TASK_STATUSES, type UpdateTaskPayload } from '../../../../../../types/project';
+import { deleteTask, getProjectById, updateTask } from '../../../../../../server/projects';
+
+const updateTaskSchema = z.object({
+    name: z.string().trim().min(1).optional(),
+    date: z.union([z.string().trim(), z.null()]).optional(),
+    location: z.union([z.string().trim(), z.null()]).optional(),
+    status: z.enum(PROJECT_TASK_STATUSES).optional(),
+    orderIndex: z.number().int().optional(),
+    completedAt: z.union([z.string().trim(), z.null()]).optional()
+});
+
+function sanitizeUpdate(
+    input: z.infer<typeof updateTaskSchema>,
+    projectId: string
+): UpdateTaskPayload {
+    const payload: UpdateTaskPayload = { projectId };
+
+    if (input.name !== undefined) {
+        payload.name = input.name.trim();
+    }
+    if (input.date !== undefined) {
+        payload.date =
+            typeof input.date === 'string' && input.date.trim().length > 0 ? input.date.trim() : null;
+    }
+    if (input.location !== undefined) {
+        payload.location =
+            typeof input.location === 'string' && input.location.trim().length > 0
+                ? input.location.trim()
+                : null;
+    }
+    if (input.status !== undefined) {
+        payload.status = input.status;
+    }
+    if (input.orderIndex !== undefined) {
+        payload.orderIndex = input.orderIndex;
+    }
+    if (input.completedAt !== undefined) {
+        payload.completedAt =
+            typeof input.completedAt === 'string' && input.completedAt.trim().length > 0
+                ? input.completedAt.trim()
+                : null;
+    }
+
+    return payload;
+}
+
+export async function PATCH(
+    request: NextRequest,
+    context: { params: Promise<Record<string, string | string[] | undefined>> }
+) {
+    const params = await context.params;
+    const projectIdParam = params?.projectId;
+    const taskIdParam = params?.taskId;
+    const projectId = Array.isArray(projectIdParam) ? projectIdParam[0] : projectIdParam;
+    const taskId = Array.isArray(taskIdParam) ? taskIdParam[0] : taskIdParam;
+
+    if (!projectId || !taskId) {
+        return NextResponse.json({ error: 'Project and task IDs are required.' }, { status: 400 });
+    }
+
+    try {
+        const payload = await request.json().catch(() => null);
+        const parsed = updateTaskSchema.safeParse(payload ?? {});
+
+        if (!parsed.success) {
+            const issue = parsed.error.issues[0];
+            const message = issue?.message ?? 'Invalid task update.';
+            return NextResponse.json({ error: message }, { status: 400 });
+        }
+
+        const task = await updateTask(taskId, sanitizeUpdate(parsed.data, projectId));
+        const project = await getProjectById(projectId);
+        return NextResponse.json({ task, project });
+    } catch (error) {
+        console.error('Failed to update task', error);
+        return NextResponse.json({ error: 'Unable to update task.' }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    _request: NextRequest,
+    context: { params: Promise<Record<string, string | string[] | undefined>> }
+) {
+    const params = await context.params;
+    const projectIdParam = params?.projectId;
+    const taskIdParam = params?.taskId;
+    const projectId = Array.isArray(projectIdParam) ? projectIdParam[0] : projectIdParam;
+    const taskId = Array.isArray(taskIdParam) ? taskIdParam[0] : taskIdParam;
+
+    if (!projectId || !taskId) {
+        return NextResponse.json({ error: 'Project and task IDs are required.' }, { status: 400 });
+    }
+
+    try {
+        await deleteTask(taskId);
+        const project = await getProjectById(projectId);
+        return NextResponse.json({ success: true, project }, { status: 200 });
+    } catch (error) {
+        console.error('Failed to delete task', error);
+        return NextResponse.json({ error: 'Unable to delete task.' }, { status: 500 });
+    }
+}

--- a/src/app/api/projects/[projectId]/tasks/route.ts
+++ b/src/app/api/projects/[projectId]/tasks/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { PROJECT_TASK_STATUSES, type CreateTaskPayload } from '../../../../../types/project';
+import { createTask, getProjectById } from '../../../../../server/projects';
+
+const createTaskSchema = z.object({
+    name: z.string().trim().min(1, 'Task name is required'),
+    date: z.union([z.string().trim(), z.null()]).optional(),
+    location: z.union([z.string().trim(), z.null()]).optional(),
+    status: z.enum(PROJECT_TASK_STATUSES).optional(),
+    orderIndex: z.number().int().optional(),
+    completedAt: z.union([z.string().trim(), z.null()]).optional()
+});
+
+function sanitizeTask(input: z.infer<typeof createTaskSchema>, projectId: string): CreateTaskPayload {
+    return {
+        projectId,
+        name: input.name.trim(),
+        date:
+            typeof input.date === 'string' && input.date.trim().length > 0 ? input.date.trim() : null,
+        location:
+            typeof input.location === 'string' && input.location.trim().length > 0
+                ? input.location.trim()
+                : null,
+        status: input.status ?? 'PENDING',
+        orderIndex: typeof input.orderIndex === 'number' ? input.orderIndex : 0,
+        completedAt:
+            typeof input.completedAt === 'string' && input.completedAt.trim().length > 0
+                ? input.completedAt.trim()
+                : null
+    };
+}
+
+export async function POST(
+    request: NextRequest,
+    context: { params: Promise<Record<string, string | string[] | undefined>> }
+) {
+    const params = await context.params;
+    const projectIdParam = params?.projectId;
+    const projectId = Array.isArray(projectIdParam) ? projectIdParam[0] : projectIdParam;
+    if (!projectId) {
+        return NextResponse.json({ error: 'Project ID is required.' }, { status: 400 });
+    }
+
+    try {
+        const payload = await request.json().catch(() => null);
+        const parsed = createTaskSchema.safeParse(payload ?? {});
+
+        if (!parsed.success) {
+            const issue = parsed.error.issues[0];
+            const message = issue?.message ?? 'Invalid task payload.';
+            return NextResponse.json({ error: message }, { status: 400 });
+        }
+
+        const task = await createTask(sanitizeTask(parsed.data, projectId));
+        const project = await getProjectById(projectId);
+        return NextResponse.json({ task, project });
+    } catch (error) {
+        console.error('Failed to create task', error);
+        return NextResponse.json({ error: 'Unable to create task.' }, { status: 500 });
+    }
+}

--- a/src/app/api/projects/clients/route.ts
+++ b/src/app/api/projects/clients/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+import { supabaseAdmin } from '../../../../lib/supabase-admin';
+
+type ClientRow = {
+    id: string;
+    name: string | null;
+};
+
+export async function GET() {
+    try {
+        const { data, error } = await supabaseAdmin
+            .from('clients')
+            .select('id, name')
+            .order('name', { ascending: true });
+
+        if (error) {
+            throw new Error(error.message);
+        }
+
+        const clients = (data ?? []).map((row) => ({
+            id: row.id,
+            name: row.name ?? 'Unnamed client'
+        }));
+
+        return NextResponse.json({ clients });
+    } catch (error) {
+        console.error('Failed to load clients for project form', error);
+        return NextResponse.json({ error: 'Unable to load clients.' }, { status: 500 });
+    }
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import {
+    PROJECT_STATUSES,
+    PROJECT_TASK_STATUSES,
+    type CreateProjectPayload,
+    type ProjectInput,
+    type ProjectListFilters,
+    type ProjectTaskInput
+} from '../../../types/project';
+import { createProject, listProjects } from '../../../server/projects';
+
+const createProjectSchema = z.object({
+    project: z.object({
+        title: z.string().trim().min(1, 'Title is required'),
+        clientId: z.string().trim().min(1, 'Client is required'),
+        status: z.enum(PROJECT_STATUSES).default('PLANNING'),
+        startDate: z.union([z.string().trim(), z.null()]).optional(),
+        endDate: z.union([z.string().trim(), z.null()]).optional(),
+        description: z.union([z.string(), z.null()]).optional(),
+        tags: z.array(z.string().trim()).optional(),
+        createdBy: z.union([z.string().trim(), z.null()]).optional()
+    }),
+    tasks: z
+        .array(
+            z.object({
+                name: z.string().trim().min(1, 'Task name is required'),
+                date: z.union([z.string().trim(), z.null()]).optional(),
+                location: z.union([z.string().trim(), z.null()]).optional(),
+                status: z.enum(PROJECT_TASK_STATUSES).optional(),
+                orderIndex: z.number().int().optional(),
+                completedAt: z.union([z.string().trim(), z.null()]).optional()
+            })
+        )
+        .optional()
+});
+
+function sanitizeProjectInput(input: ProjectInput): ProjectInput {
+    return {
+        title: input.title.trim(),
+        clientId: input.clientId.trim(),
+        status: input.status,
+        startDate: input.startDate && input.startDate.length > 0 ? input.startDate : null,
+        endDate: input.endDate && input.endDate.length > 0 ? input.endDate : null,
+        description:
+            input.description && input.description.trim().length > 0 ? input.description.trim() : null,
+        tags: input.tags?.map((tag) => tag.trim()).filter((tag) => tag.length > 0) ?? [],
+        createdBy:
+            input.createdBy && input.createdBy.trim().length > 0 ? input.createdBy.trim() : null
+    };
+}
+
+function sanitizeTasks(tasks: ProjectTaskInput[] | undefined): ProjectTaskInput[] {
+    if (!tasks) {
+        return [];
+    }
+
+    return tasks.map((task, index) => ({
+        name: task.name.trim(),
+        date: task.date && task.date.trim().length > 0 ? task.date.trim() : null,
+        location: task.location && task.location.trim().length > 0 ? task.location.trim() : null,
+        status: task.status ?? 'PENDING',
+        orderIndex: typeof task.orderIndex === 'number' ? task.orderIndex : index,
+        completedAt:
+            task.completedAt && task.completedAt.trim().length > 0 ? task.completedAt.trim() : null
+    }));
+}
+
+function parseFilters(request: NextRequest): ProjectListFilters {
+    const url = new URL(request.url);
+    const statusParam = url.searchParams.get('status');
+    const qParam = url.searchParams.get('q');
+    const tagParam = url.searchParams.get('tag');
+    const pageParam = url.searchParams.get('page');
+    const pageSizeParam = url.searchParams.get('pageSize');
+
+    const normalizeStatus = (value: string | null) => {
+        if (!value) {
+            return undefined;
+        }
+        const candidate = value.toUpperCase();
+        if (candidate === 'ALL') {
+            return 'ALL';
+        }
+        return PROJECT_STATUSES.includes(candidate as (typeof PROJECT_STATUSES)[number])
+            ? (candidate as (typeof PROJECT_STATUSES)[number])
+            : undefined;
+    };
+
+    const safeParseInt = (value: string | null) => {
+        if (!value) {
+            return undefined;
+        }
+        const parsed = Number.parseInt(value, 10);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    };
+
+    return {
+        status: normalizeStatus(statusParam),
+        q: qParam?.trim() ? qParam.trim() : undefined,
+        tag: tagParam?.trim() ? tagParam.trim() : undefined,
+        page: safeParseInt(pageParam),
+        pageSize: safeParseInt(pageSizeParam)
+    };
+}
+
+export async function GET(request: NextRequest) {
+    try {
+        const filters = parseFilters(request);
+        const projects = await listProjects(filters);
+        return NextResponse.json(projects);
+    } catch (error) {
+        console.error('Failed to load projects', error);
+        return NextResponse.json({ error: 'Unable to load projects.' }, { status: 500 });
+    }
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const payload = await request.json().catch(() => null);
+        const parsed = createProjectSchema.safeParse(payload ?? {});
+
+        if (!parsed.success) {
+            const issue = parsed.error.issues[0];
+            const message = issue?.message ?? 'Invalid project payload.';
+            return NextResponse.json({ error: message }, { status: 400 });
+        }
+
+        const sanitized: CreateProjectPayload = {
+            project: sanitizeProjectInput(parsed.data.project),
+            tasks: sanitizeTasks(parsed.data.tasks)
+        };
+
+        const project = await createProject(sanitized);
+        return NextResponse.json({ project }, { status: 201 });
+    } catch (error) {
+        console.error('Failed to create project', error);
+        return NextResponse.json({ error: 'Unable to create project.' }, { status: 500 });
+    }
+}

--- a/src/components/dashboard/card.tsx
+++ b/src/components/dashboard/card.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+type CardProps = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+export function DashboardCard({ children, className }: CardProps) {
+    return (
+        <div
+            className={cn(
+                'flex h-full flex-col rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/40',
+                className
+            )}
+        >
+            {children}
+        </div>
+    );
+}
+
+export default DashboardCard;

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,0 +1,5 @@
+export { LayoutShell } from './layout-shell';
+export { PageHeader } from './page-header';
+export { Toolbar, ToolbarSection } from './toolbar';
+export { DashboardCard } from './card';
+export { Progress } from './progress';

--- a/src/components/dashboard/layout-shell.tsx
+++ b/src/components/dashboard/layout-shell.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+type LayoutShellProps = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+export function LayoutShell({ children, className }: LayoutShellProps) {
+    return (
+        <div className={cn('mx-auto w-full max-w-7xl space-y-8 px-6 py-10 lg:px-8 lg:py-12', className)}>
+            {children}
+        </div>
+    );
+}
+
+export default LayoutShell;

--- a/src/components/dashboard/page-header.tsx
+++ b/src/components/dashboard/page-header.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+type PageHeaderProps = {
+    title: string;
+    description?: string;
+    children?: React.ReactNode;
+    className?: string;
+};
+
+export function PageHeader({ title, description, children, className }: PageHeaderProps) {
+    return (
+        <div className={cn('flex flex-col gap-4 text-slate-100 sm:flex-row sm:items-start sm:justify-between', className)}>
+            <div className="space-y-2">
+                <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{title}</h1>
+                {description ? <p className="max-w-2xl text-sm text-slate-400">{description}</p> : null}
+            </div>
+            {children ? <div className="flex flex-none items-center gap-3">{children}</div> : null}
+        </div>
+    );
+}
+
+export default PageHeader;

--- a/src/components/dashboard/progress.tsx
+++ b/src/components/dashboard/progress.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+type ProgressProps = {
+    value: number;
+    className?: string;
+};
+
+export function Progress({ value, className }: ProgressProps) {
+    const clamped = Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
+    return (
+        <div className={cn('h-2 w-full rounded-full bg-slate-800/80', className)}>
+            <div
+                className="h-full rounded-full bg-indigo-500 transition-all"
+                style={{ width: `${clamped}%` }}
+                aria-hidden
+            />
+            <span className="sr-only">{clamped}% complete</span>
+        </div>
+    );
+}
+
+export default Progress;

--- a/src/components/dashboard/toolbar.tsx
+++ b/src/components/dashboard/toolbar.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+type ToolbarProps = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+type ToolbarSectionProps = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+export function Toolbar({ children, className }: ToolbarProps) {
+    return (
+        <div
+            className={cn(
+                'flex flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-950/60 p-4 shadow-lg shadow-slate-950/40 sm:flex-row sm:items-center sm:justify-between',
+                className
+            )}
+        >
+            {children}
+        </div>
+    );
+}
+
+export function ToolbarSection({ children, className }: ToolbarSectionProps) {
+    return <div className={cn('flex flex-wrap items-center gap-3', className)}>{children}</div>;
+}
+
+export default Toolbar;

--- a/src/components/projects/index.ts
+++ b/src/components/projects/index.ts
@@ -1,0 +1,2 @@
+export { ProjectCard } from './project-card';
+export { NewProjectDrawer } from './new-project-drawer';

--- a/src/components/projects/new-project-drawer.tsx
+++ b/src/components/projects/new-project-drawer.tsx
@@ -1,0 +1,514 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+    DndContext,
+    MouseSensor,
+    TouchSensor,
+    closestCenter,
+    type DragEndEvent,
+    useSensor,
+    useSensors
+} from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import * as React from 'react';
+import { Controller, type FieldErrors, useFieldArray, useForm } from 'react-hook-form';
+import { HiOutlineBars3, HiOutlinePlus, HiOutlineTrash } from 'react-icons/hi2';
+import useSWR from 'swr';
+import { z } from 'zod';
+
+import { Button } from '../ui/button';
+import {
+    Drawer,
+    DrawerClose,
+    DrawerContent,
+    DrawerDescription,
+    DrawerFooter,
+    DrawerHeader,
+    DrawerTitle
+} from '../ui/drawer';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Select } from '../ui/select';
+import { Textarea } from '../ui/textarea';
+import { Badge } from '../ui/badge';
+import { PROJECT_STATUSES, PROJECT_TASK_STATUSES, type ProjectRecord } from '../../types/project';
+
+const fetcher = async <T,>(url: string): Promise<T> => {
+    const response = await fetch(url);
+    if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Request failed');
+    }
+    return (await response.json()) as T;
+};
+
+type ClientOption = {
+    id: string;
+    name: string;
+};
+
+const dateField = z
+    .union([z.string(), z.undefined(), z.null()])
+    .transform((value) => (value ?? '').trim())
+    .refine((value) => value.length === 0 || !Number.isNaN(Date.parse(value)), {
+        message: 'Enter a valid date'
+    });
+
+const taskSchema = z.object({
+    id: z.string().optional(),
+    name: z.string().trim().min(1, 'Task name is required'),
+    date: dateField,
+    location: z.string().optional().transform((value) => (value ?? '').trim()),
+    status: z.enum(PROJECT_TASK_STATUSES).default('PENDING')
+});
+
+const formSchema = z.object({
+    title: z.string().trim().min(1, 'Title is required'),
+    clientId: z.string().trim().min(1, 'Client is required'),
+    status: z.enum(PROJECT_STATUSES).default('PLANNING'),
+    startDate: dateField,
+    endDate: dateField,
+    description: z.string().optional(),
+    tags: z.array(z.string().min(1)).default([]),
+    tasks: z.array(taskSchema).default([])
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type NewProjectDrawerProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onProjectCreated: (project: ProjectRecord) => void;
+};
+
+type TagsInputProps = {
+    value: string[];
+    onChange: (tags: string[]) => void;
+};
+
+function TagsInput({ value, onChange }: TagsInputProps) {
+    const [inputValue, setInputValue] = React.useState('');
+
+    const addTag = React.useCallback(
+        (tag: string) => {
+            const trimmed = tag.trim();
+            if (!trimmed) {
+                return;
+            }
+            if (value.includes(trimmed)) {
+                setInputValue('');
+                return;
+            }
+            onChange([...value, trimmed]);
+            setInputValue('');
+        },
+        [onChange, value]
+    );
+
+    const handleKeyDown = React.useCallback(
+        (event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter' || event.key === ',') {
+                event.preventDefault();
+                addTag(inputValue);
+            }
+        },
+        [addTag, inputValue]
+    );
+
+    const handleBlur = React.useCallback(() => {
+        if (inputValue.trim()) {
+            addTag(inputValue);
+        }
+    }, [addTag, inputValue]);
+
+    const removeTag = React.useCallback(
+        (tag: string) => {
+            onChange(value.filter((existing) => existing !== tag));
+        },
+        [onChange, value]
+    );
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap gap-2">
+                {value.map((tag) => (
+                    <Badge
+                        key={tag}
+                        variant="neutral"
+                        className="border-slate-700/80 bg-slate-900/80 text-xs uppercase tracking-wide text-slate-300"
+                    >
+                        <span>{tag}</span>
+                        <button
+                            type="button"
+                            className="ml-2 text-slate-400 transition hover:text-slate-200"
+                            onClick={() => removeTag(tag)}
+                        >
+                            ×
+                        </button>
+                    </Badge>
+                ))}
+                <Input
+                    value={inputValue}
+                    onChange={(event) => setInputValue(event.target.value)}
+                    onKeyDown={handleKeyDown}
+                    onBlur={handleBlur}
+                    placeholder={value.length === 0 ? 'Add tags (press Enter)' : 'Add another tag'}
+                    className="h-9 w-auto min-w-[140px] flex-1 border-dashed border-slate-700/60 bg-slate-900/50 px-3 text-xs"
+                />
+            </div>
+        </div>
+    );
+}
+
+type SortableTaskItemProps = {
+    fieldId: string;
+    index: number;
+    register: ReturnType<typeof useForm<FormValues>>['register'];
+    control: ReturnType<typeof useForm<FormValues>>['control'];
+    remove: (index: number) => void;
+    error?: FieldErrors<FormValues['tasks'][number]>;
+};
+
+function FieldError({ message }: { message?: string }) {
+    if (!message) {
+        return null;
+    }
+    return <p className="text-xs text-rose-300">{message}</p>;
+}
+
+function SortableTaskItem({ fieldId, index, register, control, remove, error }: SortableTaskItemProps) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging
+    } = useSortable({ id: fieldId });
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition
+    };
+
+    const taskError = error ?? {};
+
+    return (
+        <li
+            ref={setNodeRef}
+            style={style}
+            className={`rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4 shadow-inner shadow-slate-950/30 transition ${
+                isDragging ? 'ring-2 ring-indigo-400' : ''
+            }`}
+        >
+            <div className="flex items-start gap-3">
+                <button
+                    type="button"
+                    className="mt-1 text-slate-500 transition hover:text-slate-200"
+                    {...listeners}
+                    {...attributes}
+                    aria-label="Reorder task"
+                >
+                    <HiOutlineBars3 className="h-5 w-5" />
+                </button>
+                <div className="flex-1 space-y-3">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor={`task-name-${fieldId}`}>Task name</Label>
+                            <Input id={`task-name-${fieldId}`} {...register(`tasks.${index}.name` as const)} />
+                            <FieldError message={taskError?.name?.message} />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor={`task-date-${fieldId}`}>Date</Label>
+                            <Input id={`task-date-${fieldId}`} type="date" {...register(`tasks.${index}.date` as const)} />
+                            <FieldError message={taskError?.date?.message} />
+                        </div>
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor={`task-location-${fieldId}`}>Location</Label>
+                            <Input id={`task-location-${fieldId}`} {...register(`tasks.${index}.location` as const)} />
+                            <FieldError message={taskError?.location?.message} />
+                        </div>
+                        <Controller
+                            control={control}
+                            name={`tasks.${index}.status` as const}
+                            render={({ field }) => (
+                                <div className="space-y-2">
+                                    <Label htmlFor={`task-status-${fieldId}`}>Status</Label>
+                                    <Select
+                                        id={`task-status-${fieldId}`}
+                                        value={field.value}
+                                        onChange={(event) => field.onChange(event.target.value)}
+                                    >
+                                        {PROJECT_TASK_STATUSES.map((status) => (
+                                            <option key={status} value={status}>
+                                                {status.replace(/_/g, ' ')}
+                                            </option>
+                                        ))}
+                                    </Select>
+                                </div>
+                            )}
+                        />
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    className="ml-2 mt-1 text-slate-500 transition hover:text-rose-300"
+                    onClick={() => remove(index)}
+                    aria-label="Remove task"
+                >
+                    <HiOutlineTrash className="h-5 w-5" />
+                </button>
+            </div>
+        </li>
+    );
+}
+
+export function NewProjectDrawer({ open, onOpenChange, onProjectCreated }: NewProjectDrawerProps) {
+    const {
+        register,
+        control,
+        handleSubmit,
+        reset,
+        formState: { errors, isSubmitting }
+    } = useForm<FormValues>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            title: '',
+            clientId: '',
+            status: 'PLANNING',
+            startDate: '',
+            endDate: '',
+            description: '',
+            tags: [],
+            tasks: []
+        }
+    });
+
+    const {
+        fields: taskFields,
+        append: appendTask,
+        remove: removeTask,
+        move: moveTask
+    } = useFieldArray({ control, name: 'tasks' });
+
+    const sensors = useSensors(
+        useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+        useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 5 } })
+    );
+
+    const [submitError, setSubmitError] = React.useState<string | null>(null);
+
+    const { data: clientsData } = useSWR<{ clients: ClientOption[] }>(
+        open ? '/api/projects/clients' : null,
+        fetcher
+    );
+
+    const clients = clientsData?.clients ?? [];
+
+    const onDragEnd = React.useCallback(
+        (event: DragEndEvent) => {
+            const { active, over } = event;
+            if (!over || active.id === over.id) {
+                return;
+            }
+            const oldIndex = taskFields.findIndex((field) => field.id === active.id);
+            const newIndex = taskFields.findIndex((field) => field.id === over.id);
+            if (oldIndex === -1 || newIndex === -1) {
+                return;
+            }
+            moveTask(oldIndex, newIndex);
+        },
+        [moveTask, taskFields]
+    );
+
+    const onSubmit = React.useCallback(
+        async (values: FormValues) => {
+            setSubmitError(null);
+            try {
+                const payload = {
+                    project: {
+                        title: values.title.trim(),
+                        clientId: values.clientId.trim(),
+                        status: values.status,
+                        startDate: values.startDate.length > 0 ? values.startDate : null,
+                        endDate: values.endDate.length > 0 ? values.endDate : null,
+                        description:
+                            values.description && values.description.trim().length > 0
+                                ? values.description.trim()
+                                : null,
+                        tags: values.tags
+                    },
+                    tasks: values.tasks.map((task, index) => ({
+                        name: task.name.trim(),
+                        date: task.date.length > 0 ? task.date : null,
+                        location: task.location && task.location.length > 0 ? task.location : null,
+                        status: task.status,
+                        orderIndex: index
+                    }))
+                };
+
+                const response = await fetch('/api/projects', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+
+                if (!response.ok) {
+                    const data = (await response.json().catch(() => null)) as { error?: string } | null;
+                    throw new Error(data?.error ?? 'Failed to create project.');
+                }
+
+                const body = (await response.json()) as { project: ProjectRecord };
+                onProjectCreated(body.project);
+                reset();
+                onOpenChange(false);
+            } catch (error) {
+                console.error('Create project failed', error);
+                setSubmitError(error instanceof Error ? error.message : 'Failed to create project.');
+            }
+        },
+        [onOpenChange, onProjectCreated, reset]
+    );
+
+    React.useEffect(() => {
+        if (!open) {
+            setSubmitError(null);
+            reset();
+        }
+    }, [open, reset]);
+
+    return (
+        <Drawer open={open} onOpenChange={onOpenChange}>
+            <DrawerContent>
+                <DrawerHeader>
+                    <DrawerTitle>New project</DrawerTitle>
+                    <DrawerDescription>Create a project and track its timeline, tasks, and billing.</DrawerDescription>
+                </DrawerHeader>
+                <form className="flex flex-1 flex-col gap-6" onSubmit={handleSubmit(onSubmit)}>
+                    <div className="grid gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="project-title">Title</Label>
+                            <Input id="project-title" placeholder="Project title" {...register('title')} />
+                            <FieldError message={errors.title?.message} />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="project-client">Client</Label>
+                            <Select id="project-client" {...register('clientId')} disabled={clients.length === 0}>
+                                <option value="" disabled>
+                                    {clients.length === 0 ? 'Loading clients…' : 'Select a client'}
+                                </option>
+                                {clients.map((client) => (
+                                    <option key={client.id} value={client.id}>
+                                        {client.name}
+                                    </option>
+                                ))}
+                            </Select>
+                            <FieldError message={errors.clientId?.message} />
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-3">
+                            <div className="space-y-2">
+                                <Label htmlFor="project-status">Status</Label>
+                                <Select id="project-status" {...register('status')}>
+                                    {PROJECT_STATUSES.map((status) => (
+                                        <option key={status} value={status}>
+                                            {status.replace(/_/g, ' ')}
+                                        </option>
+                                    ))}
+                                </Select>
+                                <FieldError message={errors.status?.message} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="project-start">Start date</Label>
+                                <Input id="project-start" type="date" {...register('startDate')} />
+                                <FieldError message={errors.startDate?.message} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="project-end">End date</Label>
+                                <Input id="project-end" type="date" {...register('endDate')} />
+                                <FieldError message={errors.endDate?.message} />
+                            </div>
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="project-description">Description</Label>
+                            <Textarea
+                                id="project-description"
+                                rows={4}
+                                placeholder="Describe the project scope, deliverables, and notes."
+                                {...register('description')}
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label>Tags</Label>
+                            <Controller
+                                control={control}
+                                name="tags"
+                                render={({ field }) => <TagsInput value={field.value} onChange={field.onChange} />}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                            <h3 className="text-sm font-semibold text-white">Tasks</h3>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                className="h-9 border border-slate-700/70 bg-slate-900/60 px-3 text-xs text-slate-200 hover:bg-slate-800/70"
+                                onClick={() => appendTask({ name: '', date: '', location: '', status: 'PENDING' })}
+                            >
+                                <HiOutlinePlus className="mr-1.5 h-4 w-4" /> Add task
+                            </Button>
+                        </div>
+                        {taskFields.length === 0 ? (
+                            <div className="rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/50 p-6 text-sm text-slate-400">
+                                Start building the project plan by adding tasks.
+                            </div>
+                        ) : (
+                            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+                                <SortableContext items={taskFields.map((field) => field.id)} strategy={verticalListSortingStrategy}>
+                                    <ul className="space-y-3">
+                                        {taskFields.map((field, index) => (
+                                            <SortableTaskItem
+                                                key={field.id}
+                                                fieldId={field.id}
+                                                index={index}
+                                                register={register}
+                                                control={control}
+                                                remove={removeTask}
+                                                error={
+                                                    Array.isArray(errors.tasks)
+                                                        ? (errors.tasks[index] as FieldErrors<FormValues['tasks'][number]> | undefined)
+                                                        : undefined
+                                                }
+                                            />
+                                        ))}
+                                    </ul>
+                                </SortableContext>
+                            </DndContext>
+                        )}
+                    </div>
+
+                    {submitError ? (
+                        <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                            {submitError}
+                        </div>
+                    ) : null}
+
+                    <DrawerFooter>
+                        <DrawerClose asChild>
+                            <Button type="button" variant="ghost" className="border border-slate-700/70 bg-slate-900/60 text-slate-200">
+                                Cancel
+                            </Button>
+                        </DrawerClose>
+                        <Button type="submit" disabled={isSubmitting} isLoading={isSubmitting}>
+                            Create project
+                        </Button>
+                    </DrawerFooter>
+                </form>
+            </DrawerContent>
+        </Drawer>
+    );
+}
+
+export default NewProjectDrawer;

--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -1,0 +1,188 @@
+import Link from 'next/link';
+import * as React from 'react';
+
+import { DashboardCard, Progress } from '../dashboard';
+import { Badge } from '../ui/badge';
+import { formatCurrency, formatDate } from '../../lib/formatters';
+import {
+    type ProjectInvoiceSnippet,
+    type ProjectRecord,
+    type ProjectStatus,
+    type ProjectTaskRecord,
+    type ProjectTaskStatus
+} from '../../types/project';
+
+const projectStatusMap: Record<ProjectStatus, { label: string; badgeClass: string }> = {
+    PLANNING: {
+        label: 'Planning',
+        badgeClass: 'border-amber-400/40 bg-amber-500/15 text-amber-200'
+    },
+    IN_PROGRESS: {
+        label: 'In progress',
+        badgeClass: 'border-indigo-400/40 bg-indigo-500/15 text-indigo-200'
+    },
+    ON_HOLD: {
+        label: 'On hold',
+        badgeClass: 'border-slate-400/40 bg-slate-500/15 text-slate-200'
+    },
+    COMPLETE: {
+        label: 'Complete',
+        badgeClass: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200'
+    },
+    CANCELLED: {
+        label: 'Cancelled',
+        badgeClass: 'border-rose-400/40 bg-rose-500/15 text-rose-200'
+    }
+};
+
+const taskStatusMap: Record<ProjectTaskStatus, { label: string; className: string }> = {
+    PENDING: { label: 'Pending', className: 'border-amber-400/40 bg-amber-500/15 text-amber-200' },
+    CONFIRMED: { label: 'Confirmed', className: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200' },
+    EDITING: { label: 'Editing', className: 'border-sky-400/40 bg-sky-500/15 text-sky-200' },
+    COMPLETE: { label: 'Complete', className: 'border-indigo-400/40 bg-indigo-500/15 text-indigo-200' }
+};
+
+const invoiceStatusMap: Record<ProjectInvoiceSnippet['status'], string> = {
+    PAID: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200',
+    SENT: 'border-sky-400/40 bg-sky-500/15 text-sky-200',
+    OVERDUE: 'border-rose-400/40 bg-rose-500/15 text-rose-200',
+    DRAFT: 'border-slate-400/40 bg-slate-500/15 text-slate-200'
+};
+
+function sortTasks(tasks: ProjectTaskRecord[]): ProjectTaskRecord[] {
+    return [...tasks].sort((a, b) => {
+        const aTime = a.date ? Date.parse(a.date) : Number.MAX_SAFE_INTEGER;
+        const bTime = b.date ? Date.parse(b.date) : Number.MAX_SAFE_INTEGER;
+        if (aTime !== bTime) {
+            return aTime - bTime;
+        }
+        return a.orderIndex - b.orderIndex;
+    });
+}
+
+type ProjectCardProps = {
+    project: ProjectRecord;
+};
+
+function formatInvoiceLine(invoice: ProjectInvoiceSnippet) {
+    const amount = typeof invoice.amountCents === 'number' ? formatCurrency(invoice.amountCents) : '$0.00';
+    const number = invoice.number ? `#${invoice.number}` : `#${invoice.id}`;
+    const dueDate = invoice.dueAt ? `Due ${formatDate(invoice.dueAt)}` : 'No due date';
+    return { amount, number, dueDate };
+}
+
+export function ProjectCard({ project }: ProjectCardProps) {
+    const statusMeta = projectStatusMap[project.status];
+    const tasks = sortTasks(project.tasks);
+    const hasTimeline = tasks.length > 0;
+    const hasDateRange = project.startDate && project.endDate;
+
+    return (
+        <DashboardCard>
+            <div className="flex items-start justify-between gap-6">
+                <div className="space-y-3">
+                    <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${statusMeta.badgeClass}`}>
+                        {statusMeta.label}
+                    </span>
+                    <div>
+                        <h2 className="text-xl font-semibold text-white">{project.title}</h2>
+                        <p className="mt-1 text-sm text-slate-400">Client · {project.clientName ?? 'Unknown client'}</p>
+                    </div>
+                </div>
+                <div className="text-right">
+                    <div className="text-3xl font-semibold text-white">{project.completionPercent}%</div>
+                    <div className="text-xs uppercase tracking-wide text-slate-500">Completion</div>
+                </div>
+            </div>
+
+            {project.description ? (
+                <p className="mt-5 text-sm text-slate-300 line-clamp-3">{project.description}</p>
+            ) : null}
+
+            {hasTimeline ? (
+                <div className="mt-6 space-y-3">
+                    <h3 className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500">Timeline</h3>
+                    <ul className="space-y-3">
+                        {tasks.map((task) => {
+                            const tone = taskStatusMap[task.status];
+                            return (
+                                <li key={task.id} className="flex items-start gap-3">
+                                    <span className="mt-1 h-2 w-2 rounded-full bg-slate-600" aria-hidden />
+                                    <div className="flex-1">
+                                        <div className="flex items-center justify-between gap-3">
+                                            <span className="text-sm font-semibold text-white">{task.name}</span>
+                                            <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${tone.className}`}>
+                                                {tone.label}
+                                            </span>
+                                        </div>
+                                        <div className="mt-1 text-xs text-slate-400">
+                                            {task.date ? formatDate(task.date) : 'Date TBD'}
+                                            {task.location ? ` · ${task.location}` : ''}
+                                        </div>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            ) : null}
+
+            <div className="mt-6 space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500">Accounts</h3>
+                {project.invoices.length > 0 ? (
+                    <ul className="space-y-3">
+                        {project.invoices.map((invoice) => {
+                            const statusClass = invoiceStatusMap[invoice.status];
+                            const { amount, number, dueDate } = formatInvoiceLine(invoice);
+                            const invoiceHref = `/accounts-payable/?invoiceId=${invoice.id}`;
+                            return (
+                                <li key={invoice.id} className="flex items-center justify-between gap-4">
+                                    <div>
+                                        <Link href={invoiceHref} className="text-sm font-semibold text-white hover:text-indigo-200">
+                                            Invoice {number}
+                                        </Link>
+                                        <div className="text-xs text-slate-500">{dueDate}</div>
+                                    </div>
+                                    <div className="text-right">
+                                        <div className="text-sm font-semibold text-white">{amount}</div>
+                                        <span className={`mt-1 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusClass}`}>
+                                            {invoice.status}
+                                        </span>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                ) : (
+                    <p className="text-sm text-slate-400">No invoices yet.</p>
+                )}
+            </div>
+
+            {hasDateRange ? (
+                <div className="mt-6 space-y-2">
+                    <Progress value={project.completionPercent} />
+                    <div className="flex items-center justify-between text-xs text-slate-500">
+                        <span>{formatDate(project.startDate)}</span>
+                        <span>{formatDate(project.endDate)}</span>
+                    </div>
+                </div>
+            ) : null}
+
+            {project.tags.length > 0 ? (
+                <div className="mt-6 flex flex-wrap gap-2">
+                    {project.tags.map((tag) => (
+                        <Badge
+                            key={tag}
+                            variant="neutral"
+                            className="border-slate-700/80 bg-slate-900/80 text-xs uppercase tracking-wide text-slate-300"
+                        >
+                            {tag}
+                        </Badge>
+                    ))}
+                </div>
+            ) : null}
+        </DashboardCard>
+    );
+}
+
+export default ProjectCard;

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '../../lib/cn';
+
+const Drawer = DialogPrimitive.Root;
+const DrawerTrigger = DialogPrimitive.Trigger;
+const DrawerPortal = DialogPrimitive.Portal;
+
+const DrawerOverlay = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+        ref={ref}
+        className={cn('fixed inset-0 z-40 bg-slate-950/70 backdrop-blur-sm', className)}
+        {...props}
+    />
+));
+DrawerOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <DrawerPortal>
+        <DrawerOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                'fixed inset-y-0 right-0 z-50 flex w-full max-w-xl flex-col gap-6 overflow-y-auto border-l border-slate-800 bg-slate-950/95 p-6 text-slate-100 shadow-2xl focus:outline-none',
+                className
+            )}
+            {...props}
+        >
+            {children}
+        </DialogPrimitive.Content>
+    </DrawerPortal>
+));
+DrawerContent.displayName = DialogPrimitive.Content.displayName;
+
+const DrawerHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col gap-1.5 text-left', className)} {...props} />
+));
+DrawerHeader.displayName = 'DrawerHeader';
+
+const DrawerFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('mt-auto flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4', className)} {...props} />
+));
+DrawerFooter.displayName = 'DrawerFooter';
+
+const DrawerTitle = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Title ref={ref} className={cn('text-xl font-semibold leading-tight text-white', className)} {...props} />
+));
+DrawerTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Description ref={ref} className={cn('text-sm text-slate-400', className)} {...props} />
+));
+DrawerDescription.displayName = DialogPrimitive.Description.displayName;
+
+const DrawerClose = DialogPrimitive.Close;
+
+export {
+    Drawer,
+    DrawerTrigger,
+    DrawerContent,
+    DrawerHeader,
+    DrawerFooter,
+    DrawerTitle,
+    DrawerDescription,
+    DrawerClose
+};

--- a/src/pages/api/projects.js
+++ b/src/pages/api/projects.js
@@ -1,3 +1,0 @@
-import { createCrudHandler } from '../../utils/create-crud-handler';
-
-export default createCrudHandler('projects');

--- a/src/server/projects/index.ts
+++ b/src/server/projects/index.ts
@@ -1,0 +1,558 @@
+import { supabaseAdmin } from '../../lib/supabase-admin';
+import {
+    CreateProjectPayload,
+    CreateTaskPayload,
+    ProjectInput,
+    ProjectInvoiceSnippet,
+    ProjectListFilters,
+    ProjectListResponse,
+    ProjectRecord,
+    ProjectStatus,
+    ProjectTaskInput,
+    ProjectTaskRecord,
+    ProjectTaskStatus,
+    UpdateProjectPayload,
+    UpdateTaskPayload
+} from '../../types/project';
+
+type ProjectRow = {
+    id: string;
+    created_at: string;
+    updated_at: string;
+    title: string;
+    client_id: string;
+    status: ProjectStatus;
+    start_date: string | null;
+    end_date: string | null;
+    description: string | null;
+    tags: string[] | null;
+    created_by?: string | null;
+    clients?: {
+        name?: string | null;
+    } | null;
+};
+
+type TaskRow = {
+    id: string;
+    project_id: string;
+    name: string;
+    date: string | null;
+    location: string | null;
+    status: ProjectTaskStatus;
+    order_index: number | null;
+    completed_at: string | null;
+};
+
+type InvoiceRow = {
+    id: string;
+    number: string | null;
+    amount_cents: number | null;
+    status: string | null;
+    due_at: string | null;
+    project_id: string | null;
+    client_id: string | null;
+};
+
+function normalizeTags(tags: string[] | null | undefined): string[] {
+    if (!Array.isArray(tags)) {
+        return [];
+    }
+    return tags.filter((tag) => typeof tag === 'string' && tag.trim().length > 0);
+}
+
+function toTaskRecord(row: TaskRow): ProjectTaskRecord {
+    return {
+        id: row.id,
+        projectId: row.project_id,
+        name: row.name,
+        date: row.date,
+        location: row.location,
+        status: row.status,
+        orderIndex: typeof row.order_index === 'number' ? row.order_index : 0,
+        completedAt: row.completed_at
+    };
+}
+
+function compareTasks(a: ProjectTaskRecord, b: ProjectTaskRecord): number {
+    const aDate = a.date ? Date.parse(a.date) : null;
+    const bDate = b.date ? Date.parse(b.date) : null;
+
+    if (aDate !== null && bDate !== null) {
+        if (aDate < bDate) {
+            return -1;
+        }
+        if (aDate > bDate) {
+            return 1;
+        }
+    } else if (aDate !== null) {
+        return -1;
+    } else if (bDate !== null) {
+        return 1;
+    }
+
+    return a.orderIndex - b.orderIndex;
+}
+
+function toInvoiceSnippet(row: InvoiceRow): ProjectInvoiceSnippet {
+    const normalizedStatus = (row.status ?? 'DRAFT').toUpperCase();
+    const status: ProjectInvoiceSnippet['status'] =
+        normalizedStatus === 'PAID'
+            ? 'PAID'
+            : normalizedStatus === 'SENT'
+              ? 'SENT'
+              : normalizedStatus === 'OVERDUE'
+                ? 'OVERDUE'
+                : 'DRAFT';
+
+    return {
+        id: row.id,
+        number: row.number,
+        amountCents: row.amount_cents,
+        status,
+        dueAt: row.due_at
+    };
+}
+
+function computeCompletion(tasks: ProjectTaskRecord[]): number {
+    const total = tasks.length;
+    if (total === 0) {
+        return 0;
+    }
+    const completed = tasks.filter((task) => task.status === 'COMPLETE').length;
+    return Math.round((completed / Math.max(1, total)) * 100);
+}
+
+function buildProjectRecord(
+    row: ProjectRow,
+    tasksMap: Record<string, ProjectTaskRecord[]>,
+    invoicesMap: Record<string, ProjectInvoiceSnippet[]>
+): ProjectRecord {
+    const tasks = tasksMap[row.id] ?? [];
+    const invoices = invoicesMap[row.id] ?? [];
+
+    return {
+        id: row.id,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+        title: row.title,
+        clientId: row.client_id,
+        clientName: row.clients?.name ?? null,
+        status: row.status,
+        startDate: row.start_date,
+        endDate: row.end_date,
+        description: row.description,
+        tags: normalizeTags(row.tags),
+        tasks,
+        invoices,
+        completionPercent: computeCompletion(tasks)
+    };
+}
+
+async function fetchTasksByProjectIds(projectIds: string[]): Promise<Record<string, ProjectTaskRecord[]>> {
+    if (projectIds.length === 0) {
+        return {};
+    }
+
+    const { data, error } = await supabaseAdmin
+        .from('project_tasks')
+        .select('id, project_id, name, date, location, status, order_index, completed_at')
+        .in('project_id', projectIds)
+        .order('order_index', { ascending: true })
+        .order('created_at', { ascending: true });
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    const grouped: Record<string, ProjectTaskRecord[]> = {};
+    const rows = (data as TaskRow[]) ?? [];
+
+    for (const row of rows) {
+        if (!row?.project_id) {
+            continue;
+        }
+        const task = toTaskRecord(row);
+        if (!grouped[row.project_id]) {
+            grouped[row.project_id] = [];
+        }
+        grouped[row.project_id].push(task);
+    }
+
+    for (const projectId of Object.keys(grouped)) {
+        grouped[projectId].sort(compareTasks);
+    }
+
+    return grouped;
+}
+
+async function fetchInvoicesForProjects(projectRows: ProjectRow[]): Promise<Record<string, ProjectInvoiceSnippet[]>> {
+    if (projectRows.length === 0) {
+        return {};
+    }
+
+    const projectIds = projectRows.map((row) => row.id);
+
+    const { data: directData, error: directError } = await supabaseAdmin
+        .from('invoices')
+        .select('id, number, amount_cents, status, due_at, project_id, client_id')
+        .in('project_id', projectIds)
+        .order('due_at', { ascending: false })
+        .order('created_at', { ascending: false });
+
+    if (directError) {
+        throw new Error(directError.message);
+    }
+
+    const directMap = new Map<string, InvoiceRow[]>();
+    const directRows = (directData as InvoiceRow[]) ?? [];
+
+    for (const row of directRows) {
+        const projectId = row.project_id;
+        if (!projectId) {
+            continue;
+        }
+        const entries = directMap.get(projectId) ?? [];
+        entries.push(row);
+        directMap.set(projectId, entries);
+    }
+
+    const projectsNeedingFallback = projectRows.filter((row) => (directMap.get(row.id)?.length ?? 0) < 2);
+    const fallbackClientIds = Array.from(new Set(projectsNeedingFallback.map((row) => row.client_id))).filter(Boolean);
+
+    let fallbackRows: InvoiceRow[] = [];
+    if (fallbackClientIds.length > 0) {
+        const { data: fallbackData, error: fallbackError } = await supabaseAdmin
+            .from('invoices')
+            .select('id, number, amount_cents, status, due_at, project_id, client_id')
+            .in('client_id', fallbackClientIds)
+            .order('due_at', { ascending: false })
+            .limit(fallbackClientIds.length * 6);
+
+        if (fallbackError) {
+            throw new Error(fallbackError.message);
+        }
+
+        fallbackRows = (fallbackData as InvoiceRow[]) ?? [];
+    }
+
+    const invoicesMap: Record<string, ProjectInvoiceSnippet[]> = {};
+
+    for (const project of projectRows) {
+        const directRows = [...(directMap.get(project.id) ?? [])];
+        directRows.sort((a, b) => {
+            const aTime = a.due_at ? Date.parse(a.due_at) : Number.NEGATIVE_INFINITY;
+            const bTime = b.due_at ? Date.parse(b.due_at) : Number.NEGATIVE_INFINITY;
+            return bTime - aTime;
+        });
+
+        const snippets: ProjectInvoiceSnippet[] = [];
+        const seen = new Set<string>();
+
+        for (const row of directRows) {
+            if (!row.id || seen.has(row.id)) {
+                continue;
+            }
+            snippets.push(toInvoiceSnippet(row));
+            seen.add(row.id);
+            if (snippets.length >= 2) {
+                break;
+            }
+        }
+
+        if (snippets.length < 2) {
+            for (const row of fallbackRows) {
+                if (!row.id || seen.has(row.id)) {
+                    continue;
+                }
+                if (row.client_id !== project.client_id) {
+                    continue;
+                }
+                snippets.push(toInvoiceSnippet(row));
+                seen.add(row.id);
+                if (snippets.length >= 2) {
+                    break;
+                }
+            }
+        }
+
+        invoicesMap[project.id] = snippets;
+    }
+
+    return invoicesMap;
+}
+
+async function fetchProjectRowById(projectId: string): Promise<ProjectRow | null> {
+    const { data, error } = await supabaseAdmin
+        .from('projects')
+        .select('id, created_at, updated_at, title, client_id, status, start_date, end_date, description, tags, clients(name)')
+        .eq('id', projectId)
+        .maybeSingle();
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return (data as ProjectRow | null) ?? null;
+}
+
+export async function listProjects(filters: ProjectListFilters): Promise<ProjectListResponse> {
+    const pageSize = Math.max(1, Math.min(filters.pageSize ?? 12, 100));
+    const page = Math.max(1, filters.page ?? 1);
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = supabaseAdmin
+        .from('projects')
+        .select('id, created_at, updated_at, title, client_id, status, start_date, end_date, description, tags, clients(name)', {
+            count: 'exact'
+        })
+        .order('created_at', { ascending: false });
+
+    if (filters.status && filters.status !== 'ALL') {
+        query = query.eq('status', filters.status);
+    }
+
+    if (filters.tag) {
+        query = query.contains('tags', [filters.tag]);
+    }
+
+    if (filters.q) {
+        const term = filters.q.trim();
+        if (term.length > 0) {
+            query = query.or(`title.ilike.%${term}%,description.ilike.%${term}%`);
+        }
+    }
+
+    const { data, error, count } = await query.range(from, to);
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    const rows = (data as ProjectRow[]) ?? [];
+    const tasksMap = await fetchTasksByProjectIds(rows.map((row) => row.id));
+    const invoicesMap = await fetchInvoicesForProjects(rows);
+
+    const projects = rows.map((row) => buildProjectRecord(row, tasksMap, invoicesMap));
+
+    return {
+        data: projects,
+        page,
+        pageSize,
+        total: count ?? projects.length
+    };
+}
+
+function mapProjectInputToRow(input: ProjectInput): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+        title: input.title,
+        client_id: input.clientId,
+        status: input.status,
+        description: input.description ?? null,
+        start_date: input.startDate ?? null,
+        end_date: input.endDate ?? null,
+        tags: input.tags ?? []
+    };
+
+    if (input.createdBy) {
+        payload.created_by = input.createdBy;
+    }
+
+    return payload;
+}
+
+function normalizeTaskInput(task: ProjectTaskInput, index: number): Record<string, unknown> {
+    const status: ProjectTaskStatus = task.status ?? 'PENDING';
+    const payload: Record<string, unknown> = {
+        name: task.name,
+        date: task.date ?? null,
+        location: task.location ?? null,
+        status,
+        order_index: typeof task.orderIndex === 'number' ? task.orderIndex : index
+    };
+
+    if (status === 'COMPLETE') {
+        payload.completed_at = task.completedAt ?? new Date().toISOString();
+    } else if (task.completedAt !== undefined) {
+        payload.completed_at = task.completedAt;
+    }
+
+    return payload;
+}
+
+export async function createProject(payload: CreateProjectPayload): Promise<ProjectRecord> {
+    const { project, tasks = [] } = payload;
+
+    const { data, error } = await supabaseAdmin
+        .from('projects')
+        .insert(mapProjectInputToRow(project))
+        .select('id, created_at, updated_at, title, client_id, status, start_date, end_date, description, tags, clients(name)')
+        .single();
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    const projectRow = data as ProjectRow;
+
+    if (tasks.length > 0) {
+        const taskPayload = tasks.map((task, index) => ({
+            ...normalizeTaskInput(task, index),
+            project_id: projectRow.id
+        }));
+
+        const { error: taskError } = await supabaseAdmin.from('project_tasks').insert(taskPayload);
+        if (taskError) {
+            throw new Error(taskError.message);
+        }
+    }
+
+    const tasksMap = await fetchTasksByProjectIds([projectRow.id]);
+    const invoicesMap = await fetchInvoicesForProjects([projectRow]);
+
+    return buildProjectRecord(projectRow, tasksMap, invoicesMap);
+}
+
+export async function updateProject(projectId: string, payload: UpdateProjectPayload): Promise<ProjectRecord> {
+    const updateBody: Record<string, unknown> = {};
+
+    if (payload.title !== undefined) {
+        updateBody.title = payload.title;
+    }
+    if (payload.clientId !== undefined) {
+        updateBody.client_id = payload.clientId;
+    }
+    if (payload.status !== undefined) {
+        updateBody.status = payload.status;
+    }
+    if (payload.startDate !== undefined) {
+        updateBody.start_date = payload.startDate ?? null;
+    }
+    if (payload.endDate !== undefined) {
+        updateBody.end_date = payload.endDate ?? null;
+    }
+    if (payload.description !== undefined) {
+        updateBody.description = payload.description ?? null;
+    }
+    if (payload.tags !== undefined) {
+        updateBody.tags = payload.tags ?? [];
+    }
+    if (payload.createdBy !== undefined) {
+        updateBody.created_by = payload.createdBy;
+    }
+
+    if (Object.keys(updateBody).length === 0) {
+        const existing = await fetchProjectRowById(projectId);
+        if (!existing) {
+            throw new Error('Project not found');
+        }
+        const tasksMap = await fetchTasksByProjectIds([projectId]);
+        const invoicesMap = await fetchInvoicesForProjects([existing]);
+        return buildProjectRecord(existing, tasksMap, invoicesMap);
+    }
+
+    const { data, error } = await supabaseAdmin
+        .from('projects')
+        .update(updateBody)
+        .eq('id', projectId)
+        .select('id, created_at, updated_at, title, client_id, status, start_date, end_date, description, tags, clients(name)')
+        .single();
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    const projectRow = data as ProjectRow;
+    const tasksMap = await fetchTasksByProjectIds([projectId]);
+    const invoicesMap = await fetchInvoicesForProjects([projectRow]);
+
+    return buildProjectRecord(projectRow, tasksMap, invoicesMap);
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+    const { error } = await supabaseAdmin.from('projects').delete().eq('id', projectId);
+    if (error) {
+        throw new Error(error.message);
+    }
+}
+
+export async function createTask(payload: CreateTaskPayload): Promise<ProjectTaskRecord> {
+    const { projectId, ...rest } = payload;
+
+    const insertPayload = {
+        ...normalizeTaskInput(rest, rest.orderIndex ?? 0),
+        project_id: projectId
+    };
+
+    const { data, error } = await supabaseAdmin
+        .from('project_tasks')
+        .insert(insertPayload)
+        .select('id, project_id, name, date, location, status, order_index, completed_at')
+        .single();
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return toTaskRecord(data as TaskRow);
+}
+
+export async function updateTask(taskId: string, payload: UpdateTaskPayload): Promise<ProjectTaskRecord> {
+    const updates: Record<string, unknown> = {};
+
+    if (payload.name !== undefined) {
+        updates.name = payload.name;
+    }
+    if (payload.date !== undefined) {
+        updates.date = payload.date ?? null;
+    }
+    if (payload.location !== undefined) {
+        updates.location = payload.location ?? null;
+    }
+    if (payload.status !== undefined) {
+        updates.status = payload.status;
+        if (payload.status === 'COMPLETE') {
+            updates.completed_at = payload.completedAt ?? new Date().toISOString();
+        } else if (payload.completedAt === undefined) {
+            updates.completed_at = null;
+        }
+    }
+    if (payload.orderIndex !== undefined) {
+        updates.order_index = payload.orderIndex;
+    }
+    if (payload.completedAt !== undefined) {
+        updates.completed_at = payload.completedAt;
+    }
+
+    const { data, error } = await supabaseAdmin
+        .from('project_tasks')
+        .update(updates)
+        .eq('id', taskId)
+        .select('id, project_id, name, date, location, status, order_index, completed_at')
+        .single();
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return toTaskRecord(data as TaskRow);
+}
+
+export async function deleteTask(taskId: string): Promise<void> {
+    const { error } = await supabaseAdmin.from('project_tasks').delete().eq('id', taskId);
+    if (error) {
+        throw new Error(error.message);
+    }
+}
+
+export async function getProjectById(projectId: string): Promise<ProjectRecord | null> {
+    const row = await fetchProjectRowById(projectId);
+    if (!row) {
+        return null;
+    }
+
+    const tasksMap = await fetchTasksByProjectIds([projectId]);
+    const invoicesMap = await fetchInvoicesForProjects([row]);
+
+    return buildProjectRecord(row, tasksMap, invoicesMap);
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,102 @@
+export const PROJECT_STATUSES = [
+    'PLANNING',
+    'IN_PROGRESS',
+    'ON_HOLD',
+    'COMPLETE',
+    'CANCELLED'
+] as const;
+
+export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
+
+export const PROJECT_TASK_STATUSES = ['PENDING', 'CONFIRMED', 'EDITING', 'COMPLETE'] as const;
+
+export type ProjectTaskStatus = (typeof PROJECT_TASK_STATUSES)[number];
+
+export type ProjectTaskRecord = {
+    id: string;
+    projectId: string;
+    name: string;
+    date: string | null;
+    location: string | null;
+    status: ProjectTaskStatus;
+    orderIndex: number;
+    completedAt: string | null;
+};
+
+export type ProjectInvoiceSnippet = {
+    id: string;
+    number: string | null;
+    amountCents: number | null;
+    status: 'PAID' | 'SENT' | 'OVERDUE' | 'DRAFT';
+    dueAt: string | null;
+};
+
+export type ProjectRecord = {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    title: string;
+    clientId: string;
+    clientName: string | null;
+    status: ProjectStatus;
+    startDate: string | null;
+    endDate: string | null;
+    description: string | null;
+    tags: string[];
+    tasks: ProjectTaskRecord[];
+    invoices: ProjectInvoiceSnippet[];
+    completionPercent: number;
+};
+
+export type ProjectListResponse = {
+    data: ProjectRecord[];
+    page: number;
+    pageSize: number;
+    total: number;
+};
+
+export type ProjectListFilters = {
+    status?: ProjectStatus | 'ALL';
+    q?: string;
+    tag?: string;
+    page?: number;
+    pageSize?: number;
+};
+
+export type ProjectInput = {
+    title: string;
+    clientId: string;
+    status: ProjectStatus;
+    startDate?: string | null;
+    endDate?: string | null;
+    description?: string | null;
+    tags?: string[];
+    createdBy?: string | null;
+};
+
+export type ProjectTaskInput = {
+    id?: string;
+    name: string;
+    date?: string | null;
+    location?: string | null;
+    status?: ProjectTaskStatus;
+    orderIndex?: number;
+    completedAt?: string | null;
+};
+
+export type CreateProjectPayload = {
+    project: ProjectInput;
+    tasks?: ProjectTaskInput[];
+};
+
+export type UpdateProjectPayload = Partial<Omit<ProjectInput, 'clientId'>> & {
+    clientId?: string;
+};
+
+export type CreateTaskPayload = ProjectTaskInput & {
+    projectId: string;
+};
+
+export type UpdateTaskPayload = Partial<ProjectTaskInput> & {
+    projectId: string;
+};


### PR DESCRIPTION
## Summary
- add project domain types and Supabase server utilities for computing tasks, invoices, and completion
- expose App Router project endpoints for CRUD, task management, and client lookup
- rebuild the Projects workspace with the dashboard card grid, drawer form, and realtime updates

## Testing
- SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=dummy SUPABASE_ANON_KEY=dummy CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec295c5f08329b25f6ee5e54e7151