### PR TITLE
Handle missing calendar owner id values

### DIFF
--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -113,9 +113,16 @@ function createEventColors(userId: string) {
 }
 
 function mapResponseEvent(record: Record<string, any>): CalendarEventRecord {
+    const ownerUserId =
+        typeof record.owner_user_id === 'string'
+            ? record.owner_user_id
+            : record.owner_user_id != null
+                ? String(record.owner_user_id)
+                : '';
+
     return {
         id: record.id,
-        ownerUserId: record.owner_user_id,
+        ownerUserId,
         title: record.title,
         description: record.description ?? null,
         startAt: record.start_at,


### PR DESCRIPTION
## Summary
- coerce calendar event owner IDs to a safe fallback string when absent
- ensure createEventColors always receives a string identifier for unassigned events

## Testing
- npm run build *(fails: Module not found: Can't resolve '@dnd-kit/core')*

------
https://chatgpt.com/codex/tasks/task_e_68cf202d2f34832985cdfad02bb7a4d7