### PR TITLE
Add studio calendar with Supabase persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "bcryptjs": "^3.0.2",
                 "classnames": "^2.5.1",
                 "cookie": "^0.6.0",
+                "date-fns": "^4.1.0",
                 "dayjs": "^1.11.11",
                 "framer-motion": "^12.23.13",
                 "front-matter": "^4.0.2",
@@ -4771,6 +4772,16 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "bcryptjs": "^3.0.2",
         "classnames": "^2.5.1",
         "cookie": "^0.6.0",
+        "date-fns": "^4.1.0",
         "dayjs": "^1.11.11",
         "framer-motion": "^12.23.13",
         "front-matter": "^4.0.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,24 @@
+import '@tabler/core/dist/css/tabler.min.css';
+import '@tabler/core/dist/css/tabler-flags.min.css';
+import '@tabler/core/dist/css/tabler-payments.min.css';
+import '@tabler/core/dist/css/tabler-vendors.min.css';
+import '../css/main.css';
+
+import type { Metadata } from 'next';
+
+import { AppProviders } from './providers';
+
+export const metadata: Metadata = {
+    title: 'Studio Calendar',
+    description: 'Manage studio events and tasks.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <html lang="en">
+            <body className="bg-body">
+                <AppProviders>{children}</AppProviders>
+            </body>
+        </html>
+    );
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { NetlifyIdentityProvider } from '../components/auth';
+import { IntegrationProvider } from '../components/crm/integration-context';
+import { QuickActionSettingsProvider } from '../components/crm/quick-action-settings';
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+    useEffect(() => {
+        async function loadTabler() {
+            try {
+                await import('@tabler/core/dist/js/tabler.min.js');
+            } catch (error) {
+                console.error('Failed to load Tabler scripts', error);
+            }
+        }
+
+        void loadTabler();
+    }, []);
+
+    return (
+        <NetlifyIdentityProvider>
+            <QuickActionSettingsProvider>
+                <IntegrationProvider>{children}</IntegrationProvider>
+            </QuickActionSettingsProvider>
+        </NetlifyIdentityProvider>
+    );
+}

--- a/src/app/studio/calendars/page.tsx
+++ b/src/app/studio/calendars/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { StudioCalendar } from '../../../components/calendar/StudioCalendar';
+
+export default function CalendarsPage() {
+    return <StudioCalendar />;
+}

