### PR TITLE
Implement dynamic CRM user profile editing

### DIFF
--- a/src/components/crm/CrmAuthGuard.tsx
+++ b/src/components/crm/CrmAuthGuard.tsx
@@ -7,13 +7,13 @@ import { ApertureMark } from './ApertureMark';
 type CrmAuthContextValue = {
     isAuthenticated: boolean;
     guardEnabled: boolean;
-    signOut: () => void;
+    signOut: () => Promise<void>;
 };
 
 const CrmAuthContext = React.createContext<CrmAuthContextValue>({
     isAuthenticated: false,
     guardEnabled: true,
-    signOut: () => undefined
+    signOut: async () => undefined
 });
 
 export function useCrmAuth(): CrmAuthContextValue {

--- a/src/data/crm.ts
+++ b/src/data/crm.ts
@@ -96,24 +96,6 @@ export type ProjectRecord = {
     tags: string[];
 };
 
-export type AdminUser = {
-    name: string;
-    role: string;
-    email: string;
-    phone?: string;
-    avatar: string;
-    status?: string;
-};
-
-export const adminUser: AdminUser = {
-    name: 'Avery Logan',
-    role: 'Studio Admin',
-    email: 'avery@codex.studio',
-    phone: '+1 (415) 555-0114',
-    avatar: '/images/avatar1.svg',
-    status: 'Online'
-};
-
 export const clients: ClientRecord[] = [
     {
         id: 'cl-01',

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -12,7 +12,12 @@ function mapUser(record: Record<string, any>): AuthUser {
         email: record.email,
         name: record.name ?? record.full_name ?? null,
         roles: Array.isArray(record.roles) ? record.roles : [],
-        createdAt: record.created_at
+        createdAt: record.created_at,
+        roleTitle: record.role_title ?? null,
+        phone: record.phone ?? null,
+        welcomeMessage: record.welcome_message ?? null,
+        avatarUrl: record.avatar_url ?? null,
+        status: record.status ?? null
     };
 }
 
@@ -33,7 +38,9 @@ export default async function handler(request: NextApiRequest, response: NextApi
     try {
         const query = await supabaseAdmin
             .from('users')
-            .select('id,email,password_hash,name,roles,created_at')
+            .select(
+                'id,email,password_hash,name,roles,created_at,role_title,phone,welcome_message,avatar_url,status'
+            )
             .eq('email', normalizedEmail)
             .maybeSingle();
 

--- a/src/pages/api/auth/session.ts
+++ b/src/pages/api/auth/session.ts
@@ -11,7 +11,12 @@ function mapUser(record: Record<string, any>): AuthUser {
         email: record.email,
         name: record.name ?? record.full_name ?? null,
         roles: Array.isArray(record.roles) ? record.roles : [],
-        createdAt: record.created_at
+        createdAt: record.created_at,
+        roleTitle: record.role_title ?? null,
+        phone: record.phone ?? null,
+        welcomeMessage: record.welcome_message ?? null,
+        avatarUrl: record.avatar_url ?? null,
+        status: record.status ?? null
     };
 }
 
@@ -30,7 +35,7 @@ export default async function handler(request: NextApiRequest, response: NextApi
         const payload = await verifySession(cookie);
         const query = await supabaseAdmin
             .from('users')
-            .select('id,email,name,roles,created_at')
+            .select('id,email,name,roles,created_at,role_title,phone,welcome_message,avatar_url,status')
             .eq('id', payload.userId)
             .maybeSingle();
 

--- a/src/pages/api/auth/signup.ts
+++ b/src/pages/api/auth/signup.ts
@@ -12,7 +12,12 @@ function mapUser(record: Record<string, any>): AuthUser {
         email: record.email,
         name: record.name ?? record.full_name ?? null,
         roles: Array.isArray(record.roles) ? record.roles : [],
-        createdAt: record.created_at
+        createdAt: record.created_at,
+        roleTitle: record.role_title ?? null,
+        phone: record.phone ?? null,
+        welcomeMessage: record.welcome_message ?? null,
+        avatarUrl: record.avatar_url ?? null,
+        status: record.status ?? null
     };
 }
 
@@ -42,9 +47,10 @@ export default async function handler(request: NextApiRequest, response: NextApi
                 email: normalizedEmail,
                 password_hash: passwordHash,
                 name: typeof name === 'string' ? name.trim() : null,
-                roles: ['photographer']
+                roles: ['photographer'],
+                role_title: 'Studio Admin'
             })
-            .select('id,email,name,roles,created_at')
+            .select('id,email,name,roles,created_at,role_title,phone,welcome_message,avatar_url,status')
             .single();
 
         if (insert.error || !insert.data) {

--- a/src/pages/api/users/me.ts
+++ b/src/pages/api/users/me.ts
@@ -1,0 +1,200 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { supabaseAdmin } from '../../../lib/supabase-admin';
+import { signSession, verifySession } from '../../../lib/jwt';
+import { clearSessionCookie, readSessionCookie, setSessionCookie } from '../../../lib/session-cookie';
+import type { UserProfile } from '../../../types/user';
+
+function mapProfile(record: Record<string, any>): UserProfile {
+    return {
+        id: record.id,
+        email: record.email,
+        name: record.name ?? record.full_name ?? null,
+        roles: Array.isArray(record.roles) ? record.roles : [],
+        roleTitle: record.role_title ?? null,
+        phone: record.phone ?? null,
+        welcomeMessage: record.welcome_message ?? null,
+        avatarUrl: record.avatar_url ?? null,
+        status: record.status ?? null,
+        createdAt: record.created_at
+    };
+}
+
+function sanitizeNullableString(value: unknown): string | null {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+function sanitizeOptionalString(value: unknown): string | null | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (value === null) {
+        return null;
+    }
+
+    return sanitizeNullableString(value);
+}
+
+function sanitizeEmail(value: unknown): string | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+        return undefined;
+    }
+
+    return trimmed;
+}
+
+async function handleGetProfile(request: NextApiRequest, response: NextApiResponse) {
+    const cookie = readSessionCookie(request);
+    if (!cookie) {
+        return response.status(401).json({ error: 'Authentication required.' });
+    }
+
+    try {
+        const payload = await verifySession(cookie);
+        const query = await supabaseAdmin
+            .from('users')
+            .select('id,email,name,roles,created_at,role_title,phone,welcome_message,avatar_url,status')
+            .eq('id', payload.userId)
+            .maybeSingle();
+
+        if (query.error) {
+            console.error('Failed to load profile', query.error);
+            return response.status(500).json({ error: 'Unable to load profile.' });
+        }
+
+        if (!query.data) {
+            clearSessionCookie(response);
+            return response.status(401).json({ error: 'Session is no longer valid.' });
+        }
+
+        const profile = mapProfile(query.data);
+        return response.status(200).json({ profile });
+    } catch (error) {
+        console.error('Profile lookup failed', error);
+        clearSessionCookie(response);
+        return response.status(401).json({ error: 'Authentication required.' });
+    }
+}
+
+async function handleUpdateProfile(request: NextApiRequest, response: NextApiResponse) {
+    const cookie = readSessionCookie(request);
+    if (!cookie) {
+        return response.status(401).json({ error: 'Authentication required.' });
+    }
+
+    let payload: Awaited<ReturnType<typeof verifySession>>;
+
+    try {
+        payload = await verifySession(cookie);
+    } catch (error) {
+        console.error('Profile update session verification failed', error);
+        clearSessionCookie(response);
+        return response.status(401).json({ error: 'Authentication required.' });
+    }
+
+    const { name, email, roleTitle, phone, welcomeMessage, avatarUrl, status } = request.body ?? {};
+
+    const updates: Record<string, string | null> = {};
+
+    if (name !== undefined) {
+        updates.name = sanitizeOptionalString(name) ?? null;
+    }
+
+    const normalizedEmail = sanitizeEmail(email);
+    if (email !== undefined && !normalizedEmail) {
+        return response.status(400).json({ error: 'Please provide a valid email address.' });
+    }
+    if (normalizedEmail) {
+        updates.email = normalizedEmail;
+    }
+
+    if (roleTitle !== undefined) {
+        updates.role_title = sanitizeOptionalString(roleTitle) ?? null;
+    }
+
+    if (phone !== undefined) {
+        updates.phone = sanitizeOptionalString(phone) ?? null;
+    }
+
+    if (welcomeMessage !== undefined) {
+        updates.welcome_message = sanitizeOptionalString(welcomeMessage) ?? null;
+    }
+
+    if (avatarUrl !== undefined) {
+        updates.avatar_url = sanitizeOptionalString(avatarUrl) ?? null;
+    }
+
+    if (status !== undefined) {
+        updates.status = sanitizeOptionalString(status) ?? null;
+    }
+
+    if (Object.keys(updates).length === 0) {
+        return response.status(400).json({ error: 'No profile changes supplied.' });
+    }
+
+    try {
+        const mutation = await supabaseAdmin
+            .from('users')
+            .update(updates)
+            .eq('id', payload.userId)
+            .select('id,email,name,roles,created_at,role_title,phone,welcome_message,avatar_url,status')
+            .single();
+
+        if (mutation.error) {
+            if (mutation.error.code === '23505') {
+                return response.status(409).json({ error: 'That email is already in use.' });
+            }
+
+            console.error('Failed to update profile', mutation.error);
+            return response.status(500).json({ error: 'Unable to update profile.' });
+        }
+
+        const profile = mapProfile(mutation.data);
+
+        if (normalizedEmail && normalizedEmail !== payload.email) {
+            const token = await signSession({
+                userId: payload.userId,
+                email: normalizedEmail,
+                roles: profile.roles
+            });
+            setSessionCookie(response, token);
+        }
+
+        return response.status(200).json({ profile });
+    } catch (error) {
+        console.error('Unexpected profile update error', error);
+        return response.status(500).json({ error: 'Unable to update profile.' });
+    }
+}
+
+export default async function handler(request: NextApiRequest, response: NextApiResponse) {
+    if (request.method === 'GET') {
+        return handleGetProfile(request, response);
+    }
+
+    if (request.method === 'PUT') {
+        return handleUpdateProfile(request, response);
+    }
+
+    response.setHeader('Allow', 'GET, PUT');
+    return response.status(405).json({ error: 'Method not allowed' });
+}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import Head from 'next/head';
 
-import { WorkspaceLayout } from '../../components/crm';
+import { useNetlifyIdentity } from '../../components/auth';
+import { CrmAuthGuard, WorkspaceLayout } from '../../components/crm';
 import { useIntegrations, type IntegrationStatus } from '../../components/crm/integration-context';
-import { adminUser } from '../../data/crm';
 import { INTEGRATION_CATEGORIES } from '../../data/integrations';
+import type { UserProfile } from '../../types/user';
 
 const notificationPreferences = [
     {
@@ -33,7 +34,77 @@ const notificationPreferences = [
     }
 ];
 
+const DEFAULT_WELCOME_MESSAGE =
+    'We can’t wait to collaborate. Share any mood boards, location inspiration, or must-have shots and we’ll add them to the project brief.';
+
+const AVATAR_PLACEHOLDER = '/images/avatar1.svg';
+
+type ProfileFormState = {
+    name: string;
+    email: string;
+    roleTitle: string;
+    phone: string;
+    welcomeMessage: string;
+    avatarUrl: string;
+};
+
+type NoticeState = {
+    type: 'success' | 'error' | 'info';
+    message: string;
+};
+
+const NOTICE_CLASS: Record<NoticeState['type'], string> = {
+    success: 'alert-success',
+    error: 'alert-danger',
+    info: 'alert-secondary'
+};
+
+const EMPTY_PROFILE_FORM: ProfileFormState = {
+    name: '',
+    email: '',
+    roleTitle: '',
+    phone: '',
+    welcomeMessage: DEFAULT_WELCOME_MESSAGE,
+    avatarUrl: ''
+};
+
+function safeTrim(value: string | null | undefined): string {
+    if (typeof value !== 'string') {
+        return '';
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : '';
+}
+
+function mapProfileToForm(profile: UserProfile): ProfileFormState {
+    const welcome = safeTrim(profile.welcomeMessage);
+    return {
+        name: safeTrim(profile.name),
+        email: profile.email.trim(),
+        roleTitle: safeTrim(profile.roleTitle),
+        phone: safeTrim(profile.phone),
+        welcomeMessage: welcome.length > 0 ? welcome : DEFAULT_WELCOME_MESSAGE,
+        avatarUrl: safeTrim(profile.avatarUrl)
+    };
+}
+
 export default function SettingsPage() {
+    return (
+        <>
+            <Head>
+                <title>Settings · Aperture Studio CRM</title>
+            </Head>
+            <CrmAuthGuard>
+                <WorkspaceLayout>
+                    <SettingsWorkspace />
+                </WorkspaceLayout>
+            </CrmAuthGuard>
+        </>
+    );
+}
+
+function SettingsWorkspace() {
+    const identity = useNetlifyIdentity();
     const {
         availableIntegrations,
         connectedIntegrations,
@@ -44,6 +115,194 @@ export default function SettingsPage() {
     const [isAddOpen, setIsAddOpen] = React.useState(false);
     const [selectedIntegrationId, setSelectedIntegrationId] = React.useState<string>('');
     const [activeIntegrationId, setActiveIntegrationId] = React.useState<string | null>(null);
+    const [profileForm, setProfileForm] = React.useState<ProfileFormState>(EMPTY_PROFILE_FORM);
+    const [profile, setProfile] = React.useState<UserProfile | null>(null);
+    const [isLoadingProfile, setIsLoadingProfile] = React.useState(false);
+    const [isSavingProfile, setIsSavingProfile] = React.useState(false);
+    const [isSendingInvite, setIsSendingInvite] = React.useState(false);
+    const [notice, setNotice] = React.useState<NoticeState | null>(null);
+    const isMountedRef = React.useRef(true);
+
+    React.useEffect(() => {
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
+
+    const fetchProfile = React.useCallback(async () => {
+        if (!identity.isReady || !identity.isAuthenticated) {
+            return null;
+        }
+
+        if (isMountedRef.current) {
+            setIsLoadingProfile(true);
+        }
+
+        try {
+            const response = await fetch('/api/users/me', { credentials: 'include' });
+            const payload = (await response.json().catch(() => null)) as
+                | { profile?: UserProfile; error?: string }
+                | null;
+
+            if (!response.ok || !payload?.profile) {
+                const message = payload?.error ?? 'Unable to load profile.';
+                throw new Error(message);
+            }
+
+            if (!isMountedRef.current) {
+                return payload.profile;
+            }
+
+            setProfile(payload.profile);
+            setProfileForm(mapProfileToForm(payload.profile));
+            setNotice(null);
+
+            return payload.profile;
+        } catch (error) {
+            if (isMountedRef.current) {
+                const message = error instanceof Error ? error.message : 'Unable to load profile.';
+                setNotice({ type: 'error', message });
+            }
+            return null;
+        } finally {
+            if (isMountedRef.current) {
+                setIsLoadingProfile(false);
+            }
+        }
+    }, [identity.isAuthenticated, identity.isReady]);
+
+    React.useEffect(() => {
+        if (!identity.isReady || !identity.isAuthenticated) {
+            return;
+        }
+
+        void fetchProfile();
+    }, [identity.isAuthenticated, identity.isReady, fetchProfile]);
+
+    React.useEffect(() => {
+        if (!notice || notice.type === 'error') {
+            return;
+        }
+        if (typeof window === 'undefined') {
+            return;
+        }
+        const timer = window.setTimeout(() => setNotice(null), 3600);
+        return () => window.clearTimeout(timer);
+    }, [notice]);
+
+    const handleFieldChange = React.useCallback(
+        (key: keyof ProfileFormState) =>
+            (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+                const value = event.target.value;
+                setProfileForm((previous) => ({ ...previous, [key]: value }));
+            },
+        []
+    );
+
+    const avatarPreview =
+        profileForm.avatarUrl.trim().length > 0 ? profileForm.avatarUrl : AVATAR_PLACEHOLDER;
+    const isProfileBusy = isLoadingProfile || isSavingProfile;
+
+    const handleProfileSubmit = React.useCallback(
+        async (event: React.FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            if (!identity.isAuthenticated) {
+                setNotice({ type: 'error', message: 'You need to be signed in to update your profile.' });
+                return;
+            }
+
+            if (isMountedRef.current) {
+                setIsSavingProfile(true);
+                setNotice(null);
+            }
+
+            try {
+                const response = await fetch('/api/users/me', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        name: profileForm.name,
+                        email: profileForm.email,
+                        roleTitle: profileForm.roleTitle,
+                        phone: profileForm.phone,
+                        welcomeMessage: profileForm.welcomeMessage,
+                        avatarUrl: profileForm.avatarUrl
+                    })
+                });
+
+                const payload = (await response.json().catch(() => null)) as
+                    | { profile?: UserProfile; error?: string }
+                    | null;
+
+                if (!response.ok || !payload?.profile) {
+                    const message = payload?.error ?? 'Unable to update profile.';
+                    throw new Error(message);
+                }
+
+                if (isMountedRef.current) {
+                    setProfile(payload.profile);
+                    setProfileForm(mapProfileToForm(payload.profile));
+                    setNotice({ type: 'success', message: 'Profile saved.' });
+                }
+
+                try {
+                    await identity.refresh();
+                } catch (refreshError) {
+                    console.warn('Failed to refresh identity after profile update', refreshError);
+                }
+            } catch (error) {
+                if (isMountedRef.current) {
+                    const message = error instanceof Error ? error.message : 'Unable to update profile.';
+                    setNotice({ type: 'error', message });
+                }
+            } finally {
+                if (isMountedRef.current) {
+                    setIsSavingProfile(false);
+                }
+            }
+        },
+        [identity, profileForm]
+    );
+
+    const handleSendInvite = React.useCallback(async () => {
+        if (isSendingInvite) {
+            return;
+        }
+
+        const targetEmail = profileForm.email.trim();
+        if (targetEmail.length === 0) {
+            setNotice({ type: 'error', message: 'Add an email address before sending a preview invite.' });
+            return;
+        }
+
+        if (isMountedRef.current) {
+            setIsSendingInvite(true);
+            setNotice(null);
+        }
+
+        try {
+            await new Promise<void>((resolve) => {
+                globalThis.setTimeout(resolve, 900);
+            });
+
+            console.info('Preview invite queued for delivery', {
+                email: targetEmail,
+                userId: profile?.id ?? 'unknown'
+            });
+
+            if (isMountedRef.current) {
+                setNotice({ type: 'info', message: 'Preview invite queued for delivery.' });
+            }
+        } catch (error) {
+            if (isMountedRef.current) {
+                setNotice({ type: 'error', message: 'Unable to send preview invite.' });
+            }
+        } finally {
+            if (isMountedRef.current) {
+                setIsSendingInvite(false);
+            }
+        }
+    }, [isSendingInvite, profile?.id, profileForm.email]);
 
     const availableOptions = React.useMemo(
         () =>
@@ -106,265 +365,335 @@ export default function SettingsPage() {
     };
 
     return (
-        <>
-            <Head>
-                <title>Settings · Aperture Studio CRM</title>
-            </Head>
-            <WorkspaceLayout>
-                <div className="row row-cards">
-                    <div className="col-xl-6">
-                        <div className="card h-100">
-                            <div className="card-header d-flex align-items-center justify-content-between">
-                                <div>
-                                    <h2 className="card-title mb-0">Studio profile</h2>
-                                    <div className="text-secondary">Update contact details and booking hand-offs.</div>
-                                </div>
-                                <span className="badge bg-success-lt text-success">Live</span>
-                            </div>
-                            <div className="card-body">
-                                <form className="row g-3">
-                                    <div className="col-12">
-                                        <label className="form-label" htmlFor="studio-name">
-                                            Studio name
-                                        </label>
-                                        <input id="studio-name" type="text" className="form-control" defaultValue="Aperture Studio" />
-                                    </div>
-                                    <div className="col-md-6">
-                                        <label className="form-label" htmlFor="profile-name">
-                                            Primary contact
-                                        </label>
-                                        <input id="profile-name" type="text" className="form-control" defaultValue={adminUser.name} />
-                                    </div>
-                                    <div className="col-md-6">
-                                        <label className="form-label" htmlFor="profile-role">
-                                            Role
-                                        </label>
-                                        <input id="profile-role" type="text" className="form-control" defaultValue={adminUser.role} />
-                                    </div>
-                                    <div className="col-md-6">
-                                        <label className="form-label" htmlFor="profile-email">
-                                            Email
-                                        </label>
-                                        <input id="profile-email" type="email" className="form-control" defaultValue={adminUser.email} />
-                                    </div>
-                                    <div className="col-md-6">
-                                        <label className="form-label" htmlFor="profile-phone">
-                                            Phone
-                                        </label>
-                                        <input id="profile-phone" type="tel" className="form-control" defaultValue={adminUser.phone ?? ''} />
-                                    </div>
-                                    <div className="col-12">
-                                        <label className="form-label" htmlFor="profile-welcome">
-                                            Client welcome message
-                                        </label>
-                                        <textarea
-                                            id="profile-welcome"
-                                            className="form-control"
-                                            rows={3}
-                                            defaultValue="We can’t wait to collaborate. Share any mood boards, location inspiration, or must-have shots and we’ll add them to the project brief."
-                                        />
-                                    </div>
-                                    <div className="col-12 d-flex flex-wrap gap-2">
-                                        <button type="button" className="btn btn-primary">
-                                            Save profile
-                                        </button>
-                                        <button type="button" className="btn btn-outline-secondary">
-                                            Send preview invite
-                                        </button>
-                                    </div>
-                                </form>
-                            </div>
+        <div className="row row-cards">
+            <div className="col-xl-6">
+                <div className="card h-100">
+                    <div className="card-header d-flex align-items-center justify-content-between">
+                        <div>
+                            <h2 className="card-title mb-0">Studio profile</h2>
+                            <div className="text-secondary">Update contact details and booking hand-offs.</div>
                         </div>
+                        <span className="badge bg-success-lt text-success">Live</span>
                     </div>
-                    <div className="col-xl-6">
-                        <div className="card h-100">
-                            <div className="card-header">
-                                <h2 className="card-title mb-0">Notification preferences</h2>
-                                <div className="text-secondary">Choose how the studio stays in sync.</div>
+                    <div className="card-body">
+                        {isLoadingProfile && !profile ? (
+                            <div className="text-secondary small mb-3">Loading profile…</div>
+                        ) : null}
+                        {notice ? (
+                            <div className={`alert ${NOTICE_CLASS[notice.type]} mb-3`} role="alert">
+                                {notice.message}
                             </div>
-                            <div className="card-body d-flex flex-column gap-3">
-                                {notificationPreferences.map((preference) => (
-                                    <div key={preference.id} className="form-check form-switch crm-settings-toggle">
+                        ) : null}
+                        <form className="row g-3" onSubmit={handleProfileSubmit}>
+                            <div className="col-12">
+                                <label className="form-label" htmlFor="studio-name">
+                                    Studio name
+                                </label>
+                                <input
+                                    id="studio-name"
+                                    type="text"
+                                    className="form-control"
+                                    defaultValue="Aperture Studio"
+                                />
+                            </div>
+                            <div className="col-12">
+                                <label className="form-label" htmlFor="profile-avatar">
+                                    Profile photo
+                                </label>
+                                <div className="d-flex align-items-center gap-3">
+                                    <span className="avatar avatar-xl" style={{ backgroundImage: `url(${avatarPreview})` }} />
+                                    <div className="flex-grow-1">
                                         <input
-                                            className="form-check-input"
-                                            type="checkbox"
-                                            role="switch"
-                                            id={preference.id}
-                                            defaultChecked={preference.defaultChecked}
+                                            id="profile-avatar"
+                                            type="url"
+                                            className="form-control"
+                                            value={profileForm.avatarUrl}
+                                            onChange={handleFieldChange('avatarUrl')}
+                                            placeholder="https://"
+                                            disabled={isProfileBusy}
                                         />
-                                        <label className="form-check-label" htmlFor={preference.id}>
-                                            <span className="fw-semibold d-block">{preference.label}</span>
-                                            <span className="text-secondary">{preference.description}</span>
-                                        </label>
+                                        <div className="form-text">Use a square image for best results.</div>
                                     </div>
-                                ))}
-                                <div className="mt-2">
-                                    <button type="button" className="btn btn-outline-secondary">
-                                        Update notifications
-                                    </button>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <div className="col-12">
-                        <div className="card">
-                            <div className="card-header d-flex align-items-center justify-content-between">
-                                <div>
-                                    <h2 className="card-title mb-0">Connected integrations</h2>
-                                    <div className="text-secondary">Bring your favorite tools into the workflow.</div>
-                                </div>
+                            <div className="col-md-6">
+                                <label className="form-label" htmlFor="profile-name">
+                                    Primary contact
+                                </label>
+                                <input
+                                    id="profile-name"
+                                    type="text"
+                                    className="form-control"
+                                    value={profileForm.name}
+                                    onChange={handleFieldChange('name')}
+                                    disabled={isProfileBusy}
+                                />
+                            </div>
+                            <div className="col-md-6">
+                                <label className="form-label" htmlFor="profile-role">
+                                    Role
+                                </label>
+                                <input
+                                    id="profile-role"
+                                    type="text"
+                                    className="form-control"
+                                    value={profileForm.roleTitle}
+                                    onChange={handleFieldChange('roleTitle')}
+                                    disabled={isProfileBusy}
+                                />
+                            </div>
+                            <div className="col-md-6">
+                                <label className="form-label" htmlFor="profile-email">
+                                    Email
+                                </label>
+                                <input
+                                    id="profile-email"
+                                    type="email"
+                                    className="form-control"
+                                    value={profileForm.email}
+                                    onChange={handleFieldChange('email')}
+                                    disabled={isProfileBusy}
+                                    required
+                                />
+                            </div>
+                            <div className="col-md-6">
+                                <label className="form-label" htmlFor="profile-phone">
+                                    Phone
+                                </label>
+                                <input
+                                    id="profile-phone"
+                                    type="tel"
+                                    className="form-control"
+                                    value={profileForm.phone}
+                                    onChange={handleFieldChange('phone')}
+                                    disabled={isProfileBusy}
+                                />
+                            </div>
+                            <div className="col-12">
+                                <label className="form-label" htmlFor="profile-welcome">
+                                    Client welcome message
+                                </label>
+                                <textarea
+                                    id="profile-welcome"
+                                    className="form-control"
+                                    rows={3}
+                                    value={profileForm.welcomeMessage}
+                                    onChange={handleFieldChange('welcomeMessage')}
+                                    disabled={isProfileBusy}
+                                />
+                            </div>
+                            <div className="col-12 d-flex flex-wrap gap-2">
+                                <button
+                                    type="submit"
+                                    className="btn btn-primary"
+                                    disabled={isProfileBusy || profileForm.email.trim().length === 0}
+                                >
+                                    {isSavingProfile ? 'Saving…' : 'Save profile'}
+                                </button>
                                 <button
                                     type="button"
                                     className="btn btn-outline-secondary"
-                                    onClick={() => setIsAddOpen((previous) => !previous)}
-                                    aria-expanded={isAddOpen}
-                                    disabled={availableOptions.length === 0 && !isAddOpen}
+                                    onClick={handleSendInvite}
+                                    disabled={
+                                        isLoadingProfile ||
+                                        isSendingInvite ||
+                                        profileForm.email.trim().length === 0
+                                    }
                                 >
-                                    {isAddOpen ? 'Close' : 'Add integration'}
+                                    {isSendingInvite ? 'Sending…' : 'Send preview invite'}
                                 </button>
                             </div>
-                            <div className="card-body d-grid gap-3">
-                                {isAddOpen ? (
-                                    <div className="crm-integration-add p-3 border rounded">
-                                        <div className="fw-semibold mb-1">Connect a new integration</div>
-                                        {availableOptions.length > 0 ? (
-                                            <>
-                                                <label className="form-label" htmlFor="integration-select">
-                                                    Choose from connected services
-                                                </label>
-                                                <select
-                                                    id="integration-select"
-                                                    className="form-select"
-                                                    value={selectedIntegrationId}
-                                                    onChange={(event) => setSelectedIntegrationId(event.target.value)}
-                                                >
-                                                    {INTEGRATION_CATEGORIES.map((category) => {
-                                                        const categoryOptions = availableOptions.filter(
-                                                            (option) => option.categoryId === category.id
-                                                        );
-                                                        if (categoryOptions.length === 0) {
-                                                            return null;
-                                                        }
-                                                        return (
-                                                            <optgroup key={category.id} label={category.label}>
-                                                                {categoryOptions.map((option) => (
-                                                                    <option key={option.id} value={option.id}>
-                                                                        {option.name}
-                                                                    </option>
-                                                                ))}
-                                                            </optgroup>
-                                                        );
-                                                    })}
-                                                </select>
-                                                <div className="d-flex gap-2 mt-3">
-                                                    <button
-                                                        type="button"
-                                                        className="btn btn-primary"
-                                                        onClick={handleAddIntegration}
-                                                        disabled={!selectedIntegrationId}
-                                                    >
-                                                        Connect integration
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        className="btn btn-outline-secondary"
-                                                        onClick={() => setIsAddOpen(false)}
-                                                    >
-                                                        Cancel
-                                                    </button>
-                                                </div>
-                                            </>
-                                        ) : (
-                                            <div className="text-secondary">
-                                                All available integrations are already connected.
-                                            </div>
-                                        )}
-                                    </div>
-                                ) : null}
-
-                                {orderedIntegrations.length > 0 ? (
-                                    orderedIntegrations.map((integration) => {
-                                        const Icon = integration.definition.icon;
-                                        const iconStyle: React.CSSProperties = {
-                                            backgroundColor: integration.definition.badgeColor,
-                                            color: integration.definition.iconColor ?? '#ffffff'
-                                        };
-
-                                        return (
-                                            <div key={integration.id} className="crm-integration-item">
-                                                <div className="d-flex align-items-center gap-3">
-                                                    <span className="crm-integration-icon" style={iconStyle} aria-hidden>
-                                                        <Icon size={20} aria-hidden />
-                                                    </span>
-                                                    <div>
-                                                        <div className="fw-semibold">{integration.definition.name}</div>
-                                                        <div className="text-secondary small">
-                                                            {integration.definition.description}
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="crm-integration-actions">
-                                                    <span
-                                                        className={`badge ${statusBadgeTone[integration.status]} d-block mb-2`}
-                                                    >
-                                                        {statusLabels[integration.status]}
-                                                    </span>
-                                                    <button
-                                                        type="button"
-                                                        className="btn btn-link p-0"
-                                                        onClick={() =>
-                                                            setActiveIntegrationId((previous) =>
-                                                                previous === integration.id ? null : integration.id
-                                                            )
-                                                        }
-                                                        aria-expanded={activeIntegrationId === integration.id}
-                                                    >
-                                                        Manage
-                                                    </button>
-                                                    {activeIntegrationId === integration.id ? (
-                                                        <div className="crm-integration-manage mt-2">
-                                                            <div className="btn-group btn-group-sm" role="group">
-                                                                <button
-                                                                    type="button"
-                                                                    className="btn btn-outline-success"
-                                                                    onClick={() => handleStatusChange(integration.id, 'Connected')}
-                                                                    disabled={integration.status === 'Connected'}
-                                                                >
-                                                                    Mark connected
-                                                                </button>
-                                                                <button
-                                                                    type="button"
-                                                                    className="btn btn-outline-primary"
-                                                                    onClick={() => handleStatusChange(integration.id, 'Syncing')}
-                                                                    disabled={integration.status === 'Syncing'}
-                                                                >
-                                                                    Mark syncing
-                                                                </button>
-                                                            </div>
-                                                            <button
-                                                                type="button"
-                                                                className="btn btn-outline-danger btn-sm"
-                                                                onClick={() => handleDisconnect(integration.id)}
-                                                            >
-                                                                Disconnect
-                                                            </button>
-                                                        </div>
-                                                    ) : null}
-                                                </div>
-                                            </div>
-                                        );
-                                    })
-                                ) : (
-                                    <div className="crm-integration-empty text-center text-secondary py-4">
-                                        <p className="mb-2">No integrations are connected yet.</p>
-                                        <p className="mb-0">Use the add integration button to bring tools into your dashboard.</p>
-                                    </div>
-                                )}
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div className="col-xl-6">
+                <div className="card h-100">
+                    <div className="card-header">
+                        <h2 className="card-title mb-0">Notification preferences</h2>
+                        <div className="text-secondary">Choose how the studio stays in sync.</div>
+                    </div>
+                    <div className="card-body d-flex flex-column gap-3">
+                        {notificationPreferences.map((preference) => (
+                            <div key={preference.id} className="form-check form-switch crm-settings-toggle">
+                                <input
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    role="switch"
+                                    id={preference.id}
+                                    defaultChecked={preference.defaultChecked}
+                                />
+                                <label className="form-check-label" htmlFor={preference.id}>
+                                    <span className="fw-semibold d-block">{preference.label}</span>
+                                    <span className="text-secondary">{preference.description}</span>
+                                </label>
                             </div>
+                        ))}
+                        <div className="mt-2">
+                            <button type="button" className="btn btn-outline-secondary">
+                                Update notifications
+                            </button>
                         </div>
                     </div>
                 </div>
-            </WorkspaceLayout>
-        </>
+            </div>
+            <div className="col-12">
+                <div className="card">
+                    <div className="card-header d-flex align-items-center justify-content-between">
+                        <div>
+                            <h2 className="card-title mb-0">Connected integrations</h2>
+                            <div className="text-secondary">Bring your favorite tools into the workflow.</div>
+                        </div>
+                        <button
+                            type="button"
+                            className="btn btn-outline-secondary"
+                            onClick={() => setIsAddOpen((previous) => !previous)}
+                            aria-expanded={isAddOpen}
+                            disabled={availableOptions.length === 0 && !isAddOpen}
+                        >
+                            {isAddOpen ? 'Close' : 'Add integration'}
+                        </button>
+                    </div>
+                    <div className="card-body d-grid gap-3">
+                        {isAddOpen ? (
+                            <div className="crm-integration-add p-3 border rounded">
+                                <div className="fw-semibold mb-1">Connect a new integration</div>
+                                {availableOptions.length > 0 ? (
+                                    <>
+                                        <label className="form-label" htmlFor="integration-select">
+                                            Choose from connected services
+                                        </label>
+                                        <select
+                                            id="integration-select"
+                                            className="form-select"
+                                            value={selectedIntegrationId}
+                                            onChange={(event) => setSelectedIntegrationId(event.target.value)}
+                                        >
+                                            {INTEGRATION_CATEGORIES.map((category) => {
+                                                const categoryOptions = availableOptions.filter(
+                                                    (option) => option.categoryId === category.id
+                                                );
+                                                if (categoryOptions.length === 0) {
+                                                    return null;
+                                                }
+                                                return (
+                                                    <optgroup key={category.id} label={category.label}>
+                                                        {categoryOptions.map((option) => (
+                                                            <option key={option.id} value={option.id}>
+                                                                {option.name}
+                                                            </option>
+                                                        ))}
+                                                    </optgroup>
+                                                );
+                                            })}
+                                        </select>
+                                        <div className="d-flex gap-2 mt-3">
+                                            <button
+                                                type="button"
+                                                className="btn btn-primary"
+                                                onClick={handleAddIntegration}
+                                                disabled={!selectedIntegrationId}
+                                            >
+                                                Connect integration
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className="btn btn-outline-secondary"
+                                                onClick={() => setIsAddOpen(false)}
+                                            >
+                                                Cancel
+                                            </button>
+                                        </div>
+                                    </>
+                                ) : (
+                                    <div className="text-secondary">
+                                        All available integrations are already connected.
+                                    </div>
+                                )}
+                            </div>
+                        ) : null}
+
+                        {orderedIntegrations.length > 0 ? (
+                            orderedIntegrations.map((integration) => {
+                                const Icon = integration.definition.icon;
+                                const iconStyle: React.CSSProperties = {
+                                    backgroundColor: integration.definition.badgeColor,
+                                    color: integration.definition.iconColor ?? '#ffffff'
+                                };
+
+                                return (
+                                    <div key={integration.id} className="crm-integration-item">
+                                        <div className="d-flex align-items-center gap-3">
+                                            <span className="crm-integration-icon" style={iconStyle} aria-hidden>
+                                                <Icon size={20} aria-hidden />
+                                            </span>
+                                            <div>
+                                                <div className="fw-semibold">{integration.definition.name}</div>
+                                                <div className="text-secondary small">
+                                                    {integration.definition.description}
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div className="crm-integration-actions">
+                                            <span
+                                                className={`badge ${statusBadgeTone[integration.status]} d-block mb-2`}
+                                            >
+                                                {statusLabels[integration.status]}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                className="btn btn-link p-0"
+                                                onClick={() =>
+                                                    setActiveIntegrationId((previous) =>
+                                                        previous === integration.id ? null : integration.id
+                                                    )
+                                                }
+                                                aria-expanded={activeIntegrationId === integration.id}
+                                            >
+                                                Manage
+                                            </button>
+                                            {activeIntegrationId === integration.id ? (
+                                                <div className="crm-integration-manage mt-2">
+                                                    <div className="btn-group btn-group-sm" role="group">
+                                                        <button
+                                                            type="button"
+                                                            className="btn btn-outline-success"
+                                                            onClick={() => handleStatusChange(integration.id, 'Connected')}
+                                                            disabled={integration.status === 'Connected'}
+                                                        >
+                                                            Mark connected
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            className="btn btn-outline-primary"
+                                                            onClick={() => handleStatusChange(integration.id, 'Syncing')}
+                                                            disabled={integration.status === 'Syncing'}
+                                                        >
+                                                            Mark syncing
+                                                        </button>
+                                                    </div>
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-outline-danger btn-sm"
+                                                        onClick={() => handleDisconnect(integration.id)}
+                                                    >
+                                                        Disconnect
+                                                    </button>
+                                                </div>
+                                            ) : null}
+                                        </div>
+                                    </div>
+                                );
+                            })
+                        ) : (
+                            <div className="crm-integration-empty text-center text-secondary py-4">
+                                <p className="mb-2">No integrations are connected yet.</p>
+                                <p className="mb-0">Use the add integration button to bring tools into your dashboard.</p>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
     );
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -4,4 +4,9 @@ export type AuthUser = {
     name: string | null;
     roles: string[];
     createdAt: string;
+    roleTitle: string | null;
+    phone: string | null;
+    welcomeMessage: string | null;
+    avatarUrl: string | null;
+    status: string | null;
 };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,22 @@
+export type UserProfile = {
+    id: string;
+    email: string;
+    name: string | null;
+    roles: string[];
+    roleTitle: string | null;
+    phone: string | null;
+    welcomeMessage: string | null;
+    avatarUrl: string | null;
+    status: string | null;
+    createdAt: string;
+};
+
+export type UpdateUserProfileInput = {
+    name?: string | null;
+    email?: string;
+    roleTitle?: string | null;
+    phone?: string | null;
+    welcomeMessage?: string | null;
+    avatarUrl?: string | null;
+    status?: string | null;
+};

--- a/supabase/migrations/20250301000000_extend_users_profile_fields.sql
+++ b/supabase/migrations/20250301000000_extend_users_profile_fields.sql
@@ -1,0 +1,6 @@
+alter table public.users
+    add column if not exists role_title text,
+    add column if not exists phone text,
+    add column if not exists welcome_message text,
+    add column if not exists avatar_url text,
+    add column if not exists status text;


### PR DESCRIPTION
## Summary
- add a Supabase migration and shared user types to persist avatar, role, phone, welcome message, and status details for each account
- surface the extended profile fields through the auth endpoints and a new `/api/users/me` route that lets the current user fetch and update their data while keeping sessions in sync
- replace the settings workspace form and header menu with live identity-backed profile details, including avatar preview, editable role, and a mock preview invite action

## Testing
- SUPABASE_URL=https://example.com SUPABASE_SERVICE_ROLE_KEY=dummy-key CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ced0e75ed08329bb93a0d79ca3ae88