### PR TITLE
Expose Supabase env vars to the browser

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,31 @@
 /**
  * @type {import('next').NextConfig}
  */
+const env = {
+    stackbitPreview: process.env.STACKBIT_PREVIEW
+};
+
+const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    process.env.PUBLIC_SUPABASE_URL ||
+    process.env.SUPABASE_URL ||
+    process.env.SUPABASE_DATABASE_URL;
+
+if (supabaseUrl) {
+    env.NEXT_PUBLIC_SUPABASE_URL = supabaseUrl;
+}
+
+const supabaseAnonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    process.env.PUBLIC_SUPABASE_ANON_KEY ||
+    process.env.SUPABASE_ANON_KEY;
+
+if (supabaseAnonKey) {
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY = supabaseAnonKey;
+}
+
 const nextConfig = {
-    env: {
-        stackbitPreview: process.env.STACKBIT_PREVIEW
-    },
+    env,
     trailingSlash: true,
     reactStrictMode: true,
     allowedDevOrigins: [


### PR DESCRIPTION
## Summary
- expose public Supabase URL and anon key environment variables to the Next.js client build when only server-prefixed vars are set
- prevent calendar and projects pages from throwing missing Supabase configuration errors in production

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01586193c83299f8e5df62328408b