--- a/src/components/calendar/AssignTaskDialog.tsx
+++ b/src/components/calendar/AssignTaskDialog.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import * as React from 'react';
+import useSWR from 'swr';
+
+import { Button } from '../ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Select } from '../ui/select';
+import { Textarea } from '../ui/textarea';
+import {
+    createTaskForEvent,
+    fetchAssignableUsers,
+    type CreateTaskInput,
+    type TaskPriority,
+    type TaskRecord,
+    type UserSummary
+} from '../../lib/supabase/tasks';
+
+const PRIORITY_OPTIONS: TaskPriority[] = ['low', 'normal', 'high'];
+
+type AssignTaskDialogProps = {
+    eventId: string | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    currentUserId: string | null;
+    onAssigned?: (task: TaskRecord) => void;
+};
+
+type FormState = {
+    title: string;
+    details: string;
+    dueAt: string;
+    priority: TaskPriority;
+    assigneeId: string;
+};
+
+const defaultFormState: FormState = {
+    title: '',
+    details: '',
+    dueAt: '',
+    priority: 'normal',
+    assigneeId: ''
+};
+
+export function AssignTaskDialog({ eventId, open, onOpenChange, currentUserId, onAssigned }: AssignTaskDialogProps) {
+    const { data: userOptions, error: usersError } = useSWR<UserSummary[]>(open ? 'calendar-assignable-users' : null, () =>
+        fetchAssignableUsers()
+    );
+
+    const [formState, setFormState] = React.useState<FormState>(defaultFormState);
+    const [isSubmitting, setSubmitting] = React.useState(false);
+    const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        if (!open) {
+            setFormState(defaultFormState);
+            setErrorMessage(null);
+        }
+    }, [open]);
+
+    const handleChange = <Key extends keyof FormState>(key: Key, value: FormState[Key]) => {
+        setFormState((prev) => ({ ...prev, [key]: value }));
+    };
+
+    const handleAssignToMe = () => {
+        if (currentUserId) {
+            handleChange('assigneeId', currentUserId);
+        }
+    };
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (!eventId) {
+            setErrorMessage('Save the event before assigning tasks.');
+            return;
+        }
+
+        if (!currentUserId) {
+            setErrorMessage('You must be signed in to assign tasks.');
+            return;
+        }
+
+        if (formState.title.trim().length === 0) {
+            setErrorMessage('Task title is required.');
+            return;
+        }
+
+        if (!formState.assigneeId) {
+            setErrorMessage('Select an assignee.');
+            return;
+        }
+
+        setSubmitting(true);
+        setErrorMessage(null);
+
+        const payload: CreateTaskInput = {
+            title: formState.title,
+            details: formState.details.length > 0 ? formState.details : null,
+            due_at: formState.dueAt ? new Date(formState.dueAt).toISOString() : null,
+            priority: formState.priority,
+            assigned_to: formState.assigneeId,
+            event_id: eventId,
+            created_by: currentUserId
+        };
+
+        try {
+            const task = await createTaskForEvent(payload);
+            setFormState(defaultFormState);
+            onOpenChange(false);
+            onAssigned?.(task);
+        } catch (error) {
+            console.error('Failed to assign task', error);
+            setErrorMessage(error instanceof Error ? error.message : 'Unable to assign task.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Assign Task</DialogTitle>
+                </DialogHeader>
+                <form id="assign-task-form" onSubmit={handleSubmit} className="modal-body">
+                    <div className="mb-3">
+                        <Label htmlFor="task-title">Task title</Label>
+                        <Input
+                            id="task-title"
+                            value={formState.title}
+                            onChange={(event) => handleChange('title', event.target.value)}
+                            placeholder="Describe the task"
+                            required
+                        />
+                    </div>
+                    <div className="mb-3">
+                        <Label htmlFor="task-details">Details</Label>
+                        <Textarea
+                            id="task-details"
+                            value={formState.details}
+                            onChange={(event) => handleChange('details', event.target.value)}
+                            rows={3}
+                            placeholder="Add context or instructions"
+                        />
+                    </div>
+                    <div className="row g-3">
+                        <div className="col-md-6">
+                            <Label htmlFor="task-due">Due date</Label>
+                            <Input
+                                id="task-due"
+                                type="datetime-local"
+                                value={formState.dueAt}
+                                onChange={(event) => handleChange('dueAt', event.target.value)}
+                            />
+                        </div>
+                        <div className="col-md-6">
+                            <Label htmlFor="task-priority">Priority</Label>
+                            <Select
+                                id="task-priority"
+                                value={formState.priority}
+                                onChange={(event) => handleChange('priority', event.target.value as TaskPriority)}
+                            >
+                                {PRIORITY_OPTIONS.map((option) => (
+                                    <option key={option} value={option}>
+                                        {option.charAt(0).toUpperCase() + option.slice(1)}
+                                    </option>
+                                ))}
+                            </Select>
+                        </div>
+                    </div>
+                    <div className="mt-3">
+                        <div className="d-flex justify-content-between align-items-center mb-2">
+                            <Label htmlFor="task-assignee" className="mb-0">
+                                Assign to
+                            </Label>
+                            <Button type="button" variant="ghost" size="sm" onClick={handleAssignToMe} disabled={!currentUserId}>
+                                Assign to me
+                            </Button>
+                        </div>
+                        <Select
+                            id="task-assignee"
+                            value={formState.assigneeId}
+                            onChange={(event) => handleChange('assigneeId', event.target.value)}
+                            required
+                        >
+                            <option value="" disabled>
+                                Select teammate
+                            </option>
+                            {(userOptions ?? []).map((user) => (
+                                <option key={user.id} value={user.id}>
+                                    {user.name ?? user.email ?? 'Unknown user'}
+                                </option>
+                            ))}
+                        </Select>
+                        {usersError ? (
+                            <p className="mt-2 text-danger small">Unable to load users. Refresh and try again.</p>
+                        ) : null}
+                    </div>
+                    {errorMessage ? <p className="mt-3 text-danger small">{errorMessage}</p> : null}
+                </form>
+                <DialogFooter>
+                    <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type="submit"
+                        form="assign-task-form"
+                        disabled={isSubmitting}
+                        isLoading={isSubmitting}
+                    >
+                        Save task
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/calendar/EventDialog.tsx
+++ b/src/components/calendar/EventDialog.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+import * as React from 'react';
+import { addDays, addMinutes, differenceInMinutes, format, isBefore, startOfDay, setHours, setMinutes } from 'date-fns';
+
+import { Button } from '../ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Select } from '../ui/select';
+import { Textarea } from '../ui/textarea';
+import type { CalendarEvent } from '../../lib/supabase/calendar';
+
+export type ClientOption = {
+    id: string;
+    name: string;
+};
+
+export type EventDialogMode = 'create' | 'edit';
+
+type EventDialogSubmit = (input: {
+    title: string;
+    description: string | null;
+    start_at: string;
+    end_at: string;
+    all_day: boolean;
+    client_id: string | null;
+    location: string | null;
+}) => Promise<void>;
+
+type EventDialogProps = {
+    mode: EventDialogMode;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    event: CalendarEvent | null;
+    initialRange?: { start: Date; end: Date; allDay: boolean } | null;
+    clientOptions: ClientOption[];
+    timezone: string;
+    canEdit: boolean;
+    onSubmit: EventDialogSubmit;
+    onDelete?: () => Promise<void>;
+    onAssignTask?: () => void;
+    isLoadingClients?: boolean;
+};
+
+function formatDateTimeInput(date: Date): string {
+    return format(date, "yyyy-MM-dd'T'HH:mm");
+}
+
+function formatDateInput(date: Date): string {
+    return format(date, 'yyyy-MM-dd');
+}
+
+function clampEndDate(startDate: Date, proposedEnd: Date): Date {
+    if (isBefore(proposedEnd, addMinutes(startDate, 5))) {
+        return addMinutes(startDate, 60);
+    }
+
+    return proposedEnd;
+}
+
+export function EventDialog({
+    mode,
+    open,
+    onOpenChange,
+    event,
+    initialRange,
+    clientOptions,
+    timezone,
+    canEdit,
+    onSubmit,
+    onDelete,
+    onAssignTask,
+    isLoadingClients
+}: EventDialogProps) {
+    const [title, setTitle] = React.useState('');
+    const [description, setDescription] = React.useState('');
+    const [location, setLocation] = React.useState('');
+    const [clientId, setClientId] = React.useState('');
+    const [allDay, setAllDay] = React.useState(false);
+    const [startDate, setStartDate] = React.useState<Date>(() => new Date());
+    const [endDate, setEndDate] = React.useState<Date>(() => addMinutes(new Date(), 60));
+    const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+    const [isSaving, setSaving] = React.useState(false);
+    const [isDeleting, setDeleting] = React.useState(false);
+
+    const resetState = React.useCallback(() => {
+        setTitle('');
+        setDescription('');
+        setLocation('');
+        setClientId('');
+        setAllDay(false);
+        const now = new Date();
+        const roundedStart = setMinutes(setHours(now, now.getHours()), Math.floor(now.getMinutes() / 15) * 15);
+        setStartDate(roundedStart);
+        setEndDate(addMinutes(roundedStart, 60));
+        setErrorMessage(null);
+        setSaving(false);
+        setDeleting(false);
+    }, []);
+
+    React.useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        if (mode === 'edit' && event) {
+            setTitle(event.title);
+            setDescription(event.description ?? '');
+            setLocation(event.location ?? '');
+            setClientId(event.clientId ?? '');
+            setAllDay(event.allDay);
+            const start = new Date(event.startAt);
+            const end = new Date(event.endAt);
+            setStartDate(event.allDay ? startOfDay(start) : start);
+            setEndDate(event.allDay ? startOfDay(end) : end);
+            setErrorMessage(null);
+            setSaving(false);
+            setDeleting(false);
+            return;
+        }
+
+        const range = initialRange ?? null;
+        const now = new Date();
+        const start = range?.start ?? now;
+        const end = range?.end ?? addMinutes(start, 60);
+        const initialAllDay = Boolean(range?.allDay);
+        setTitle('');
+        setDescription('');
+        setLocation('');
+        setClientId('');
+        setAllDay(initialAllDay);
+        setStartDate(initialAllDay ? startOfDay(start) : start);
+        setEndDate(initialAllDay ? startOfDay(end) : clampEndDate(initialAllDay ? startOfDay(start) : start, end));
+        setErrorMessage(null);
+        setSaving(false);
+        setDeleting(false);
+    }, [event, initialRange, mode, open]);
+
+    React.useEffect(() => {
+        if (!open) {
+            resetState();
+        }
+    }, [open, resetState]);
+
+    const handleAllDayChange = (checked: boolean) => {
+        setAllDay(checked);
+        setErrorMessage(null);
+
+        if (checked) {
+            setStartDate((prev) => {
+                const normalizedStart = startOfDay(prev);
+                setEndDate((prevEnd) => {
+                    const normalizedEnd = startOfDay(prevEnd);
+                    const minEnd = addDays(normalizedStart, 1);
+                    return isBefore(normalizedEnd, minEnd) ? minEnd : normalizedEnd;
+                });
+                return normalizedStart;
+            });
+        } else {
+            setStartDate((prev) => {
+                const base = startOfDay(prev);
+                const nextStart = setMinutes(setHours(base, 9), 0);
+                setEndDate((prevEnd) => {
+                    const minutes = Math.max(60, differenceInMinutes(prevEnd, prev));
+                    return addMinutes(nextStart, minutes);
+                });
+                return nextStart;
+            });
+        }
+    };
+
+    const handleStartChange = (value: string) => {
+        if (allDay) {
+            const parsed = new Date(`${value}T00:00:00`);
+            if (Number.isNaN(parsed.getTime())) {
+                return;
+            }
+            setStartDate(parsed);
+            setEndDate((prevEnd) => {
+                const minEnd = addDays(parsed, 1);
+                return isBefore(prevEnd, minEnd) ? minEnd : prevEnd;
+            });
+            return;
+        }
+
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            return;
+        }
+        setStartDate(parsed);
+        setEndDate((prevEnd) => clampEndDate(parsed, prevEnd));
+    };
+
+    const handleEndChange = (value: string) => {
+        if (allDay) {
+            const parsed = new Date(`${value}T00:00:00`);
+            if (Number.isNaN(parsed.getTime())) {
+                return;
+            }
+            const exclusiveEnd = addDays(parsed, 1);
+            setEndDate(() => {
+                const minEnd = addDays(startDate, 1);
+                return isBefore(exclusiveEnd, minEnd) ? minEnd : exclusiveEnd;
+            });
+            return;
+        }
+
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            return;
+        }
+        setEndDate(clampEndDate(startDate, parsed));
+    };
+
+    const handleSubmit = async (submitEvent: React.FormEvent<HTMLFormElement>) => {
+        submitEvent.preventDefault();
+
+        if (!canEdit) {
+            onOpenChange(false);
+            return;
+        }
+
+        if (title.trim().length === 0) {
+            setErrorMessage('Title is required.');
+            return;
+        }
+
+        if (!allDay && !isBefore(startDate, endDate)) {
+            setErrorMessage('End time must be after the start time.');
+            return;
+        }
+
+        if (allDay && !isBefore(startDate, endDate)) {
+            setErrorMessage('End date must be after the start date.');
+            return;
+        }
+
+        setSaving(true);
+        setErrorMessage(null);
+
+        const payload = {
+            title: title.trim(),
+            description: description.trim().length > 0 ? description.trim() : null,
+            start_at: allDay ? startOfDay(startDate).toISOString() : startDate.toISOString(),
+            end_at: endDate.toISOString(),
+            all_day: allDay,
+            client_id: clientId.length > 0 ? clientId : null,
+            location: location.trim().length > 0 ? location.trim() : null
+        };
+
+        try {
+            await onSubmit(payload);
+            onOpenChange(false);
+        } catch (error) {
+            console.error('Failed to save event', error);
+            setErrorMessage(error instanceof Error ? error.message : 'Unable to save event.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!onDelete || !event) {
+            return;
+        }
+
+        const confirmed = window.confirm('Delete this event? This action cannot be undone.');
+        if (!confirmed) {
+            return;
+        }
+
+        setDeleting(true);
+        setErrorMessage(null);
+
+        try {
+            await onDelete();
+            onOpenChange(false);
+        } catch (error) {
+            console.error('Failed to delete event', error);
+            setErrorMessage(error instanceof Error ? error.message : 'Unable to delete event.');
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    const startInputValue = allDay ? formatDateInput(startDate) : formatDateTimeInput(startDate);
+    const endInputValue = allDay ? formatDateInput(addDays(endDate, -1)) : formatDateTimeInput(endDate);
+    const timezoneLabel = `Times shown in ${timezone}`;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>{mode === 'edit' ? 'Edit event' : 'New event'}</DialogTitle>
+                </DialogHeader>
+                <form id="event-dialog-form" onSubmit={handleSubmit} className="modal-body">
+                    <div className="mb-3">
+                        <Label htmlFor="event-title">Title</Label>
+                        <Input
+                            id="event-title"
+                            value={title}
+                            onChange={(event) => setTitle(event.target.value)}
+                            disabled={!canEdit}
+                            required
+                        />
+                    </div>
+                    <div className="mb-3">
+                        <Label htmlFor="event-description">Description</Label>
+                        <Textarea
+                            id="event-description"
+                            value={description}
+                            onChange={(event) => setDescription(event.target.value)}
+                            rows={4}
+                            disabled={!canEdit}
+                        />
+                    </div>
+                    <div className="row g-3">
+                        <div className="col-md-6">
+                            <Label htmlFor="event-start">Start</Label>
+                            <Input
+                                id="event-start"
+                                type={allDay ? 'date' : 'datetime-local'}
+                                value={startInputValue}
+                                onChange={(event) => handleStartChange(event.target.value)}
+                                disabled={!canEdit}
+                                required
+                            />
+                        </div>
+                        <div className="col-md-6">
+                            <Label htmlFor="event-end">End</Label>
+                            <Input
+                                id="event-end"
+                                type={allDay ? 'date' : 'datetime-local'}
+                                value={endInputValue}
+                                onChange={(event) => handleEndChange(event.target.value)}
+                                disabled={!canEdit}
+                                required
+                            />
+                        </div>
+                    </div>
+                    <div className="form-check form-switch mt-3">
+                        <input
+                            className="form-check-input"
+                            type="checkbox"
+                            role="switch"
+                            id="event-all-day"
+                            checked={allDay}
+                            onChange={(event) => handleAllDayChange(event.target.checked)}
+                            disabled={!canEdit}
+                        />
+                        <label className="form-check-label" htmlFor="event-all-day">
+                            All-day event
+                        </label>
+                    </div>
+                    <p className="mt-2 text-secondary small">{timezoneLabel}</p>
+                    <div className="row g-3 mt-1">
+                        <div className="col-md-6">
+                            <Label htmlFor="event-client">Client</Label>
+                            <Select
+                                id="event-client"
+                                value={clientId}
+                                onChange={(event) => setClientId(event.target.value)}
+                                disabled={!canEdit || isLoadingClients}
+                            >
+                                <option value="">No client</option>
+                                {clientOptions.map((client) => (
+                                    <option key={client.id} value={client.id}>
+                                        {client.name}
+                                    </option>
+                                ))}
+                            </Select>
+                            {isLoadingClients ? (
+                                <p className="mt-2 text-secondary small">Loading clients…</p>
+                            ) : null}
+                        </div>
+                        <div className="col-md-6">
+                            <Label htmlFor="event-location">Location</Label>
+                            <Input
+                                id="event-location"
+                                value={location}
+                                onChange={(event) => setLocation(event.target.value)}
+                                disabled={!canEdit}
+                                placeholder="Studio, address, or meeting link"
+                            />
+                        </div>
+                    </div>
+                    {errorMessage ? <p className="mt-3 text-danger small">{errorMessage}</p> : null}
+                </form>
+                <DialogFooter className="d-flex flex-wrap gap-2 justify-content-between">
+                    <div className="d-flex gap-2">
+                        {mode === 'edit' && onAssignTask ? (
+                            <Button type="button" variant="outline" onClick={onAssignTask} disabled={!event}>
+                                Assign task
+                            </Button>
+                        ) : null}
+                        {mode === 'edit' && onDelete ? (
+                            <Button type="button" variant="ghost" onClick={handleDelete} disabled={isDeleting}>
+                                {isDeleting ? 'Deleting…' : 'Delete'}
+                            </Button>
+                        ) : null}
+                    </div>
+                    <div className="d-flex gap-2 ms-auto">
+                        <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={isSaving}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" form="event-dialog-form" disabled={!canEdit || isSaving} isLoading={isSaving}>
+                            Save event
+                        </Button>
+                    </div>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/calendar/StudioCalendar.tsx
+++ b/src/components/calendar/StudioCalendar.tsx
@@ -1,0 +1,694 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import * as React from 'react';
+import useSWR from 'swr';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import listPlugin from '@fullcalendar/list';
+import timeGridPlugin from '@fullcalendar/timegrid';
+
+import { Button } from '../ui/button';
+import { AssignTaskDialog } from './AssignTaskDialog';
+import { EventDialog, type ClientOption, type EventDialogMode } from './EventDialog';
+import {
+    DEFAULT_TIME_ZONE,
+    type CalendarEvent,
+    type CalendarEventPayload,
+    createCalendarEvent,
+    deleteCalendarEvent,
+    fetchCalendarEvents,
+    updateCalendarEvent
+} from '../../lib/supabase/calendar';
+import { getSupabaseBrowserClient } from '../../lib/supabase-browser';
+
+const FullCalendar = dynamic(async () => {
+    const module = await import('@fullcalendar/react');
+    return module.default;
+}, { ssr: false });
+
+type ToastState = {
+    id: number;
+    message: string;
+    variant: 'success' | 'error';
+};
+
+type VisibleRange = {
+    start: string;
+    end: string;
+};
+
+type CurrentUserRecord = {
+    id: string;
+    name: string | null;
+    email: string | null;
+    role: string | null;
+    roles: string[] | null;
+};
+
+async function fetchClients(): Promise<ClientOption[]> {
+    const supabase = getSupabaseBrowserClient();
+    const { data, error } = await supabase.from('clients').select('id, name').order('name', { ascending: true });
+    if (error) {
+        throw error;
+    }
+    return (data ?? []).map((row) => ({
+        id: row.id,
+        name: typeof row.name === 'string' && row.name.length > 0 ? row.name : 'Unnamed client'
+    }));
+}
+
+function Toast({ toast }: { toast: ToastState | null }) {
+    if (!toast) {
+        return null;
+    }
+
+    const toneClass =
+        toast.variant === 'success'
+            ? 'border-emerald-400/40 bg-emerald-500/15 text-emerald-100'
+            : 'border-rose-400/40 bg-rose-500/15 text-rose-100';
+
+    return (
+        <div className="pointer-events-none fixed bottom-6 right-6 z-50">
+            <div className={`pointer-events-auto rounded-2xl border px-4 py-3 text-sm shadow-lg ${toneClass}`}>{toast.message}</div>
+        </div>
+    );
+}
+
+function mapPayloadToOptimisticEvent(
+    payload: CalendarEventPayload,
+    base: Partial<CalendarEvent> & { id: string }
+): CalendarEvent {
+    return {
+        id: base.id,
+        title: payload.title,
+        description: payload.description ?? base.description ?? null,
+        startAt: payload.start_at,
+        endAt: payload.end_at,
+        allDay: payload.all_day,
+        ownerUserId: payload.owner_user_id ?? base.ownerUserId ?? '',
+        clientId: payload.client_id ?? base.clientId ?? null,
+        clientName: base.clientName ?? null,
+        location: payload.location ?? base.location ?? null,
+        createdAt: base.createdAt ?? null,
+        updatedAt: base.updatedAt ?? null,
+        assignees: base.assignees ?? []
+    };
+}
+
+function hasOverlap(
+    events: CalendarEvent[] | undefined,
+    targetId: string,
+    ownerId: string,
+    proposedStart: Date,
+    proposedEnd: Date
+): boolean {
+    if (!events || !ownerId) {
+        return false;
+    }
+
+    return events.some((event) => {
+        if (event.id === targetId) {
+            return false;
+        }
+        if (event.ownerUserId !== ownerId) {
+            return false;
+        }
+        const eventStart = new Date(event.startAt);
+        const eventEnd = new Date(event.endAt);
+        return eventStart < proposedEnd && eventEnd > proposedStart;
+    });
+}
+
+export function StudioCalendar() {
+    const calendarRef = React.useRef<any>(null);
+    const [visibleRange, setVisibleRange] = React.useState<VisibleRange | null>(null);
+    const [calendarTitle, setCalendarTitle] = React.useState('');
+    const [currentView, setCurrentView] = React.useState<'dayGridMonth' | 'timeGridWeek' | 'timeGridDay' | 'listWeek'>(
+        'dayGridMonth'
+    );
+    const [eventDialogOpen, setEventDialogOpen] = React.useState(false);
+    const [eventDialogMode, setEventDialogMode] = React.useState<EventDialogMode>('create');
+    const [selectedRange, setSelectedRange] = React.useState<{ start: Date; end: Date; allDay: boolean } | null>(null);
+    const [activeEvent, setActiveEvent] = React.useState<CalendarEvent | null>(null);
+    const [assignDialogOpen, setAssignDialogOpen] = React.useState(false);
+    const [toast, setToast] = React.useState<ToastState | null>(null);
+    const [currentUser, setCurrentUser] = React.useState<CurrentUserRecord | null>(null);
+
+    React.useEffect(() => {
+        if (!toast) {
+            return;
+        }
+        const timeout = window.setTimeout(() => setToast(null), 3200);
+        return () => window.clearTimeout(timeout);
+    }, [toast]);
+
+    const supabase = React.useMemo(() => getSupabaseBrowserClient(), []);
+
+    React.useEffect(() => {
+        let isMounted = true;
+        supabase.auth.getUser().then(({ data, error }) => {
+            if (!isMounted) {
+                return;
+            }
+            if (error || !data?.user) {
+                setCurrentUser(null);
+                return;
+            }
+            const userId = data.user.id;
+            supabase
+                .from('users')
+                .select('id, name, email, role, roles')
+                .eq('id', userId)
+                .single()
+                .then(({ data: record, error: recordError }) => {
+                    if (recordError || !record) {
+                        setCurrentUser({
+                            id: userId,
+                            name: data.user.user_metadata?.name ?? null,
+                            email: data.user.email ?? null,
+                            role: null,
+                            roles: null
+                        });
+                        return;
+                    }
+                    setCurrentUser({
+                        id: record.id,
+                        name: record.name ?? null,
+                        email: record.email ?? null,
+                        role: record.role ?? null,
+                        roles: Array.isArray(record.roles) ? (record.roles as string[]) : null
+                    });
+                });
+        });
+        return () => {
+            isMounted = false;
+        };
+    }, [supabase]);
+
+    const currentUserId = currentUser?.id ?? null;
+    const isAdmin = React.useMemo(() => {
+        if (!currentUser) {
+            return false;
+        }
+        if (currentUser.role === 'admin') {
+            return true;
+        }
+        if (Array.isArray(currentUser.roles)) {
+            return currentUser.roles.includes('admin');
+        }
+        return false;
+    }, [currentUser]);
+
+    const { data: clientOptions = [], isLoading: isLoadingClients } = useSWR<ClientOption[]>(
+        'calendar-client-options',
+        fetchClients
+    );
+
+    const {
+        data: events,
+        error: eventsError,
+        isLoading: isLoadingEvents,
+        mutate: mutateEvents
+    } = useSWR<CalendarEvent[]>(
+        visibleRange ? ['studio-calendar-events', visibleRange.start, visibleRange.end] : null,
+        (key) => {
+            const [, start, end] = key as [string, string, string];
+            return fetchCalendarEvents({ start, end });
+        },
+        { revalidateOnFocus: false }
+    );
+
+    const calendarEvents = React.useMemo(() => {
+        return (events ?? []).map((event) => ({
+            id: event.id,
+            title: event.title,
+            start: event.startAt,
+            end: event.endAt,
+            allDay: event.allDay,
+            extendedProps: { calendarEvent: event }
+        }));
+    }, [events]);
+
+    const handleDatesSet = React.useCallback((arg: any) => {
+        setVisibleRange({ start: arg.start.toISOString(), end: arg.end.toISOString() });
+        setCalendarTitle(arg.view.title);
+        const viewType = arg.view.type;
+        if (viewType === 'dayGridMonth' || viewType === 'timeGridWeek' || viewType === 'timeGridDay' || viewType === 'listWeek') {
+            setCurrentView(viewType);
+        }
+    }, []);
+
+    const handleCalendarReady = React.useCallback((calendar: any) => {
+        calendarRef.current = calendar;
+        setCalendarTitle(calendar.view.title);
+        setCurrentView(calendar.view.type as typeof currentView);
+        setVisibleRange({ start: calendar.view.activeStart.toISOString(), end: calendar.view.activeEnd.toISOString() });
+    }, []);
+
+    const openCreateDialog = React.useCallback((range: { start: Date; end: Date; allDay: boolean }) => {
+        setEventDialogMode('create');
+        setSelectedRange(range);
+        setActiveEvent(null);
+        setEventDialogOpen(true);
+    }, []);
+
+    const openEditDialog = React.useCallback((event: CalendarEvent) => {
+        setEventDialogMode('edit');
+        setActiveEvent(event);
+        setSelectedRange(null);
+        setEventDialogOpen(true);
+    }, []);
+
+    const closeEventDialog = React.useCallback(() => {
+        setEventDialogOpen(false);
+        setSelectedRange(null);
+    }, []);
+
+    const handleSelect = React.useCallback(
+        (selection: any) => {
+            if (!currentUserId) {
+                setToast({ id: Date.now(), message: 'Sign in to create events.', variant: 'error' });
+                return;
+            }
+            selection.view.calendar.unselect();
+            openCreateDialog({ start: selection.start, end: selection.end, allDay: selection.allDay });
+        },
+        [currentUserId, openCreateDialog]
+    );
+
+    const handleEventClick = React.useCallback(
+        (clickInfo: any) => {
+            const calendarEvent = (clickInfo.event.extendedProps.calendarEvent as CalendarEvent | undefined) ?? null;
+            if (!calendarEvent) {
+                return;
+            }
+            setActiveEvent(calendarEvent);
+            openEditDialog(calendarEvent);
+        },
+        [openEditDialog]
+    );
+
+    const canEditEvent = React.useCallback(
+        (event: CalendarEvent | null | undefined) => {
+            if (!event || !currentUserId) {
+                return false;
+            }
+            return event.ownerUserId === currentUserId || isAdmin;
+        },
+        [currentUserId, isAdmin]
+    );
+
+    const handleAssignTask = React.useCallback(() => {
+        if (!activeEvent) {
+            return;
+        }
+        setAssignDialogOpen(true);
+    }, [activeEvent]);
+
+    const assignFromList = React.useCallback(
+        (event: CalendarEvent) => {
+            setActiveEvent(event);
+            setAssignDialogOpen(true);
+        },
+        []
+    );
+
+    const renderEventContent = React.useCallback(
+        (arg: any) => {
+            const calendarEvent = arg.event.extendedProps.calendarEvent as CalendarEvent | undefined;
+            if (!calendarEvent) {
+                return undefined;
+            }
+
+            if (arg.view.type.startsWith('list') && currentUserId) {
+                return (
+                    <div className="d-flex w-100 align-items-center justify-content-between gap-3">
+                        <div>
+                            <div className="fw-semibold">
+                                {arg.timeText ? `${arg.timeText} · ` : ''}
+                                {calendarEvent.title}
+                            </div>
+                            {calendarEvent.clientName ? (
+                                <div className="text-secondary small">{calendarEvent.clientName}</div>
+                            ) : null}
+                        </div>
+                        <button
+                            type="button"
+                            className="btn btn-outline-secondary btn-sm"
+                            onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                assignFromList(calendarEvent);
+                            }}
+                        >
+                            Assign task
+                        </button>
+                    </div>
+                );
+            }
+
+            return undefined;
+        },
+        [assignFromList, currentUserId]
+    );
+
+    const handleCreate = React.useCallback(
+        async (values: CalendarEventPayload) => {
+            if (!currentUserId) {
+                throw new Error('You must be signed in to create events.');
+            }
+            const ownerId = currentUserId;
+            const optimisticId = `temp-${Date.now()}`;
+            const clientName = values.client_id
+                ? clientOptions.find((client) => client.id === values.client_id)?.name ?? null
+                : null;
+            const optimisticEvent = mapPayloadToOptimisticEvent(
+                { ...values, owner_user_id: ownerId },
+                { id: optimisticId, ownerUserId: ownerId, clientName, assignees: [] }
+            );
+
+            await mutateEvents(
+                async (current) => {
+                    const created = await createCalendarEvent({ ...values, owner_user_id: ownerId });
+                    return (current ?? []).map((event) => (event.id === optimisticId ? created : event)).concat(
+                        current?.some((event) => event.id === optimisticId) ? [] : [created]
+                    );
+                },
+                {
+                    optimisticData: [...(events ?? []), optimisticEvent],
+                    rollbackOnError: true,
+                    populateCache: true,
+                    revalidate: false
+                }
+            );
+            setToast({ id: Date.now(), message: 'Event created.', variant: 'success' });
+        },
+        [clientOptions, currentUserId, events, mutateEvents]
+    );
+
+    const handleUpdate = React.useCallback(
+        async (eventId: string, values: CalendarEventPayload) => {
+            const existing = events?.find((event) => event.id === eventId);
+            if (!existing) {
+                throw new Error('Event not found.');
+            }
+
+            const optimisticEvent = mapPayloadToOptimisticEvent(values, {
+                id: eventId,
+                ownerUserId: existing.ownerUserId,
+                clientName:
+                    values.client_id && clientOptions.length > 0
+                        ? clientOptions.find((client) => client.id === values.client_id)?.name ?? existing.clientName
+                        : values.client_id === null
+                            ? null
+                            : existing.clientName,
+                assignees: existing.assignees,
+                createdAt: existing.createdAt,
+                updatedAt: existing.updatedAt
+            });
+
+            await mutateEvents(
+                async (current) => {
+                    const updated = await updateCalendarEvent(eventId, values);
+                    return (current ?? []).map((event) => (event.id === eventId ? updated : event));
+                },
+                {
+                    optimisticData: (events ?? []).map((event) => (event.id === eventId ? optimisticEvent : event)),
+                    rollbackOnError: true,
+                    populateCache: true,
+                    revalidate: false
+                }
+            );
+            setToast({ id: Date.now(), message: 'Event updated.', variant: 'success' });
+        },
+        [clientOptions, events, mutateEvents]
+    );
+
+    const handleDelete = React.useCallback(
+        async (eventId: string) => {
+            await mutateEvents(
+                async (current) => {
+                    await deleteCalendarEvent(eventId);
+                    return (current ?? []).filter((event) => event.id !== eventId);
+                },
+                {
+                    optimisticData: (events ?? []).filter((event) => event.id !== eventId),
+                    rollbackOnError: true,
+                    populateCache: true,
+                    revalidate: false
+                }
+            );
+            setToast({ id: Date.now(), message: 'Event deleted.', variant: 'success' });
+        },
+        [events, mutateEvents]
+    );
+
+    const updateFromDrag = React.useCallback(
+        async (eventApi: any, revert: () => void) => {
+            const calendarEvent = eventApi.extendedProps.calendarEvent as CalendarEvent | undefined;
+            if (!calendarEvent) {
+                revert();
+                return;
+            }
+
+            if (!canEditEvent(calendarEvent)) {
+                setToast({ id: Date.now(), message: 'You do not have permission to edit this event.', variant: 'error' });
+                revert();
+                return;
+            }
+
+            const newStart = eventApi.start ?? new Date(calendarEvent.startAt);
+            const newEnd = eventApi.end ?? new Date(calendarEvent.endAt);
+            if (hasOverlap(events, calendarEvent.id, calendarEvent.ownerUserId, newStart, newEnd)) {
+                setToast({ id: Date.now(), message: 'Event overlaps with another event.', variant: 'error' });
+                revert();
+                return;
+            }
+
+            try {
+                await handleUpdate(calendarEvent.id, {
+                    title: calendarEvent.title,
+                    description: calendarEvent.description,
+                    start_at: newStart.toISOString(),
+                    end_at: newEnd.toISOString(),
+                    all_day: eventApi.allDay,
+                    owner_user_id: calendarEvent.ownerUserId,
+                    client_id: calendarEvent.clientId,
+                    location: calendarEvent.location
+                });
+            } catch (error) {
+                console.error('Failed to update event position', error);
+                revert();
+                setToast({ id: Date.now(), message: 'Unable to move event.', variant: 'error' });
+            }
+        },
+        [canEditEvent, events, handleUpdate]
+    );
+
+    const handleEventDrop = React.useCallback(
+        async (arg: any) => {
+            await updateFromDrag(arg.event, arg.revert);
+        },
+        [updateFromDrag]
+    );
+
+    const handleEventResize = React.useCallback(
+        async (arg: any) => {
+            await updateFromDrag(arg.event, arg.revert);
+        },
+        [updateFromDrag]
+    );
+
+    const eventAllow = React.useCallback(
+        (_dropInfo: any, draggedEvent: any) => {
+            const calendarEvent = draggedEvent.extendedProps?.calendarEvent as CalendarEvent | undefined;
+            return canEditEvent(calendarEvent);
+        },
+        [canEditEvent]
+    );
+
+    const handleNewEventClick = React.useCallback(() => {
+        if (!currentUserId) {
+            setToast({ id: Date.now(), message: 'Sign in to create events.', variant: 'error' });
+            return;
+        }
+        const calendar = calendarRef.current;
+        const start = calendar?.getDate() ?? new Date();
+        const end = new Date(start.getTime() + 60 * 60 * 1000);
+        openCreateDialog({ start, end, allDay: false });
+    }, [currentUserId, openCreateDialog]);
+
+    const calendarApiRef = React.useCallback((instance: any) => {
+        if (instance) {
+            const api = instance.getApi();
+            handleCalendarReady(api);
+        }
+    }, [handleCalendarReady]);
+
+    const changeView = React.useCallback((view: typeof currentView) => {
+        const calendar = calendarRef.current;
+        if (!calendar) {
+            return;
+        }
+        calendar.changeView(view);
+    }, []);
+
+    const goToToday = React.useCallback(() => {
+        calendarRef.current?.today();
+    }, []);
+
+    const goToPrev = React.useCallback(() => {
+        calendarRef.current?.prev();
+    }, []);
+
+    const goToNext = React.useCallback(() => {
+        calendarRef.current?.next();
+    }, []);
+
+    const handleDialogSubmit = React.useCallback(
+        async (values: CalendarEventPayload) => {
+            if (eventDialogMode === 'create') {
+                await handleCreate(values);
+            } else if (activeEvent) {
+                await handleUpdate(activeEvent.id, values);
+            }
+        },
+        [activeEvent, eventDialogMode, handleCreate, handleUpdate]
+    );
+
+    const handleDialogDelete = React.useCallback(async () => {
+        if (activeEvent) {
+            await handleDelete(activeEvent.id);
+        }
+    }, [activeEvent, handleDelete]);
+
+    const listAssignButtonVisible = Boolean(currentUserId);
+
+    return (
+        <div className="container py-4">
+            <div className="mb-4 rounded-4 border bg-white p-4 shadow-sm">
+                <div className="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
+                    <div>
+                        <h1 className="h4 mb-1">Studio calendar</h1>
+                        <p className="text-secondary mb-0">Manage bookings, hold dates, and coordinate your team.</p>
+                    </div>
+                    <div className="d-flex flex-wrap align-items-center gap-2">
+                        <Button variant="outline" onClick={goToToday}>
+                            Today
+                        </Button>
+                        <div className="btn-group" role="group" aria-label="Navigate calendar">
+                            <Button variant="outline" onClick={goToPrev}>
+                                Prev
+                            </Button>
+                            <Button variant="outline" onClick={goToNext}>
+                                Next
+                            </Button>
+                        </div>
+                        <div className="btn-group" role="group" aria-label="Change calendar view">
+                            <Button
+                                variant={currentView === 'dayGridMonth' ? 'default' : 'outline'}
+                                onClick={() => changeView('dayGridMonth')}
+                            >
+                                Month
+                            </Button>
+                            <Button
+                                variant={currentView === 'timeGridWeek' ? 'default' : 'outline'}
+                                onClick={() => changeView('timeGridWeek')}
+                            >
+                                Week
+                            </Button>
+                            <Button
+                                variant={currentView === 'timeGridDay' ? 'default' : 'outline'}
+                                onClick={() => changeView('timeGridDay')}
+                            >
+                                Day
+                            </Button>
+                            <Button
+                                variant={currentView === 'listWeek' ? 'default' : 'outline'}
+                                onClick={() => changeView('listWeek')}
+                            >
+                                List
+                            </Button>
+                        </div>
+                        <Button onClick={handleNewEventClick}>New event</Button>
+                    </div>
+                </div>
+
+                <div className="d-flex align-items-center justify-content-between mb-3">
+                    <h2 className="h5 mb-0">{calendarTitle}</h2>
+                    <span className="text-secondary small">Times shown in {DEFAULT_TIME_ZONE}</span>
+                </div>
+
+                {eventsError ? (
+                    <div className="alert alert-danger" role="status">
+                        Unable to load events. Refresh to try again.
+                    </div>
+                ) : null}
+
+                <div className="position-relative rounded-3 border">
+                    {isLoadingEvents ? (
+                        <div className="position-absolute top-0 start-0 h-100 w-100 d-flex align-items-center justify-content-center bg-white bg-opacity-75" role="status">
+                            <div className="spinner-border" aria-hidden="true" />
+                            <span className="visually-hidden">Loading…</span>
+                        </div>
+                    ) : null}
+                    <FullCalendar
+                        ref={calendarApiRef as any}
+                        plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
+                        timeZone={DEFAULT_TIME_ZONE}
+                        initialView="dayGridMonth"
+                        headerToolbar={false}
+                        selectable
+                        editable
+                        selectMirror
+                        dayMaxEvents
+                        events={calendarEvents}
+                        select={handleSelect}
+                        eventClick={handleEventClick}
+                        eventDrop={handleEventDrop}
+                        eventResize={handleEventResize}
+                        eventContent={renderEventContent}
+                        datesSet={handleDatesSet}
+                        eventAllow={eventAllow}
+                        height="auto"
+                    />
+                </div>
+            </div>
+
+            <EventDialog
+                mode={eventDialogMode}
+                open={eventDialogOpen}
+                onOpenChange={(open) => {
+                    setEventDialogOpen(open);
+                    if (!open) {
+                        setActiveEvent(null);
+                    }
+                }}
+                event={eventDialogMode === 'edit' ? activeEvent : null}
+                initialRange={eventDialogMode === 'create' ? selectedRange : null}
+                clientOptions={clientOptions}
+                timezone={DEFAULT_TIME_ZONE}
+                canEdit={eventDialogMode === 'create' ? Boolean(currentUserId) : canEditEvent(activeEvent)}
+                onSubmit={handleDialogSubmit}
+                onDelete={eventDialogMode === 'edit' && activeEvent ? handleDialogDelete : undefined}
+                onAssignTask={eventDialogMode === 'edit' && listAssignButtonVisible ? handleAssignTask : undefined}
+                isLoadingClients={isLoadingClients}
+            />
+
+            <AssignTaskDialog
+                eventId={activeEvent?.id ?? null}
+                open={assignDialogOpen}
+                onOpenChange={setAssignDialogOpen}
+                currentUserId={currentUserId}
+                onAssigned={() => {
+                    setAssignDialogOpen(false);
+                    void mutateEvents();
+                    setToast({ id: Date.now(), message: 'Task assigned.', variant: 'success' });
+                }}
+            />
+
+            <Toast toast={toast} />
+        </div>
+    );
+}

--- a/src/components/crm/WorkspaceLayout.tsx
+++ b/src/components/crm/WorkspaceLayout.tsx
@@ -143,7 +143,7 @@ type NotificationItem = {
 
 const navItems: NavItem[] = [
     { href: '/dashboard', label: 'Home', icon: SparklesIcon },
-    { href: '/calendar', label: 'Calendar', icon: CalendarIcon },
+    { href: '/studio/calendars', label: 'Calendar', icon: CalendarIcon },
     { href: '/contacts', label: 'Contacts', icon: AddressBookIcon },
     { href: '/clients', label: 'Clients', icon: UsersIcon },
     { href: '/galleries', label: 'Galleries', icon: PhotoIcon },
@@ -153,9 +153,9 @@ const navItems: NavItem[] = [
 ];
 
 const quickActions: QuickAction[] = [
-    { href: '/calendar', label: 'New booking', icon: CalendarIcon, variant: 'primary' },
-    { href: '/calendar', label: 'Quick set up', icon: CheckIcon, variant: 'outline' },
-    { href: '/calendar', label: 'Plan a shoot', icon: PhotoIcon, variant: 'primary' },
+    { href: '/studio/calendars', label: 'New booking', icon: CalendarIcon, variant: 'primary' },
+    { href: '/studio/calendars', label: 'Quick set up', icon: CheckIcon, variant: 'outline' },
+    { href: '/studio/calendars', label: 'Plan a shoot', icon: PhotoIcon, variant: 'primary' },
     { href: '/invoices', label: 'Review billing', icon: ReceiptIcon, variant: 'outline' }
 ];
 

--- a/src/lib/supabase/calendar.ts
+++ b/src/lib/supabase/calendar.ts
@@ -1,0 +1,206 @@
+import { getSupabaseBrowserClient } from '../supabase-browser';
+
+export const DEFAULT_TIME_ZONE = 'America/Kentucky/Louisville';
+
+export type EventAssignee = {
+    userId: string;
+    role: string;
+};
+
+export type CalendarEvent = {
+    id: string;
+    title: string;
+    description: string | null;
+    startAt: string;
+    endAt: string;
+    allDay: boolean;
+    ownerUserId: string;
+    clientId: string | null;
+    clientName: string | null;
+    location: string | null;
+    createdAt: string | null;
+    updatedAt: string | null;
+    assignees: EventAssignee[];
+};
+
+export type CalendarEventPayload = {
+    title: string;
+    description?: string | null;
+    start_at: string;
+    end_at: string;
+    all_day: boolean;
+    owner_user_id?: string;
+    client_id?: string | null;
+    location?: string | null;
+};
+
+type CalendarEventRow = {
+    id: string;
+    title: string;
+    description: string | null;
+    start_at: string;
+    end_at: string;
+    all_day: boolean;
+    owner_user_id: string;
+    client_id: string | null;
+    location: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+    client?: { id: string; name: string | null } | Array<{ id: string; name: string | null }> | null;
+    event_assignees?: Array<{ user_id: string; role: string | null } | null> | null;
+};
+
+function mapEvent(row: CalendarEventRow): CalendarEvent {
+    const clientValue = Array.isArray(row.client) ? row.client[0] ?? null : row.client ?? null;
+    return {
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        startAt: row.start_at,
+        endAt: row.end_at,
+        allDay: Boolean(row.all_day),
+        ownerUserId: row.owner_user_id,
+        clientId: row.client_id,
+        clientName: clientValue?.name ?? null,
+        location: row.location,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+        assignees:
+            row.event_assignees?.filter((item): item is { user_id: string; role: string | null } => Boolean(item)).map((item) => ({
+                userId: item.user_id,
+                role: item.role ?? 'assistant'
+            })) ?? []
+    };
+}
+
+export async function fetchCalendarEvents(range: { start: string; end: string }): Promise<CalendarEvent[]> {
+    const supabase = getSupabaseBrowserClient();
+    const { data, error } = await supabase
+        .from('calendar_events')
+        .select(
+            `id, title, description, start_at, end_at, all_day, owner_user_id, client_id, location, created_at, updated_at,
+            client:clients(id, name),
+            event_assignees(user_id, role)`
+        )
+        .lt('start_at', range.end)
+        .gt('end_at', range.start)
+        .order('start_at', { ascending: true });
+
+    if (error) {
+        throw error;
+    }
+
+    return (data ?? []).map(mapEvent);
+}
+
+export async function createCalendarEvent(input: CalendarEventPayload): Promise<CalendarEvent> {
+    const supabase = getSupabaseBrowserClient();
+    const { data, error } = await supabase
+        .from('calendar_events')
+        .insert({
+            title: input.title.trim(),
+            description: input.description?.trim() ?? null,
+            start_at: input.start_at,
+            end_at: input.end_at,
+            all_day: input.all_day,
+            owner_user_id: input.owner_user_id,
+            client_id: input.client_id ?? null,
+            location: input.location?.trim() ?? null
+        })
+        .select(
+            `id, title, description, start_at, end_at, all_day, owner_user_id, client_id, location, created_at, updated_at,
+            client:clients(id, name),
+            event_assignees(user_id, role)`
+        )
+        .single();
+
+    if (error || !data) {
+        throw error ?? new Error('Unable to create calendar event');
+    }
+
+    return mapEvent(data as CalendarEventRow);
+}
+
+export async function updateCalendarEvent(
+    id: string,
+    updates: Partial<Omit<CalendarEventPayload, 'start_at' | 'end_at'>> & { start_at?: string; end_at?: string }
+): Promise<CalendarEvent> {
+    const supabase = getSupabaseBrowserClient();
+    const payload: Record<string, unknown> = {};
+
+    if (updates.title !== undefined) {
+        payload.title = updates.title.trim();
+    }
+    if (updates.description !== undefined) {
+        payload.description = updates.description ? updates.description.trim() : null;
+    }
+    if (updates.start_at !== undefined) {
+        payload.start_at = updates.start_at;
+    }
+    if (updates.end_at !== undefined) {
+        payload.end_at = updates.end_at;
+    }
+    if (updates.all_day !== undefined) {
+        payload.all_day = updates.all_day;
+    }
+    if (updates.owner_user_id !== undefined) {
+        payload.owner_user_id = updates.owner_user_id;
+    }
+    if (updates.client_id !== undefined) {
+        payload.client_id = updates.client_id;
+    }
+    if (updates.location !== undefined) {
+        payload.location = updates.location ? updates.location.trim() : null;
+    }
+
+    const { data, error } = await supabase
+        .from('calendar_events')
+        .update(payload)
+        .eq('id', id)
+        .select(
+            `id, title, description, start_at, end_at, all_day, owner_user_id, client_id, location, created_at, updated_at,
+            client:clients(id, name),
+            event_assignees(user_id, role)`
+        )
+        .single();
+
+    if (error || !data) {
+        throw error ?? new Error('Unable to update calendar event');
+    }
+
+    return mapEvent(data as CalendarEventRow);
+}
+
+export async function deleteCalendarEvent(id: string): Promise<void> {
+    const supabase = getSupabaseBrowserClient();
+    const { error } = await supabase.from('calendar_events').delete().eq('id', id);
+    if (error) {
+        throw error;
+    }
+}
+
+export async function fetchCalendarEvent(id: string): Promise<CalendarEvent | null> {
+    const supabase = getSupabaseBrowserClient();
+    const { data, error } = await supabase
+        .from('calendar_events')
+        .select(
+            `id, title, description, start_at, end_at, all_day, owner_user_id, client_id, location, created_at, updated_at,
+            client:clients(id, name),
+            event_assignees(user_id, role)`
+        )
+        .eq('id', id)
+        .single();
+
+    if (error) {
+        if (error.code === 'PGRST116') {
+            return null;
+        }
+        throw error;
+    }
+
+    if (!data) {
+        return null;
+    }
+
+    return mapEvent(data as CalendarEventRow);
+}

--- a/src/lib/supabase/tasks.ts
+++ b/src/lib/supabase/tasks.ts
@@ -1,0 +1,117 @@
+import { getSupabaseBrowserClient } from '../supabase-browser';
+
+export type TaskPriority = 'low' | 'normal' | 'high';
+export type TaskStatus = 'open' | 'in_progress' | 'done' | 'blocked';
+
+export type TaskRecord = {
+    id: string;
+    title: string;
+    details: string | null;
+    status: TaskStatus;
+    priority: TaskPriority;
+    dueAt: string | null;
+    createdBy: string;
+    assignedTo: string;
+    eventId: string | null;
+    createdAt: string | null;
+    updatedAt: string | null;
+};
+
+export type CreateTaskInput = {
+    title: string;
+    details?: string | null;
+    due_at?: string | null;
+    priority?: TaskPriority;
+    assigned_to: string;
+    event_id?: string | null;
+    created_by: string;
+};
+
+export type UserSummary = {
+    id: string;
+    name: string | null;
+    email: string | null;
+};
+
+type TaskRow = {
+    id: string;
+    title: string;
+    details: string | null;
+    status: string;
+    priority: string | null;
+    due_at: string | null;
+    created_by: string;
+    assigned_to: string;
+    event_id: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+};
+
+function mapTask(row: TaskRow): TaskRecord {
+    return {
+        id: row.id,
+        title: row.title,
+        details: row.details,
+        status: (row.status as TaskStatus) ?? 'open',
+        priority: (row.priority as TaskPriority) ?? 'normal',
+        dueAt: row.due_at,
+        createdBy: row.created_by,
+        assignedTo: row.assigned_to,
+        eventId: row.event_id,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at
+    };
+}
+
+export async function fetchAssignableUsers(): Promise<UserSummary[]> {
+    const supabase = getSupabaseBrowserClient();
+    const { data, error } = await supabase
+        .from('users')
+        .select('id, name, email')
+        .order('name', { ascending: true });
+
+    if (error) {
+        throw error;
+    }
+
+    return (data ?? []).map((row) => ({
+        id: row.id,
+        name: typeof row.name === 'string' && row.name.trim().length > 0 ? row.name : null,
+        email: typeof row.email === 'string' ? row.email : null
+    }));
+}
+
+export async function createTaskForEvent(input: CreateTaskInput): Promise<TaskRecord> {
+    const supabase = getSupabaseBrowserClient();
+    const insertPayload: Record<string, unknown> = {
+        title: input.title.trim(),
+        details: input.details?.trim() ?? null,
+        priority: input.priority ?? 'normal',
+        due_at: input.due_at ?? null,
+        created_by: input.created_by,
+        assigned_to: input.assigned_to,
+        event_id: input.event_id ?? null
+    };
+
+    const { data, error } = await supabase
+        .from('tasks')
+        .insert(insertPayload)
+        .select('id, title, details, status, priority, due_at, created_by, assigned_to, event_id, created_at, updated_at')
+        .single();
+
+    if (error || !data) {
+        throw error ?? new Error('Unable to create task');
+    }
+
+    if (input.event_id) {
+        const { error: assigneeError } = await supabase
+            .from('event_assignees')
+            .upsert({ event_id: input.event_id, user_id: input.assigned_to, role: 'assistant' }, { onConflict: 'event_id,user_id' });
+
+        if (assigneeError) {
+            throw assigneeError;
+        }
+    }
+
+    return mapTask(data as TaskRow);
+}

--- a/src/pages/crm/index.tsx
+++ b/src/pages/crm/index.tsx
@@ -1179,7 +1179,7 @@ function CrmDashboardWorkspace({
                                         title="Upcoming Shoots"
                                         description="Stay ready for every session with a quick view of the week ahead."
                                         action={
-                                            <Link href="/calendar" className="btn btn-sm btn-outline-primary">
+                                            <Link href="/studio/calendars" className="btn btn-sm btn-outline-primary">
                                                 Open calendar
                                             </Link>
                                         }

--- a/supabase/migrations/20250320090000_update_calendar_tasks_rls.sql
+++ b/supabase/migrations/20250320090000_update_calendar_tasks_rls.sql
@@ -1,0 +1,307 @@
+create extension if not exists "pgcrypto";
+
+-- Rename legacy columns to match new schema requirements
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+            AND table_name = 'calendar_events'
+            AND column_name = 'user_id'
+    ) THEN
+        ALTER TABLE public.calendar_events RENAME COLUMN user_id TO owner_user_id;
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+            AND table_name = 'calendar_events'
+            AND column_name = 'start_time'
+    ) THEN
+        ALTER TABLE public.calendar_events RENAME COLUMN start_time TO start_at;
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+            AND table_name = 'calendar_events'
+            AND column_name = 'end_time'
+    ) THEN
+        ALTER TABLE public.calendar_events RENAME COLUMN end_time TO end_at;
+    END IF;
+END
+$$;
+
+-- Ensure required columns exist
+ALTER TABLE public.calendar_events
+    ADD COLUMN IF NOT EXISTS description text,
+    ADD COLUMN IF NOT EXISTS all_day boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS client_id uuid REFERENCES public.clients(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS location text,
+    ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();
+
+ALTER TABLE public.calendar_events
+    ALTER COLUMN title SET NOT NULL,
+    ALTER COLUMN start_at SET NOT NULL,
+    ALTER COLUMN end_at SET NOT NULL,
+    ALTER COLUMN owner_user_id SET NOT NULL,
+    ALTER COLUMN created_at SET DEFAULT now(),
+    ALTER COLUMN updated_at SET DEFAULT now();
+
+UPDATE public.calendar_events
+SET updated_at = COALESCE(updated_at, now());
+
+ALTER TABLE public.calendar_events
+    ALTER COLUMN updated_at SET NOT NULL;
+
+-- Refresh foreign keys and indexes
+ALTER TABLE public.calendar_events
+    DROP CONSTRAINT IF EXISTS calendar_events_user_id_fkey;
+
+ALTER TABLE public.calendar_events
+    ADD CONSTRAINT calendar_events_owner_user_id_fkey
+        FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+DROP INDEX IF EXISTS idx_calendar_events_user_id;
+DROP INDEX IF EXISTS idx_calendar_events_start_time;
+DROP INDEX IF EXISTS idx_calendar_events_end_time;
+
+CREATE INDEX IF NOT EXISTS calendar_events_owner_user_id_idx ON public.calendar_events(owner_user_id);
+CREATE INDEX IF NOT EXISTS calendar_events_client_id_idx ON public.calendar_events(client_id);
+CREATE INDEX IF NOT EXISTS calendar_events_start_at_idx ON public.calendar_events(start_at);
+CREATE INDEX IF NOT EXISTS calendar_events_end_at_idx ON public.calendar_events(end_at);
+
+-- Ensure updated_at stays in sync
+DROP TRIGGER IF EXISTS calendar_events_set_updated_at ON public.calendar_events;
+CREATE TRIGGER calendar_events_set_updated_at
+    BEFORE UPDATE ON public.calendar_events
+    FOR EACH ROW
+    EXECUTE PROCEDURE public.set_updated_at();
+
+-- Tasks table for event assignments
+CREATE TABLE IF NOT EXISTS public.tasks (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    title text NOT NULL,
+    details text,
+    status text NOT NULL DEFAULT 'open',
+    priority text DEFAULT 'normal',
+    due_at timestamptz,
+    created_by uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    assigned_to uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    event_id uuid REFERENCES public.calendar_events(id) ON DELETE SET NULL,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS tasks_assigned_to_idx ON public.tasks(assigned_to);
+CREATE INDEX IF NOT EXISTS tasks_event_id_idx ON public.tasks(event_id);
+CREATE INDEX IF NOT EXISTS tasks_status_idx ON public.tasks(status);
+CREATE INDEX IF NOT EXISTS tasks_due_at_idx ON public.tasks(due_at);
+
+UPDATE public.tasks
+SET updated_at = COALESCE(updated_at, now());
+
+DROP TRIGGER IF EXISTS tasks_set_updated_at ON public.tasks;
+CREATE TRIGGER tasks_set_updated_at
+    BEFORE UPDATE ON public.tasks
+    FOR EACH ROW
+    EXECUTE PROCEDURE public.set_updated_at();
+
+-- Event assignees join table
+CREATE TABLE IF NOT EXISTS public.event_assignees (
+    event_id uuid NOT NULL REFERENCES public.calendar_events(id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    role text NOT NULL DEFAULT 'assistant',
+    PRIMARY KEY (event_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS event_assignees_user_id_idx ON public.event_assignees(user_id);
+
+-- Helper to check admin role
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    current_user_id uuid;
+    user_record public.users;
+BEGIN
+    current_user_id := auth.uid();
+    IF current_user_id IS NULL THEN
+        RETURN false;
+    END IF;
+
+    SELECT u.* INTO user_record
+    FROM public.users u
+    WHERE u.id = current_user_id;
+
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+
+    IF user_record.role = 'admin' THEN
+        RETURN true;
+    END IF;
+
+    IF user_record.roles IS NOT NULL AND array_position(user_record.roles, 'admin') IS NOT NULL THEN
+        RETURN true;
+    END IF;
+
+    RETURN false;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.is_admin() TO public;
+
+-- Enable RLS
+ALTER TABLE public.calendar_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_assignees ENABLE ROW LEVEL SECURITY;
+
+-- Calendar event policies
+DROP POLICY IF EXISTS calendar_events_select ON public.calendar_events;
+DROP POLICY IF EXISTS calendar_events_insert ON public.calendar_events;
+DROP POLICY IF EXISTS calendar_events_update ON public.calendar_events;
+DROP POLICY IF EXISTS calendar_events_delete ON public.calendar_events;
+
+CREATE POLICY calendar_events_select ON public.calendar_events
+    FOR SELECT
+    USING (
+        owner_user_id = auth.uid()
+        OR public.is_admin()
+        OR EXISTS (
+            SELECT 1
+            FROM public.event_assignees ea
+            WHERE ea.event_id = public.calendar_events.id
+              AND ea.user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY calendar_events_insert ON public.calendar_events
+    FOR INSERT
+    WITH CHECK (owner_user_id = auth.uid() OR public.is_admin());
+
+CREATE POLICY calendar_events_update ON public.calendar_events
+    FOR UPDATE
+    USING (owner_user_id = auth.uid() OR public.is_admin())
+    WITH CHECK (owner_user_id = auth.uid() OR public.is_admin());
+
+CREATE POLICY calendar_events_delete ON public.calendar_events
+    FOR DELETE
+    USING (owner_user_id = auth.uid() OR public.is_admin());
+
+-- Event assignee policies
+DROP POLICY IF EXISTS event_assignees_select ON public.event_assignees;
+DROP POLICY IF EXISTS event_assignees_insert ON public.event_assignees;
+DROP POLICY IF EXISTS event_assignees_update ON public.event_assignees;
+DROP POLICY IF EXISTS event_assignees_delete ON public.event_assignees;
+
+CREATE POLICY event_assignees_select ON public.event_assignees
+    FOR SELECT
+    USING (
+        user_id = auth.uid()
+        OR public.is_admin()
+        OR EXISTS (
+            SELECT 1
+            FROM public.calendar_events ce
+            WHERE ce.id = public.event_assignees.event_id
+              AND ce.owner_user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY event_assignees_insert ON public.event_assignees
+    FOR INSERT
+    WITH CHECK (
+        public.is_admin()
+        OR EXISTS (
+            SELECT 1
+            FROM public.calendar_events ce
+            WHERE ce.id = public.event_assignees.event_id
+              AND ce.owner_user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY event_assignees_update ON public.event_assignees
+    FOR UPDATE
+    USING (
+        public.is_admin()
+        OR EXISTS (
+            SELECT 1
+            FROM public.calendar_events ce
+            WHERE ce.id = public.event_assignees.event_id
+              AND ce.owner_user_id = auth.uid()
+        )
+    )
+    WITH CHECK (
+        public.is_admin()
+        OR EXISTS (
+            SELECT 1
+            FROM public.calendar_events ce
+            WHERE ce.id = public.event_assignees.event_id
+              AND ce.owner_user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY event_assignees_delete ON public.event_assignees
+    FOR DELETE
+    USING (
+        public.is_admin()
+        OR EXISTS (
+            SELECT 1
+            FROM public.calendar_events ce
+            WHERE ce.id = public.event_assignees.event_id
+              AND ce.owner_user_id = auth.uid()
+        )
+    );
+
+-- Task policies
+DROP POLICY IF EXISTS tasks_select ON public.tasks;
+DROP POLICY IF EXISTS tasks_insert ON public.tasks;
+DROP POLICY IF EXISTS tasks_update ON public.tasks;
+DROP POLICY IF EXISTS tasks_delete ON public.tasks;
+
+CREATE POLICY tasks_select ON public.tasks
+    FOR SELECT
+    USING (
+        created_by = auth.uid()
+        OR assigned_to = auth.uid()
+        OR public.is_admin()
+    );
+
+CREATE POLICY tasks_insert ON public.tasks
+    FOR INSERT
+    WITH CHECK (created_by = auth.uid() OR public.is_admin());
+
+CREATE POLICY tasks_update ON public.tasks
+    FOR UPDATE
+    USING (
+        created_by = auth.uid()
+        OR assigned_to = auth.uid()
+        OR public.is_admin()
+    )
+    WITH CHECK (
+        created_by = auth.uid()
+        OR assigned_to = auth.uid()
+        OR public.is_admin()
+    );
+
+CREATE POLICY tasks_delete ON public.tasks
+    FOR DELETE
+    USING (
+        created_by = auth.uid()
+        OR assigned_to = auth.uid()
+        OR public.is_admin()
+    );


### PR DESCRIPTION
## Summary
- build a Studio calendar page that wraps FullCalendar with toolbar controls, optimistic event mutations, and task assignment hooks
- add reusable event and task dialogs that validate input, surface permissions, and call Supabase helpers
- extend Supabase browser utilities with calendar/task CRUD plus a migration covering tables, indexes, and RLS policies
- point CRM navigation and quick actions to the Studio calendar route so the UI opens the new experience

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01a89d81c8329849be773d4a3d4a0