### PR TITLE
Refactor clients and contacts to Tabler UI

### DIFF
--- a/src/components/dashboard/card.tsx
+++ b/src/components/dashboard/card.tsx
@@ -9,13 +9,8 @@ type CardProps = {
 
 export function DashboardCard({ children, className }: CardProps) {
     return (
-        <div
-            className={cn(
-                'flex h-full flex-col rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/40',
-                className
-            )}
-        >
-            {children}
+        <div className={cn('card card-stacked h-100', className)}>
+            <div className="card-body">{children}</div>
         </div>
     );
 }

--- a/src/components/dashboard/layout-shell.tsx
+++ b/src/components/dashboard/layout-shell.tsx
@@ -8,11 +8,7 @@ type LayoutShellProps = {
 };
 
 export function LayoutShell({ children, className }: LayoutShellProps) {
-    return (
-        <div className={cn('mx-auto w-full max-w-7xl space-y-8 px-6 py-10 lg:px-8 lg:py-12', className)}>
-            {children}
-        </div>
-    );
+    return <div className={cn('container-xl py-4', className)}>{children}</div>;
 }
 
 export default LayoutShell;

--- a/src/components/dashboard/page-header.tsx
+++ b/src/components/dashboard/page-header.tsx
@@ -11,12 +11,14 @@ type PageHeaderProps = {
 
 export function PageHeader({ title, description, children, className }: PageHeaderProps) {
     return (
-        <div className={cn('flex flex-col gap-4 text-slate-100 sm:flex-row sm:items-start sm:justify-between', className)}>
-            <div className="space-y-2">
-                <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{title}</h1>
-                {description ? <p className="max-w-2xl text-sm text-slate-400">{description}</p> : null}
+        <div className={cn('page-header d-print-none', className)}>
+            <div className="row align-items-center">
+                <div className="col">
+                    <h2 className="page-title">{title}</h2>
+                    {description ? <div className="text-secondary mt-1">{description}</div> : null}
+                </div>
+                {children ? <div className="col-auto ms-auto d-print-none">{children}</div> : null}
             </div>
-            {children ? <div className="flex flex-none items-center gap-3">{children}</div> : null}
         </div>
     );
 }

--- a/src/components/dashboard/progress.tsx
+++ b/src/components/dashboard/progress.tsx
@@ -10,13 +10,17 @@ type ProgressProps = {
 export function Progress({ value, className }: ProgressProps) {
     const clamped = Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
     return (
-        <div className={cn('h-2 w-full rounded-full bg-slate-800/80', className)}>
+        <div className={cn('progress', className)}>
             <div
-                className="h-full rounded-full bg-indigo-500 transition-all"
+                className="progress-bar"
+                role="progressbar"
                 style={{ width: `${clamped}%` }}
-                aria-hidden
-            />
-            <span className="sr-only">{clamped}% complete</span>
+                aria-valuenow={clamped}
+                aria-valuemin={0}
+                aria-valuemax={100}
+            >
+                <span className="visually-hidden">{clamped}% complete</span>
+            </div>
         </div>
     );
 }

--- a/src/components/dashboard/toolbar.tsx
+++ b/src/components/dashboard/toolbar.tsx
@@ -14,19 +14,16 @@ type ToolbarSectionProps = {
 
 export function Toolbar({ children, className }: ToolbarProps) {
     return (
-        <div
-            className={cn(
-                'flex flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-950/60 p-4 shadow-lg shadow-slate-950/40 sm:flex-row sm:items-center sm:justify-between',
-                className
-            )}
-        >
-            {children}
+        <div className={cn('card card-stacked', className)}>
+            <div className="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
+                {children}
+            </div>
         </div>
     );
 }
 
 export function ToolbarSection({ children, className }: ToolbarSectionProps) {
-    return <div className={cn('flex flex-wrap items-center gap-3', className)}>{children}</div>;
+    return <div className={cn('d-flex flex-wrap align-items-center gap-3', className)}>{children}</div>;
 }
 
 export default Toolbar;

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -12,6 +12,8 @@ import {
     type SortingState
 } from '@tanstack/react-table';
 
+import { cn } from '../../lib/cn';
+
 type DataTableProps<TData> = {
     columns: ColumnDef<TData, any>[];
     data: TData[];
@@ -68,10 +70,10 @@ export function DataTable<TData>({
 
     const skeletonRows = React.useMemo(() => {
         return Array.from({ length: pageSize }).map((_, index) => (
-            <tr key={`skeleton-${index}`} className="animate-pulse">
+            <tr key={`skeleton-${index}`} className="placeholder-glow">
                 {table.getAllLeafColumns().map((column) => (
-                    <td key={column.id} className="h-12 border-b border-slate-800/60 px-4">
-                        <div className="h-3 rounded bg-slate-700/50" />
+                    <td key={column.id}>
+                        <span className="placeholder col-6" style={{ minHeight: '0.75rem' }} />
                     </td>
                 ))}
             </tr>
@@ -81,39 +83,37 @@ export function DataTable<TData>({
     const rows = table.getRowModel().rows;
 
     return (
-        <div className="flex flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/60 shadow-xl">
-            <div className="max-h-[65vh] overflow-auto">
-                <table className="min-w-full divide-y divide-slate-800 text-sm text-slate-100">
-                    <thead className="sticky top-0 z-10 bg-slate-950/80 backdrop-blur">
+        <div className="card card-stacked">
+            <div className="card-table table-responsive" style={{ maxHeight: '65vh' }}>
+                <table className="table card-table table-vcenter">
+                    <thead>
                         {table.getHeaderGroups().map((headerGroup) => (
                             <tr key={headerGroup.id}>
                                 {headerGroup.headers.map((header) => {
                                     const canSort = header.column.getCanSort();
                                     const sortingState = header.column.getIsSorted();
                                     return (
-                                        <th
-                                            key={header.id}
-                                            scope="col"
-                                            className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400"
-                                        >
-                                            {header.isPlaceholder ? null : canSort ? (
-                                                <button
-                                                    type="button"
-                                                    onClick={header.column.getToggleSortingHandler()}
-                                                    className="flex items-center gap-1 text-slate-200 transition hover:text-white"
-                                                >
-                                                    <span>{flexRender(header.column.columnDef.header, header.getContext())}</span>
-                                                    {sortingState ? (
-                                                        <span aria-hidden className="text-[10px]">
-                                                            {sortingState === 'desc' ? '↓' : '↑'}
-                                                        </span>
-                                                    ) : null}
-                                                </button>
-                                            ) : (
-                                                <div className="flex items-center gap-2 text-slate-200">
-                                                    {flexRender(header.column.columnDef.header, header.getContext())}
-                                                </div>
-                                            )}
+                                        <th key={header.id} scope="col" className="text-uppercase text-secondary small fw-semibold">
+                                            {header.isPlaceholder
+                                                ? null
+                                                : canSort
+                                                    ? (
+                                                          <button
+                                                              type="button"
+                                                              className="btn btn-link p-0 text-reset d-inline-flex align-items-center gap-1"
+                                                              onClick={header.column.getToggleSortingHandler()}
+                                                          >
+                                                              {flexRender(header.column.columnDef.header, header.getContext())}
+                                                              {sortingState ? (
+                                                                  <span aria-hidden className="text-secondary">
+                                                                      {sortingState === 'desc' ? '↓' : '↑'}
+                                                                  </span>
+                                                              ) : null}
+                                                          </button>
+                                                      )
+                                                    : (
+                                                          <span>{flexRender(header.column.columnDef.header, header.getContext())}</span>
+                                                      )}
                                         </th>
                                     );
                                 })}
@@ -124,43 +124,38 @@ export function DataTable<TData>({
                         {isLoading
                             ? skeletonRows
                             : rows.length === 0
-                              ? (
-                                    <tr>
-                                        <td
-                                            colSpan={columns.length}
-                                            className="px-6 py-16 text-center text-sm text-slate-400"
-                                        >
-                                            {emptyMessage ?? 'No results found.'}
-                                        </td>
-                                    </tr>
-                                )
-                              : rows.map((row) => {
-                                    const rowId = row.id;
-                                    return (
-                                        <tr
-                                            key={rowId}
-                                            className="group border-b border-slate-900/60 transition hover:bg-slate-900/60"
-                                            onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-                                        >
-                                            {row.getVisibleCells().map((cell) => (
-                                                <td key={cell.id} className="px-4 py-3 align-middle text-sm">
-                                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                                </td>
-                                            ))}
-                                        </tr>
-                                    );
-                                })}
+                                ? (
+                                      <tr>
+                                          <td colSpan={columns.length} className="text-center text-secondary py-5">
+                                              {emptyMessage ?? 'No results found.'}
+                                          </td>
+                                      </tr>
+                                  )
+                                : rows.map((row) => {
+                                      const rowId = row.id;
+                                      return (
+                                          <tr
+                                              key={rowId}
+                                              className={cn('align-middle', onRowClick ? 'cursor-pointer' : undefined)}
+                                              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                                          >
+                                              {row.getVisibleCells().map((cell) => (
+                                                  <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+                                              ))}
+                                          </tr>
+                                      );
+                                  })}
                     </tbody>
                 </table>
             </div>
-            <div className="flex items-center justify-between border-t border-slate-800/80 bg-slate-950/80 px-4 py-3 text-xs text-slate-400">
+            <div className="card-footer d-flex flex-column flex-md-row gap-2 align-items-center justify-content-between text-secondary small">
                 <div>
                     Page {pageIndex + 1} of {Math.max(1, table.getPageCount())}
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="d-flex align-items-center gap-2">
                     <button
                         type="button"
-                        className="rounded-full border border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-200 transition enabled:hover:border-indigo-400 enabled:hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                        className="btn btn-outline-secondary btn-sm"
                         onClick={() => table.previousPage()}
                         disabled={!table.getCanPreviousPage()}
                     >
@@ -168,7 +163,7 @@ export function DataTable<TData>({
                     </button>
                     <button
                         type="button"
-                        className="rounded-full border border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-200 transition enabled:hover:border-indigo-400 enabled:hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                        className="btn btn-outline-secondary btn-sm"
                         onClick={() => table.nextPage()}
                         disabled={!table.getCanNextPage()}
                     >

--- a/src/components/data/DataToolbar.tsx
+++ b/src/components/data/DataToolbar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Link from 'next/link';
+import classNames from 'classnames';
 
 type ToolbarFilterOption = {
     value: string;
@@ -88,60 +89,58 @@ export function DataToolbar({
     }, [localSearch, onSearchChange, searchValue]);
 
     return (
-        <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/60 p-4 backdrop-blur">
-            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div className="flex flex-1 items-center gap-3">
-                    <div className="relative flex-1">
-                        <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm text-slate-500">
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 20 20"
-                                fill="currentColor"
-                                className="h-4 w-4"
-                                aria-hidden="true"
-                            >
-                                <path
-                                    fillRule="evenodd"
-                                    d="M9 3.5a5.5 5.5 0 1 0 3.473 9.8l3.613 3.614a.75.75 0 1 0 1.06-1.061l-3.613-3.613A5.5 5.5 0 0 0 9 3.5Zm-4 5.5a4 4 0 1 1 8 0a4 4 0 0 1-8 0Z"
-                                    clipRule="evenodd"
-                                />
-                            </svg>
-                        </span>
-                        <input
-                            type="search"
-                            className="w-full rounded-xl border border-slate-700 bg-slate-900/80 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder-slate-500 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
-                            placeholder={searchPlaceholder}
-                            value={localSearch}
-                            onChange={(event) => setLocalSearch(event.target.value)}
-                            aria-label="Search"
-                        />
+        <div className="card card-stacked">
+            <div className="card-body d-flex flex-column gap-3">
+                <div className="row g-2 align-items-center">
+                    <div className="col-md">
+                        <div className="input-icon">
+                            <span className="input-icon-addon">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 20 20"
+                                    fill="currentColor"
+                                    className="icon"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fillRule="evenodd"
+                                        d="M9 3.5a5.5 5.5 0 1 0 3.473 9.8l3.613 3.614a.75.75 0 1 0 1.06-1.061l-3.613-3.613A5.5 5.5 0 0 0 9 3.5Zm-4 5.5a4 4 0 1 1 8 0a4 4 0 0 1-8 0Z"
+                                        clipRule="evenodd"
+                                    />
+                                </svg>
+                            </span>
+                            <input
+                                type="search"
+                                className="form-control"
+                                placeholder={searchPlaceholder}
+                                value={localSearch}
+                                onChange={(event) => setLocalSearch(event.target.value)}
+                                aria-label="Search"
+                            />
+                        </div>
                     </div>
                     {viewOptions && viewOptions.length > 0 ? (
-                        <nav aria-label="Views" className="hidden overflow-hidden rounded-full bg-slate-800/80 p-1 text-xs font-medium text-slate-400 shadow-inner md:flex">
-                            {viewOptions.map((option) => (
-                                <Link
-                                    key={option.id}
-                                    href={option.href}
-                                    className={`flex-1 rounded-full px-4 py-1.5 text-center transition ${
-                                        option.active
-                                            ? 'bg-gradient-to-r from-indigo-500 via-purple-500 to-indigo-600 text-white shadow'
-                                            : 'hover:text-slate-100'
-                                    }`}
-                                >
-                                    {option.label}
-                                </Link>
-                            ))}
-                        </nav>
+                        <div className="col-auto">
+                            <div className="btn-group btn-group-sm" role="group" aria-label="View options">
+                                {viewOptions.map((option) => (
+                                    <Link
+                                        key={option.id}
+                                        href={option.href}
+                                        className={classNames('btn', option.active ? 'btn-primary' : 'btn-outline-secondary')}
+                                    >
+                                        {option.label}
+                                    </Link>
+                                ))}
+                            </div>
+                        </div>
                     ) : null}
-                </div>
-                <div className="flex items-center gap-3">
-                    <div className="flex items-center gap-2 text-xs text-slate-400">
-                        <label htmlFor="sort" className="hidden md:block">
+                    <div className="col-auto d-flex align-items-center gap-2">
+                        <label htmlFor="sort" className="text-secondary small mb-0">
                             Sort by
                         </label>
                         <select
                             id="sort"
-                            className="rounded-xl border border-slate-700 bg-slate-900/80 px-3 py-1.5 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+                            className="form-select form-select-sm"
                             value={sortValue}
                             onChange={(event) => onSortChange(event.target.value)}
                         >
@@ -153,66 +152,65 @@ export function DataToolbar({
                         </select>
                     </div>
                     {primaryAction ? (
-                        primaryAction.href ? (
-                            <Link
-                                href={primaryAction.href}
-                                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:from-indigo-400 hover:via-purple-500 hover:to-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-300"
-                            >
-                                {primaryAction.icon}
-                                {primaryAction.label}
-                            </Link>
-                        ) : (
-                            <button
-                                type="button"
-                                onClick={primaryAction.onClick}
-                                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:from-indigo-400 hover:via-purple-500 hover:to-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-300"
-                            >
-                                {primaryAction.icon}
-                                {primaryAction.label}
-                            </button>
-                        )
-                    ) : null}
-                </div>
-            </div>
-            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div className="flex flex-wrap items-center gap-2">
-                    {filters.map((filter) => (
-                        <ToolbarFilterChip key={filter.id} filter={filter} />
-                    ))}
-                    {hasActiveFilters && onResetFilters ? (
-                        <button
-                            type="button"
-                            className="rounded-full border border-transparent bg-slate-800/60 px-3 py-1 text-xs font-medium text-slate-200 transition hover:border-slate-700 hover:bg-slate-800"
-                            onClick={onResetFilters}
-                        >
-                            Clear filters
-                        </button>
-                    ) : null}
-                </div>
-                <div className="flex flex-wrap items-center gap-3 md:justify-end">
-                    {typeof pageSize === 'number' && onPageSizeChange ? (
-                        <label className="flex items-center gap-2 text-xs text-slate-400">
-                            Show
-                            <select
-                                className="rounded-xl border border-slate-700 bg-slate-900/80 px-2 py-1 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
-                                value={pageSize}
-                                onChange={(event) => onPageSizeChange(Number.parseInt(event.target.value, 10))}
-                            >
-                                {pageSizeOptions.map((option) => (
-                                    <option key={option} value={option}>
-                                        {option}
-                                    </option>
-                                ))}
-                            </select>
-                            rows
-                        </label>
-                    ) : null}
-                    {selectedCount > 0 ? (
-                        <div className="rounded-full border border-indigo-400/40 bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-200">
-                            {selectedCount} selected
+                        <div className="col-auto">
+                            {primaryAction.href ? (
+                                <Link href={primaryAction.href} className="btn btn-primary d-inline-flex align-items-center gap-2">
+                                    {primaryAction.icon}
+                                    {primaryAction.label}
+                                </Link>
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={primaryAction.onClick}
+                                    className="btn btn-primary d-inline-flex align-items-center gap-2"
+                                >
+                                    {primaryAction.icon}
+                                    {primaryAction.label}
+                                </button>
+                            )}
                         </div>
                     ) : null}
-                    {bulkActions}
+                </div>
+
+                {filters.length > 0 || (hasActiveFilters && onResetFilters) ? (
+                    <div className="d-flex flex-wrap align-items-center gap-2">
+                        {filters.map((filter) => (
+                            <ToolbarFilterChip key={filter.id} filter={filter} />
+                        ))}
+                        {hasActiveFilters && onResetFilters ? (
+                            <button type="button" className="btn btn-link btn-sm text-secondary" onClick={onResetFilters}>
+                                Clear filters
+                            </button>
+                        ) : null}
+                    </div>
+                ) : null}
+
+                <div className="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                    <div className="d-flex flex-wrap align-items-center gap-3">
+                        {typeof pageSize === 'number' && onPageSizeChange ? (
+                            <label className="d-flex align-items-center gap-2 text-secondary small mb-0">
+                                Show
+                                <select
+                                    className="form-select form-select-sm"
+                                    value={pageSize}
+                                    onChange={(event) => onPageSizeChange(Number.parseInt(event.target.value, 10))}
+                                >
+                                    {pageSizeOptions.map((option) => (
+                                        <option key={option} value={option}>
+                                            {option}
+                                        </option>
+                                    ))}
+                                </select>
+                                rows
+                            </label>
+                        ) : null}
+                        {selectedCount > 0 ? (
+                            <span className="badge bg-primary-lt text-primary text-uppercase fw-semibold">
+                                {selectedCount} selected
+                            </span>
+                        ) : null}
+                    </div>
+                    <div className="d-flex flex-wrap align-items-center gap-2">{bulkActions}</div>
                 </div>
             </div>
         </div>
@@ -255,75 +253,66 @@ export function ToolbarFilterChip({ filter }: { filter: ToolbarFilter }) {
     const activeCount = filter.value.length;
 
     return (
-        <div className="relative" ref={containerRef}>
+        <div className={classNames('dropdown', { show: open })} ref={containerRef}>
             <button
                 type="button"
-                className={`flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition ${
-                    activeCount
-                        ? 'border-indigo-400/60 bg-indigo-500/10 text-indigo-200'
-                        : 'border-slate-700 bg-slate-800/60 text-slate-200 hover:border-slate-600'
-                }`}
+                className={classNames('btn btn-sm d-inline-flex align-items-center gap-2', activeCount ? 'btn-primary' : 'btn-outline-secondary')}
                 onClick={() => setOpen((previous) => !previous)}
                 aria-haspopup="menu"
                 aria-expanded={open}
             >
                 {filter.label}
-                {activeCount ? <span className="rounded-full bg-indigo-500/40 px-1.5 py-0.5 text-[10px] text-white">{activeCount}</span> : null}
+                {activeCount ? <span className="badge bg-white text-primary">{activeCount}</span> : null}
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 20 20"
                     fill="currentColor"
-                    className="h-3 w-3"
+                    className="icon"
+                    aria-hidden="true"
                 >
                     <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.94l3.71-3.71a.75.75 0 1 1 1.06 1.06l-4.24 4.25a.75.75 0 0 1-1.06 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" />
                 </svg>
             </button>
-            {open ? (
-                <div
-                    role="menu"
-                    className="absolute right-0 z-20 mt-2 w-60 rounded-2xl border border-slate-700 bg-slate-900/95 p-4 text-sm text-slate-100 shadow-2xl"
-                >
-                    <div className="mb-3 flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-                        <span>{filter.label}</span>
-                        <button
-                            type="button"
-                            className="text-[11px] font-medium text-indigo-300 hover:text-indigo-200"
-                            onClick={() => filter.onChange([])}
-                        >
-                            Clear
-                        </button>
-                    </div>
-                    <div className="flex flex-col gap-2">
-                        {filter.options.map((option) => {
-                            const checked = filter.value.includes(option.value);
-                            return (
-                                <label key={option.value} className="flex items-start gap-2 rounded-xl px-2 py-2 hover:bg-slate-800/70">
-                                    <input
-                                        type="checkbox"
-                                        checked={checked}
-                                        onChange={() => {
-                                            const next = new Set(filter.value);
-                                            if (checked) {
-                                                next.delete(option.value);
-                                            } else {
-                                                next.add(option.value);
-                                            }
-                                            filter.onChange(Array.from(next));
-                                        }}
-                                        className="mt-1 h-3.5 w-3.5 rounded border border-slate-600 bg-slate-900 text-indigo-400 focus:ring-1 focus:ring-indigo-400"
-                                    />
-                                    <span className="flex-1 text-sm text-slate-100">
-                                        <span className="block font-medium">{option.label}</span>
-                                        {option.description ? (
-                                            <span className="mt-0.5 block text-xs text-slate-400">{option.description}</span>
-                                        ) : null}
-                                    </span>
-                                </label>
-                            );
-                        })}
-                    </div>
+            <div
+                role="menu"
+                className={classNames('dropdown-menu dropdown-menu-card dropdown-menu-end p-3', { show: open })}
+            >
+                <div className="d-flex align-items-center justify-content-between text-uppercase text-secondary small mb-2">
+                    <span>{filter.label}</span>
+                    <button type="button" className="btn btn-link btn-sm p-0" onClick={() => filter.onChange([])}>
+                        Clear
+                    </button>
                 </div>
-            ) : null}
+                <div className="d-flex flex-column gap-2">
+                    {filter.options.map((option) => {
+                        const checked = filter.value.includes(option.value);
+                        return (
+                            <label key={option.value} className="form-check d-flex align-items-start gap-2">
+                                <input
+                                    type="checkbox"
+                                    className="form-check-input mt-1"
+                                    checked={checked}
+                                    onChange={() => {
+                                        const next = new Set(filter.value);
+                                        if (checked) {
+                                            next.delete(option.value);
+                                        } else {
+                                            next.add(option.value);
+                                        }
+                                        filter.onChange(Array.from(next));
+                                    }}
+                                />
+                                <span className="form-check-label">
+                                    <span className="fw-semibold d-block">{option.label}</span>
+                                    {option.description ? (
+                                        <span className="text-secondary small d-block">{option.description}</span>
+                                    ) : null}
+                                </span>
+                            </label>
+                        );
+                    })}
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -7,15 +7,15 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 const badgeStyles: Record<NonNullable<BadgeProps['variant']>, string> = {
-    default: 'bg-slate-800/80 text-slate-200 border border-slate-700/80',
-    success: 'bg-emerald-500/20 text-emerald-200 border border-emerald-400/60',
-    warning: 'bg-amber-500/20 text-amber-100 border border-amber-400/60',
-    neutral: 'bg-slate-700/40 text-slate-300 border border-slate-600/50'
+    default: 'bg-primary-lt text-primary',
+    success: 'bg-success-lt text-success',
+    warning: 'bg-warning-lt text-warning',
+    neutral: 'bg-secondary-lt text-secondary'
 };
 
 export const Badge = ({ className, variant = 'default', ...props }: BadgeProps) => (
     <span
-        className={cn('inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide', badgeStyles[variant], className)}
+        className={cn('badge text-uppercase fw-semibold', badgeStyles[variant], className)}
         {...props}
     />
 );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,19 +6,16 @@ export type ButtonVariant = 'default' | 'outline' | 'ghost';
 export type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
 
 const variantClasses: Record<ButtonVariant, string> = {
-    default:
-        'bg-indigo-500 text-white shadow-lg shadow-indigo-500/25 transition hover:bg-indigo-400 focus-visible:outline-indigo-400 dark:bg-indigo-500 dark:hover:bg-indigo-400',
-    outline:
-        'border border-slate-200 bg-white text-slate-700 transition hover:bg-slate-100 focus-visible:outline-indigo-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800',
-    ghost:
-        'bg-transparent text-slate-500 transition hover:bg-slate-100 focus-visible:outline-indigo-400 dark:text-slate-300 dark:hover:bg-slate-800'
+    default: 'btn-primary',
+    outline: 'btn-outline-secondary',
+    ghost: 'btn-link text-secondary px-0'
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
-    default: 'h-11 px-4 py-2 text-sm',
-    sm: 'h-9 px-3 text-xs',
-    lg: 'h-12 px-5 text-base',
-    icon: 'h-10 w-10 p-0'
+    default: '',
+    sm: 'btn-sm',
+    lg: 'btn-lg',
+    icon: 'btn-icon'
 };
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -34,9 +31,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             <button
                 ref={ref}
                 className={cn(
-                    'inline-flex items-center justify-center gap-2 rounded-2xl font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60',
+                    'btn d-inline-flex align-items-center gap-2 fw-semibold disabled:opacity-75',
                     variantClasses[variant],
                     sizeClasses[size],
+                    size === 'icon' && variant !== 'ghost' ? '' : undefined,
                     className
                 )}
                 disabled={isDisabled}
@@ -44,8 +42,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             >
                 {isLoading ? (
                     <>
-                        <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" aria-hidden="true" />
-                        <span className="sr-only">Loading</span>
+                        <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" />
+                        <span className="visually-hidden">Loading</span>
                         <span>{children}</span>
                     </>
                 ) : (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -11,7 +11,7 @@ const DialogOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.O
     ({ className, ...props }, ref) => (
         <DialogPrimitive.Overlay
             ref={ref}
-            className={cn('fixed inset-0 z-40 bg-slate-950/60 backdrop-blur-sm', className)}
+            className={cn('modal-backdrop fade show', className)}
             {...props}
         />
     )
@@ -24,13 +24,12 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
             <DialogOverlay />
             <DialogPrimitive.Content
                 ref={ref}
-                className={cn(
-                    'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-6 rounded-3xl border border-slate-800 bg-slate-950/95 p-6 text-slate-100 shadow-2xl focus:outline-none',
-                    className
-                )}
+                className="modal modal-blur fade show d-block"
                 {...props}
             >
-                {children}
+                <div className="modal-dialog modal-dialog-centered modal-lg" role="document">
+                    <div className={cn('modal-content shadow-sm', className)}>{children}</div>
+                </div>
             </DialogPrimitive.Content>
         </DialogPortal>
     )
@@ -38,16 +37,12 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col gap-1.5 text-left', className)} {...props} />
+    <div ref={ref} className={cn('modal-header', className)} {...props} />
 ));
 DialogHeader.displayName = 'DialogHeader';
 
 const DialogFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-    <div
-        ref={ref}
-        className={cn('flex flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-4', className)}
-        {...props}
-    />
+    <div ref={ref} className={cn('modal-footer', className)} {...props} />
 ));
 DialogFooter.displayName = 'DialogFooter';
 
@@ -55,7 +50,7 @@ const DialogTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Tit
     ({ className, ...props }, ref) => (
         <DialogPrimitive.Title
             ref={ref}
-            className={cn('text-xl font-semibold leading-tight text-white', className)}
+            className={cn('modal-title', className)}
             {...props}
         />
     )
@@ -66,7 +61,7 @@ const DialogDescription = React.forwardRef<React.ElementRef<typeof DialogPrimiti
     ({ className, ...props }, ref) => (
         <DialogPrimitive.Description
             ref={ref}
-            className={cn('text-sm text-slate-400', className)}
+            className={cn('text-secondary', className)}
             {...props}
         />
     )

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -13,7 +13,7 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <DialogPrimitive.Overlay
         ref={ref}
-        className={cn('fixed inset-0 z-40 bg-slate-950/70 backdrop-blur-sm', className)}
+        className={cn('offcanvas-backdrop fade show', className)}
         {...props}
     />
 ));
@@ -27,25 +27,22 @@ const DrawerContent = React.forwardRef<
         <DrawerOverlay />
         <DialogPrimitive.Content
             ref={ref}
-            className={cn(
-                'fixed inset-y-0 right-0 z-50 flex w-full max-w-xl flex-col gap-6 overflow-y-auto border-l border-slate-800 bg-slate-950/95 p-6 text-slate-100 shadow-2xl focus:outline-none',
-                className
-            )}
+            className={cn('offcanvas offcanvas-end show', className)}
             {...props}
         >
-            {children}
+            <div className="offcanvas-body d-flex flex-column gap-4">{children}</div>
         </DialogPrimitive.Content>
     </DrawerPortal>
 ));
 DrawerContent.displayName = DialogPrimitive.Content.displayName;
 
 const DrawerHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col gap-1.5 text-left', className)} {...props} />
+    <div ref={ref} className={cn('offcanvas-header', className)} {...props} />
 ));
 DrawerHeader.displayName = 'DrawerHeader';
 
 const DrawerFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('mt-auto flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4', className)} {...props} />
+    <div ref={ref} className={cn('offcanvas-footer border-top pt-3 d-flex gap-2 justify-content-end', className)} {...props} />
 ));
 DrawerFooter.displayName = 'DrawerFooter';
 
@@ -53,7 +50,7 @@ const DrawerTitle = React.forwardRef<
     React.ElementRef<typeof DialogPrimitive.Title>,
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-    <DialogPrimitive.Title ref={ref} className={cn('text-xl font-semibold leading-tight text-white', className)} {...props} />
+    <DialogPrimitive.Title ref={ref} className={cn('offcanvas-title h4 mb-0', className)} {...props} />
 ));
 DrawerTitle.displayName = DialogPrimitive.Title.displayName;
 
@@ -61,7 +58,7 @@ const DrawerDescription = React.forwardRef<
     React.ElementRef<typeof DialogPrimitive.Description>,
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-    <DialogPrimitive.Description ref={ref} className={cn('text-sm text-slate-400', className)} {...props} />
+    <DialogPrimitive.Description ref={ref} className={cn('text-secondary', className)} {...props} />
 ));
 DrawerDescription.displayName = DialogPrimitive.Description.displayName;
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className
             ref={ref}
             type={type}
             className={cn(
-                'flex h-11 w-full rounded-2xl border border-slate-700/60 bg-slate-900/60 px-4 text-sm text-white placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 disabled:cursor-not-allowed disabled:opacity-60',
+                'form-control',
                 className
             )}
             {...props}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -7,7 +7,7 @@ export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> 
 export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
     <label
         ref={ref}
-        className={cn('text-sm font-semibold text-slate-200', className)}
+        className={cn('form-label fw-semibold text-secondary', className)}
         {...props}
     />
 ));

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -8,7 +8,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(({ classN
     <select
         ref={ref}
         className={cn(
-            'flex h-11 w-full appearance-none rounded-2xl border border-slate-700/60 bg-slate-900/60 px-4 text-sm text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 disabled:cursor-not-allowed disabled:opacity-60',
+            'form-select',
             className
         )}
         {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ 
     <textarea
         ref={ref}
         className={cn(
-            'flex w-full rounded-2xl border border-slate-700/60 bg-slate-900/60 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 disabled:cursor-not-allowed disabled:opacity-60',
+            'form-control',
             className
         )}
         {...props}

--- a/src/pages/clients/index.tsx
+++ b/src/pages/clients/index.tsx
@@ -11,6 +11,7 @@ import {
     Dialog,
     DialogContent,
     DialogDescription,
+    DialogFooter,
     DialogHeader,
     DialogTitle
 } from '../../components/ui/dialog';
@@ -204,34 +205,42 @@ function ClientsWorkspace() {
     }, []);
 
     return (
-        <div className="flex flex-col gap-6">
-            <section className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-                <KpiCard
-                    label="Active clients"
-                    value={String(metricsData?.activeCount ?? 0)}
-                    helper="Status set to Active"
-                />
-                <KpiCard
-                    label="Outstanding balance"
-                    value={formatCurrency(metricsData?.outstandingCents ?? 0)}
-                    helper="Across all clients"
-                />
-                <KpiCard
-                    label="Upcoming shoots"
-                    value={String(metricsData?.upcomingCount60d ?? 0)}
-                    helper="Next 60 days"
-                />
-                <KpiCard
-                    label="Portal ready"
-                    value={String(metricsData?.portalReadyCount ?? 0)}
-                    helper="Client portal enabled"
-                />
-            </section>
+        <div className="d-flex flex-column gap-4 pb-5">
+            <div className="row row-cards">
+                <div className="col-sm-6 col-lg-3">
+                    <KpiCard
+                        label="Active clients"
+                        value={String(metricsData?.activeCount ?? 0)}
+                        helper="Status set to Active"
+                    />
+                </div>
+                <div className="col-sm-6 col-lg-3">
+                    <KpiCard
+                        label="Outstanding balance"
+                        value={formatCurrency(metricsData?.outstandingCents ?? 0)}
+                        helper="Across all clients"
+                    />
+                </div>
+                <div className="col-sm-6 col-lg-3">
+                    <KpiCard
+                        label="Upcoming shoots"
+                        value={String(metricsData?.upcomingCount60d ?? 0)}
+                        helper="Next 60 days"
+                    />
+                </div>
+                <div className="col-sm-6 col-lg-3">
+                    <KpiCard
+                        label="Portal ready"
+                        value={String(metricsData?.portalReadyCount ?? 0)}
+                        helper="Client portal enabled"
+                    />
+                </div>
+            </div>
 
-            <section className="flex flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/50">
-                <div className="flex flex-col gap-3 md:flex-row md:items-center">
-                    <div className="flex flex-1 flex-wrap items-center gap-3">
-                        <div className="relative min-w-[220px] flex-1">
+            <div className="card card-stacked">
+                <div className="card-body d-flex flex-column gap-3">
+                    <div className="row g-3 align-items-end">
+                        <div className="col-md">
                             <Input
                                 type="search"
                                 value={search}
@@ -240,8 +249,8 @@ function ClientsWorkspace() {
                                 aria-label="Search clients"
                             />
                         </div>
-                        <div className="flex min-w-[150px] flex-col gap-1 text-xs text-slate-400">
-                            <span>Status</span>
+                        <div className="col-sm-6 col-md-3">
+                            <Label>Status</Label>
                             <Select
                                 value={statusFilter}
                                 onChange={(event) => setStatusFilter(event.target.value as ClientStatus | 'All')}
@@ -255,8 +264,8 @@ function ClientsWorkspace() {
                                 ))}
                             </Select>
                         </div>
-                        <div className="flex min-w-[180px] flex-col gap-1 text-xs text-slate-400">
-                            <span>Sort</span>
+                        <div className="col-sm-6 col-md-3">
+                            <Label>Sort</Label>
                             <Select
                                 value={sort}
                                 onChange={(event) => setSort(event.target.value as SortOptionId)}
@@ -269,24 +278,26 @@ function ClientsWorkspace() {
                                 ))}
                             </Select>
                         </div>
+                        <div className="col-12 col-md-auto ms-auto">
+                            <Button type="button" onClick={() => setDialogOpen(true)}>
+                                Add client
+                            </Button>
+                        </div>
                     </div>
-                    <Button type="button" className="w-full md:ml-auto md:w-auto" onClick={() => setDialogOpen(true)}>
-                        Add client
-                    </Button>
+
+                    {clientsError ? (
+                        <div className="alert alert-danger" role="status">
+                            {clientsError.message}
+                        </div>
+                    ) : null}
+
+                    {showEmptyState ? (
+                        <EmptyState onAddClient={() => setDialogOpen(true)} />
+                    ) : (
+                        <ClientsTable clients={clients} isLoading={isLoadingClients} />
+                    )}
                 </div>
-
-                {clientsError ? (
-                    <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-200">
-                        {clientsError.message}
-                    </div>
-                ) : null}
-
-                {showEmptyState ? (
-                    <EmptyState onAddClient={() => setDialogOpen(true)} />
-                ) : (
-                    <ClientsTable clients={clients} isLoading={isLoadingClients} />
-                )}
-            </section>
+            </div>
 
             <AddClientDialog
                 open={isDialogOpen}
@@ -404,70 +415,101 @@ function AddClientDialog({ open, onOpenChange, onCreated, onError }: AddClientDi
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-xl">
-                <DialogHeader>
-                    <DialogTitle>Add client</DialogTitle>
-                    <DialogDescription>Capture the essentials so you can schedule shoots and share portals later.</DialogDescription>
-                </DialogHeader>
-                <form className="flex flex-col gap-4" onSubmit={onSubmit}>
-                    <div className="space-y-2">
-                        <Label htmlFor="client-name">Name</Label>
-                        <Input id="client-name" placeholder="Client name" {...register('name')} aria-invalid={Boolean(errors.name)} />
-                        {errors.name ? <FieldError message={errors.name.message} /> : null}
-                    </div>
-                    <div className="grid gap-4 md:grid-cols-2">
-                        <div className="space-y-2">
-                            <Label htmlFor="client-email">Email</Label>
-                            <Input id="client-email" type="email" placeholder="name@example.com" {...register('email')} aria-invalid={Boolean(errors.email)} />
-                            {errors.email ? <FieldError message={errors.email.message} /> : null}
+            <DialogContent>
+                <form onSubmit={onSubmit} noValidate>
+                    <DialogHeader>
+                        <DialogTitle>Add client</DialogTitle>
+                        <DialogDescription>
+                            Capture the essentials so you can schedule shoots and share portals later.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="modal-body">
+                        <div className="mb-3">
+                            <Label htmlFor="client-name">Name</Label>
+                            <Input
+                                id="client-name"
+                                placeholder="Client name"
+                                className={errors.name ? 'is-invalid' : undefined}
+                                {...register('name')}
+                            />
+                            <FieldError message={errors.name?.message} />
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="client-phone">Phone</Label>
-                            <Input id="client-phone" placeholder="(555) 555-5555" {...register('phone')} aria-invalid={Boolean(errors.phone)} />
-                            {errors.phone ? <FieldError message={errors.phone.message} /> : null}
+                        <div className="row g-3">
+                            <div className="col-md-6">
+                                <Label htmlFor="client-email">Email</Label>
+                                <Input
+                                    id="client-email"
+                                    type="email"
+                                    placeholder="name@example.com"
+                                    className={errors.email ? 'is-invalid' : undefined}
+                                    {...register('email')}
+                                />
+                                <FieldError message={errors.email?.message} />
+                            </div>
+                            <div className="col-md-6">
+                                <Label htmlFor="client-phone">Phone</Label>
+                                <Input
+                                    id="client-phone"
+                                    placeholder="(555) 555-5555"
+                                    className={errors.phone ? 'is-invalid' : undefined}
+                                    {...register('phone')}
+                                />
+                                <FieldError message={errors.phone?.message} />
+                            </div>
                         </div>
-                    </div>
-                    <div className="grid gap-4 md:grid-cols-2">
-                        <div className="space-y-2">
-                            <Label htmlFor="client-status">Status</Label>
-                            <Select id="client-status" {...register('status')} aria-invalid={Boolean(errors.status)}>
-                                {STATUS_OPTIONS.map((status) => (
-                                    <option key={status} value={status}>
-                                        {status}
-                                    </option>
-                                ))}
-                            </Select>
-                            {errors.status ? <FieldError message={errors.status.message} /> : null}
+                        <div className="row g-3 mt-1">
+                            <div className="col-md-6">
+                                <Label htmlFor="client-status">Status</Label>
+                                <Select
+                                    id="client-status"
+                                    className={errors.status ? 'is-invalid' : undefined}
+                                    {...register('status')}
+                                >
+                                    {STATUS_OPTIONS.map((status) => (
+                                        <option key={status} value={status}>
+                                            {status}
+                                        </option>
+                                    ))}
+                                </Select>
+                                <FieldError message={errors.status?.message} />
+                            </div>
+                            <div className="col-md-6">
+                                <Label htmlFor="client-upcoming">Upcoming shoot</Label>
+                                <Input
+                                    id="client-upcoming"
+                                    type="date"
+                                    className={errors.upcoming_shoot ? 'is-invalid' : undefined}
+                                    {...register('upcoming_shoot')}
+                                />
+                                <FieldError message={errors.upcoming_shoot?.message} />
+                            </div>
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="client-upcoming">Upcoming shoot</Label>
-                            <Input id="client-upcoming" type="date" {...register('upcoming_shoot')} aria-invalid={Boolean(errors.upcoming_shoot)} />
-                            {errors.upcoming_shoot ? <FieldError message={errors.upcoming_shoot.message} /> : null}
+                        <div className="mb-3 mt-3">
+                            <Label htmlFor="client-tags">Tags</Label>
+                            <Textarea
+                                id="client-tags"
+                                placeholder="wedding, vip, retainer"
+                                rows={2}
+                                className={errors.tags ? 'is-invalid' : undefined}
+                                {...register('tags')}
+                            />
+                            <div className="form-text">Separate tags with commas to group clients later.</div>
+                            <FieldError message={errors.tags?.message} />
                         </div>
+                        {serverError ? (
+                            <div className="alert alert-danger" role="alert">
+                                {serverError}
+                            </div>
+                        ) : null}
                     </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="client-tags">Tags</Label>
-                        <Textarea
-                            id="client-tags"
-                            placeholder="wedding, vip, retainer"
-                            rows={2}
-                            {...register('tags')}
-                            aria-invalid={Boolean(errors.tags)}
-                        />
-                        <p className="text-xs text-slate-400">Separate tags with commas to group clients later.</p>
-                        {errors.tags ? <FieldError message={errors.tags.message} /> : null}
-                    </div>
-                    {serverError ? (
-                        <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-200">{serverError}</div>
-                    ) : null}
-                    <div className="flex justify-end gap-3 pt-2">
+                    <DialogFooter>
                         <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
                             Cancel
                         </Button>
                         <Button type="submit" isLoading={isSubmitting}>
                             Save client
                         </Button>
-                    </div>
+                    </DialogFooter>
                 </form>
             </DialogContent>
         </Dialog>
@@ -482,35 +524,36 @@ type ClientsTableProps = {
 function ClientsTable({ clients, isLoading }: ClientsTableProps) {
     if (isLoading) {
         return (
-            <div className="flex h-32 items-center justify-center rounded-2xl border border-slate-800/70 bg-slate-950/80 text-sm text-slate-300">
-                Loading clients…
+            <div className="text-center text-secondary py-5">
+                <div className="spinner-border text-primary mb-2" role="status" aria-hidden />
+                <div>Loading clients…</div>
             </div>
         );
     }
 
     return (
-        <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 shadow-inner">
-            <table className="min-w-full divide-y divide-slate-800 text-sm">
-                <thead className="bg-slate-950/80">
+        <div className="table-responsive">
+            <table className="table card-table table-vcenter">
+                <thead>
                     <tr>
                         <TableHeaderCell>Name</TableHeaderCell>
                         <TableHeaderCell>Status</TableHeaderCell>
                         <TableHeaderCell>Email</TableHeaderCell>
                         <TableHeaderCell>Phone</TableHeaderCell>
-                        <TableHeaderCell className="text-right">Outstanding</TableHeaderCell>
+                        <TableHeaderCell className="text-end">Outstanding</TableHeaderCell>
                         <TableHeaderCell>Upcoming shoot</TableHeaderCell>
                         <TableHeaderCell>Portal ready</TableHeaderCell>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-900/80">
+                <tbody>
                     {clients.map((client) => {
                         const portalReady = client.portal_enabled || Boolean(client.portal_url);
                         return (
-                            <tr key={client.id} className="bg-slate-950/60 hover:bg-slate-900/60">
+                            <tr key={client.id}>
                                 <TableCell>
-                                    <div className="flex flex-col">
-                                        <span className="text-sm font-semibold text-white">{client.name}</span>
-                                        <span className="text-xs text-slate-400">Last updated {formatDate(client.updated_at)}</span>
+                                    <div className="d-flex flex-column">
+                                        <span className="fw-semibold">{client.name}</span>
+                                        <span className="text-secondary small">Last updated {formatDate(client.updated_at)}</span>
                                     </div>
                                 </TableCell>
                                 <TableCell>
@@ -518,7 +561,7 @@ function ClientsTable({ clients, isLoading }: ClientsTableProps) {
                                 </TableCell>
                                 <TableCell>{client.email ?? '—'}</TableCell>
                                 <TableCell>{client.phone ?? '—'}</TableCell>
-                                <TableCell className="text-right font-semibold text-white">
+                                <TableCell className="text-end fw-semibold">
                                     {formatCurrency(client.outstanding_cents)}
                                 </TableCell>
                                 <TableCell>{formatDate(client.upcoming_shoot)}</TableCell>
@@ -546,10 +589,12 @@ type KpiCardProps = {
 
 function KpiCard({ label, value, helper }: KpiCardProps) {
     return (
-        <div className="flex h-28 flex-col justify-center rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/50">
-            <span className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">{label}</span>
-            <span className="mt-3 text-3xl font-semibold leading-none text-white">{value}</span>
-            <span className="mt-2 text-xs text-slate-500">{helper}</span>
+        <div className="card card-stacked h-100">
+            <div className="card-body">
+                <div className="text-uppercase text-secondary small fw-semibold">{label}</div>
+                <div className="h2 mt-2 mb-2">{value}</div>
+                <div className="text-secondary small">{helper}</div>
+            </div>
         </div>
     );
 }
@@ -560,14 +605,18 @@ type EmptyStateProps = {
 
 function EmptyState({ onAddClient }: EmptyStateProps) {
     return (
-        <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/80 px-10 py-16 text-center text-slate-300">
-            <p className="text-lg font-semibold text-white">No clients yet</p>
-            <p className="max-w-md text-sm text-slate-400">
-                When you add your first client they will appear here with shoot dates, portal access, and balance tracking.
-            </p>
-            <Button type="button" onClick={onAddClient}>
-                Add client
-            </Button>
+        <div className="card card-stacked">
+            <div className="card-body text-center">
+                <p className="h4">No clients yet</p>
+                <p className="text-secondary">
+                    When you add your first client they will appear here with shoot dates, portal access, and balance tracking.
+                </p>
+                <div className="mt-3">
+                    <Button type="button" onClick={onAddClient}>
+                        Add client
+                    </Button>
+                </div>
+            </div>
         </div>
     );
 }
@@ -582,15 +631,9 @@ function Toast({ toast }: ToastProps) {
     }
 
     return (
-        <div className="pointer-events-none fixed bottom-6 right-6 z-50">
-            <div
-                className={`pointer-events-auto rounded-2xl border px-4 py-3 text-sm shadow-lg ${
-                    toast.variant === 'success'
-                        ? 'border-emerald-400/50 bg-emerald-500/15 text-emerald-100'
-                        : 'border-rose-400/50 bg-rose-500/15 text-rose-100'
-                }`}
-            >
-                {toast.message}
+        <div className="position-fixed bottom-0 end-0 p-3" style={{ zIndex: 1050 }}>
+            <div className={`toast show text-white ${toast.variant === 'success' ? 'bg-success' : 'bg-danger'}`} role="status">
+                <div className="toast-body">{toast.message}</div>
             </div>
         </div>
     );
@@ -601,15 +644,12 @@ type TableCellProps = React.TdHTMLAttributes<HTMLTableCellElement>;
 type TableHeaderCellProps = React.ThHTMLAttributes<HTMLTableCellElement>;
 
 function TableCell({ className, ...props }: TableCellProps) {
-    return <td className={`px-6 py-4 text-sm text-slate-200 ${className ?? ''}`} {...props} />;
+    return <td className={`align-middle ${className ?? ''}`} {...props} />;
 }
 
 function TableHeaderCell({ className, ...props }: TableHeaderCellProps) {
     return (
-        <th
-            className={`px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400 ${className ?? ''}`}
-            {...props}
-        />
+        <th className={`text-uppercase text-secondary small fw-semibold ${className ?? ''}`} {...props} />
     );
 }
 
@@ -630,5 +670,9 @@ function FieldError({ message }: FieldErrorProps) {
     if (!message) {
         return null;
     }
-    return <p className="text-xs text-rose-300">{message}</p>;
+    return (
+        <div className="invalid-feedback d-block" role="alert">
+            {message}
+        </div>
+    );
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -5,6 +5,9 @@ import { useRouter } from 'next/router';
 
 import { ApertureMark } from '../components/crm';
 import { useNetlifyIdentity } from '../components/auth';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
 
 export default function LoginPage() {
     const identity = useNetlifyIdentity();
@@ -48,104 +51,63 @@ export default function LoginPage() {
             <Head>
                 <title>Sign in · Aperture Studio CRM</title>
             </Head>
-            <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
-                <main className="flex flex-1 items-center justify-center px-6 py-12 sm:px-10 lg:px-12">
-                    <div className="relative w-full max-w-xl">
-                        <div
-                            className="absolute -inset-1 rounded-[32px] bg-gradient-to-br from-[#4DE5FF]/30 via-[#6C4DFF]/20 to-transparent opacity-80 blur-2xl"
-                            aria-hidden
-                        />
-                        <div className="relative overflow-hidden rounded-[32px] border border-white/10 bg-slate-900/80 p-8 shadow-[0_25px_60px_-30px_rgba(15,23,42,0.9)] backdrop-blur-xl sm:p-10">
-                            <div className="flex flex-col items-center gap-5 text-center">
-                                <div className="flex items-center gap-3">
-                                    <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-950/80 shadow-inner ring-1 ring-white/10">
-                                        <ApertureMark className="h-9 w-9 text-slate-950" aria-hidden />
-                                    </span>
-                                    <span className="hidden text-left text-sm font-semibold uppercase tracking-[0.48em] text-slate-300 sm:block">
-                                        <span className="bg-gradient-to-r from-[#4DE5FF] via-[#6C4DFF] to-[#B686FF] bg-clip-text text-transparent">
-                                            Aperture
-                                        </span>{' '}
-                                        Studio CRM
-                                    </span>
-                                </div>
-                                <div className="flex flex-col gap-2">
-                                    <p className="text-sm font-semibold uppercase tracking-[0.48em] text-slate-300 sm:hidden">
-                                        <span className="bg-gradient-to-r from-[#4DE5FF] via-[#6C4DFF] to-[#B686FF] bg-clip-text text-transparent">
-                                            Aperture
-                                        </span>{' '}
-                                        Studio CRM
-                                    </p>
-                                    <h1 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">Welcome back</h1>
-                                    <p className="text-sm text-slate-300 sm:text-base">
-                                        Sign in to manage schedules, clients, and production workflows inside Aperture Studio CRM.
-                                    </p>
-                                </div>
-                            </div>
-                            <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-                                <div className="space-y-2">
-                                    <label htmlFor="email" className="block text-sm font-medium text-slate-200">
-                                        Email
-                                    </label>
-                                    <input
+            <div className="page page-center">
+                <div className="container-tight py-4">
+                    <div className="text-center mb-4">
+                        <ApertureMark className="icon icon-lg text-primary" aria-hidden />
+                        <h1 className="mt-3 h2">Welcome back</h1>
+                        <p className="text-secondary">
+                            Sign in to manage schedules, clients, and production workflows inside Aperture Studio CRM.
+                        </p>
+                    </div>
+                    <div className="card card-md">
+                        <div className="card-body">
+                            <form onSubmit={handleSubmit} className="space-y-3">
+                                <div className="mb-3">
+                                    <Label htmlFor="email">Email</Label>
+                                    <Input
                                         id="email"
                                         type="email"
                                         autoComplete="email"
                                         required
                                         value={email}
                                         onChange={(event) => setEmail(event.target.value)}
-                                        className="w-full rounded-2xl border border-slate-700/70 bg-slate-950/70 px-4 py-3 text-sm text-white outline-none transition focus:border-[#4DE5FF] focus:ring-2 focus:ring-[#4DE5FF]/60 sm:text-base"
                                         placeholder="you@aperture.studio"
                                     />
                                 </div>
-                                <div className="space-y-2">
-                                    <div className="flex items-center justify-between text-sm">
-                                        <label htmlFor="password" className="font-medium text-slate-200">
-                                            Password
-                                        </label>
-                                        <Link href="/reset-password" className="font-medium text-[#4DE5FF] transition hover:text-white">
+                                <div className="mb-3">
+                                    <div className="d-flex justify-content-between align-items-center">
+                                        <Label htmlFor="password">Password</Label>
+                                        <Link href="/reset-password" className="text-secondary">
                                             Forgot password?
                                         </Link>
                                     </div>
-                                    <input
+                                    <Input
                                         id="password"
                                         type="password"
                                         autoComplete="current-password"
                                         required
                                         value={password}
                                         onChange={(event) => setPassword(event.target.value)}
-                                        className="w-full rounded-2xl border border-slate-700/70 bg-slate-950/70 px-4 py-3 text-sm text-white outline-none transition focus:border-[#4DE5FF] focus:ring-2 focus:ring-[#4DE5FF]/60 sm:text-base"
                                         placeholder="Enter your password"
                                     />
                                 </div>
                                 {formError ? (
-                                    <p
-                                        className="rounded-2xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200"
-                                        role="alert"
-                                        aria-live="polite"
-                                    >
+                                    <div className="alert alert-danger" role="alert" aria-live="polite">
                                         {formError}
-                                    </p>
+                                    </div>
                                 ) : null}
-                                <button
-                                    type="submit"
-                                    className="flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-[#4DE5FF] via-[#6C4DFF] to-[#B686FF] px-4 py-3 text-sm font-semibold text-slate-950 shadow-[0_12px_30px_-15px_rgba(77,229,255,0.9)] transition hover:opacity-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DE5FF]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 sm:text-base"
-                                    disabled={submitting}
-                                >
+                                <Button type="submit" className="w-100" isLoading={submitting}>
                                     {submitting ? 'Signing in…' : 'Sign in'}
-                                </button>
+                                </Button>
                             </form>
-                            <p className="mt-6 text-center text-sm text-slate-400">
-                                Need an account?{' '}
-                                <Link href="/signup" className="font-semibold text-[#4DE5FF] transition hover:text-white">
-                                    Create one now
-                                </Link>
-                            </p>
                         </div>
                     </div>
-                </main>
-                <footer className="px-6 pb-6 text-center text-xs text-slate-500">
-                    Powered by Codex
-                </footer>
+                    <div className="text-center text-secondary mt-3">
+                        Need an account?{' '}
+                        <Link href="/signup">Create one now</Link>
+                    </div>
+                </div>
             </div>
         </>
     );

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -3,6 +3,9 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 
 import { useNetlifyIdentity } from '../components/auth';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
 
 export default function ResetPasswordPage() {
     const identity = useNetlifyIdentity();
@@ -78,64 +81,45 @@ export default function ResetPasswordPage() {
             <Head>
                 <title>Reset password • Studio CRM</title>
             </Head>
-            <div className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-slate-100">
-                <div className="w-full max-w-md rounded-3xl border border-slate-800 bg-slate-900/80 p-10 shadow-2xl backdrop-blur">
-                    <div className="mb-8 text-center">
-                        <p className="text-xs font-semibold uppercase tracking-[0.48em] text-[#4DE5FF]">Secure access</p>
-                        <h1 className="mt-3 text-2xl font-semibold tracking-tight text-white">Set a new password</h1>
-                        <p className="mt-2 text-sm text-slate-300">
-                            Choose a strong password to keep your workspace secure.
-                        </p>
+            <div className="page page-center">
+                <div className="container-tight py-4">
+                    <div className="card card-md">
+                        <div className="card-body">
+                            <h1 className="card-title">Set a new password</h1>
+                            <p className="text-secondary mb-4">Choose a strong password to keep your workspace secure.</p>
+                            <form onSubmit={handleSubmit} className="space-y-3">
+                                <div className="mb-3">
+                                    <Label htmlFor="password">New password</Label>
+                                    <Input
+                                        id="password"
+                                        type="password"
+                                        autoComplete="new-password"
+                                        required
+                                        value={password}
+                                        onChange={(event) => setPassword(event.target.value)}
+                                        placeholder="Minimum 8 characters"
+                                    />
+                                </div>
+                                <div className="mb-3">
+                                    <Label htmlFor="confirmPassword">Confirm password</Label>
+                                    <Input
+                                        id="confirmPassword"
+                                        type="password"
+                                        autoComplete="new-password"
+                                        required
+                                        value={confirmPassword}
+                                        onChange={(event) => setConfirmPassword(event.target.value)}
+                                        placeholder="Re-enter your password"
+                                    />
+                                </div>
+                                {error ? <div className="alert alert-danger">{error}</div> : null}
+                                {message ? <div className="alert alert-success">{message}</div> : null}
+                                <Button type="submit" className="w-100" isLoading={submitting}>
+                                    {submitting ? 'Updating password…' : 'Update password'}
+                                </Button>
+                            </form>
+                        </div>
                     </div>
-                    <form className="space-y-6" onSubmit={handleSubmit}>
-                        <div>
-                            <label htmlFor="password" className="block text-sm font-medium text-slate-200">
-                                New password
-                            </label>
-                            <input
-                                id="password"
-                                type="password"
-                                autoComplete="new-password"
-                                required
-                                value={password}
-                                onChange={(event) => setPassword(event.target.value)}
-                                className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none focus:border-[#4DE5FF] focus:ring-2 focus:ring-[#4DE5FF]/60"
-                                placeholder="Minimum 8 characters"
-                            />
-                        </div>
-                        <div>
-                            <label htmlFor="confirmPassword" className="block text-sm font-medium text-slate-200">
-                                Confirm password
-                            </label>
-                            <input
-                                id="confirmPassword"
-                                type="password"
-                                autoComplete="new-password"
-                                required
-                                value={confirmPassword}
-                                onChange={(event) => setConfirmPassword(event.target.value)}
-                                className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none focus:border-[#4DE5FF] focus:ring-2 focus:ring-[#4DE5FF]/60"
-                                placeholder="Re-enter your password"
-                            />
-                        </div>
-                        {error ? (
-                            <p className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
-                                {error}
-                            </p>
-                        ) : null}
-                        {message ? (
-                            <p className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
-                                {message}
-                            </p>
-                        ) : null}
-                        <button
-                            type="submit"
-                            className="flex w-full items-center justify-center rounded-xl bg-[#4DE5FF] px-4 py-3 text-sm font-semibold text-slate-950 transition hover:bg-[#86f0ff]"
-                            disabled={submitting}
-                        >
-                            {submitting ? 'Updating password…' : 'Update password'}
-                        </button>
-                    </form>
                 </div>
             </div>
         </>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -20,31 +20,30 @@ export default function SignupPage() {
             <Head>
                 <title>Create account • Studio CRM</title>
             </Head>
-            <div className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-slate-100">
-                <div className="w-full max-w-md rounded-3xl border border-slate-800 bg-slate-900/80 p-10 shadow-2xl backdrop-blur">
-                    <div className="mb-8 text-center">
-                        <p className="text-xs font-semibold uppercase tracking-[0.48em] text-[#4DE5FF]">Get started</p>
-                        <h1 className="mt-3 text-2xl font-semibold tracking-tight text-white">Create your studio account</h1>
-                        <p className="mt-2 text-sm text-slate-300">
+            <div className="page page-center">
+                <div className="container-tight py-4">
+                    <div className="text-center mb-4">
+                        <h1 className="h2">Create your studio account</h1>
+                        <p className="text-secondary">
                             Sign up to connect calendars, manage contacts, and ship projects faster.
                         </p>
                     </div>
-                    <div className="space-y-6 rounded-2xl border border-slate-800/60 bg-slate-950/60 p-6">
-                        <p className="text-sm text-slate-300">
-                            Accounts are created by an administrator so we can assign the correct role and permissions from day
-                            one. Ask your studio admin to send an invitation email.
-                        </p>
-                        <p className="rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-3 text-xs text-slate-400">
-                            Invites include a verification link and a temporary password so you can sign in securely and finish
-                            setting up your profile.
-                        </p>
+                    <div className="card card-md">
+                        <div className="card-body">
+                            <p className="text-secondary">
+                                Accounts are created by an administrator so we can assign the correct role and permissions from day
+                                one. Ask your studio admin to send an invitation email.
+                            </p>
+                            <div className="alert alert-info mt-3" role="status">
+                                Invites include a verification link and a temporary password so you can sign in securely and finish
+                                setting up your profile.
+                            </div>
+                        </div>
                     </div>
-                    <p className="mt-6 text-center text-sm text-slate-400">
+                    <div className="text-center text-secondary mt-3">
                         Already have an account?{' '}
-                        <Link href="/login" className="font-semibold text-[#4DE5FF] hover:text-white">
-                            Sign in
-                        </Link>
-                    </p>
+                        <Link href="/login">Sign in</Link>
+                    </div>
                 </div>
             </div>
         </>

--- a/src/pages/verify-email.tsx
+++ b/src/pages/verify-email.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
+import { Button } from '../components/ui/button';
+
 export default function VerifyEmailPage() {
     const router = useRouter();
     const { token } = router.query;
@@ -45,22 +47,23 @@ export default function VerifyEmailPage() {
             <Head>
                 <title>Email verification • Studio CRM</title>
             </Head>
-            <div className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-slate-100">
-                <div className="w-full max-w-lg rounded-3xl border border-slate-800 bg-slate-900/80 p-10 text-center shadow-2xl backdrop-blur">
-                    <p className="text-xs font-semibold uppercase tracking-[0.48em] text-[#4DE5FF]">Email Verification</p>
-                    <h1 className="mt-3 text-2xl font-semibold tracking-tight text-white">
-                        {status === 'success' ? 'You are verified' : status === 'error' ? 'Verification issue' : 'Checking your link'}
-                    </h1>
-                    <p className="mt-4 text-sm text-slate-300">{message}</p>
-                    {status === 'success' ? (
-                        <button
-                            type="button"
-                            onClick={() => router.push('/login')}
-                            className="mt-8 inline-flex items-center justify-center rounded-xl bg-[#4DE5FF] px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-[#86f0ff]"
-                        >
-                            Go to sign in
-                        </button>
-                    ) : null}
+            <div className="page page-center">
+                <div className="container-tight py-4">
+                    <div className="card card-md text-center">
+                        <div className="card-body">
+                            <h1 className="card-title">
+                                {status === 'success' ? 'You are verified' : status === 'error' ? 'Verification issue' : 'Checking your link'}
+                            </h1>
+                            <p className="text-secondary">{message}</p>
+                            {status === 'success' ? (
+                                <div className="mt-4">
+                                    <Button type="button" onClick={() => router.push('/login')}>
+                                        Go to sign in
+                                    </Button>
+                                </div>
+                            ) : null}
+                        </div>
+                    </div>
                 </div>
             </div>
         </>


### PR DESCRIPTION
## Summary
- refactor shared dashboard and UI primitives to emit Tabler friendly markup across cards, toolbars, and form controls
- rebuild authentication screens plus clients and contacts workspaces to use the new layout components and Tabler styling
- update data table and toolbar utilities so list pages share consistent controls, filters, and pagination states

## Testing
- `npm run lint` *(fails: script not defined in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d017c5b3848329bc811f7e0900619f