### PR TITLE
Refactor projects page into kanban lanes

### DIFF
--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -7,33 +7,12 @@ import { formatCurrency, formatDate } from '../../lib/formatters';
 import {
     type ProjectInvoiceSnippet,
     type ProjectRecord,
-    type ProjectStatus,
     type ProjectTaskRecord,
     type ProjectTaskStatus
 } from '../../types/project';
+import { formatProjectStatusLabel, getProjectStatusMeta } from './status-meta';
 
-const projectStatusMap = {
-    PLANNING: {
-        label: 'Planning',
-        badgeClass: 'border-amber-400/40 bg-amber-500/15 text-amber-200'
-    },
-    IN_PROGRESS: {
-        label: 'In progress',
-        badgeClass: 'border-indigo-400/40 bg-indigo-500/15 text-indigo-200'
-    },
-    ON_HOLD: {
-        label: 'On hold',
-        badgeClass: 'border-slate-400/40 bg-slate-500/15 text-slate-200'
-    },
-    COMPLETE: {
-        label: 'Complete',
-        badgeClass: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200'
-    },
-    CANCELLED: {
-        label: 'Cancelled',
-        badgeClass: 'border-rose-400/40 bg-rose-500/15 text-rose-200'
-    }
-} satisfies Record<ProjectStatus, { label: string; badgeClass: string }>;
+const formatStatusLabel = formatProjectStatusLabel;
 
 const taskStatusMap = {
     PENDING: { label: 'Pending', className: 'border-amber-400/40 bg-amber-500/15 text-amber-200' },
@@ -50,41 +29,6 @@ const invoiceStatusMap: Record<ProjectInvoiceSnippet['status'], string> = {
 };
 
 const neutralBadgeClass = 'border-slate-500/40 bg-slate-500/15 text-slate-200';
-
-function formatStatusLabel(rawStatus?: string | null): string {
-    if (!rawStatus) {
-        return 'Unknown Status';
-    }
-
-    const cleaned = rawStatus
-        .replace(/([a-z])([A-Z])/g, '$1 $2')
-        .replace(/[_-]+/g, ' ')
-        .replace(/\s+/g, ' ')
-        .trim();
-
-    if (!cleaned) {
-        return 'Unknown Status';
-    }
-
-    return cleaned
-        .split(' ')
-        .filter(Boolean)
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-        .join(' ');
-}
-
-function getProjectStatusMeta(status: string | undefined) {
-    const meta = projectStatusMap[status as keyof typeof projectStatusMap];
-
-    if (meta) {
-        return meta;
-    }
-
-    return {
-        label: formatStatusLabel(status),
-        badgeClass: neutralBadgeClass
-    };
-}
 
 function getTaskStatusMeta(status: string | undefined) {
     const meta = taskStatusMap[status as keyof typeof taskStatusMap];

--- a/src/components/projects/status-meta.ts
+++ b/src/components/projects/status-meta.ts
@@ -1,0 +1,66 @@
+import type { ProjectStatus } from '../../types/project';
+
+export type ProjectStatusMeta = {
+    label: string;
+    badgeClass: string;
+};
+
+const neutralBadgeClass = 'border-slate-500/40 bg-slate-500/15 text-slate-200';
+
+export const PROJECT_STATUS_META: Record<ProjectStatus, ProjectStatusMeta> = {
+    PLANNING: {
+        label: 'Planning',
+        badgeClass: 'border-amber-400/40 bg-amber-500/15 text-amber-200'
+    },
+    IN_PROGRESS: {
+        label: 'In progress',
+        badgeClass: 'border-indigo-400/40 bg-indigo-500/15 text-indigo-200'
+    },
+    ON_HOLD: {
+        label: 'On hold',
+        badgeClass: 'border-slate-400/40 bg-slate-500/15 text-slate-200'
+    },
+    COMPLETE: {
+        label: 'Complete',
+        badgeClass: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200'
+    },
+    CANCELLED: {
+        label: 'Cancelled',
+        badgeClass: 'border-rose-400/40 bg-rose-500/15 text-rose-200'
+    }
+};
+
+export function formatProjectStatusLabel(rawStatus?: string | null): string {
+    if (!rawStatus) {
+        return 'Unknown Status';
+    }
+
+    const cleaned = rawStatus
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    if (!cleaned) {
+        return 'Unknown Status';
+    }
+
+    return cleaned
+        .split(' ')
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(' ');
+}
+
+export function getProjectStatusMeta(status?: string | null) {
+    if (status && status in PROJECT_STATUS_META) {
+        const typedStatus = status as ProjectStatus;
+        return { ...PROJECT_STATUS_META[typedStatus], isKnown: true as const };
+    }
+
+    return {
+        label: formatProjectStatusLabel(status),
+        badgeClass: neutralBadgeClass,
+        isKnown: false as const
+    };
+}


### PR DESCRIPTION
## Summary
- refactor the projects workspace into status-based kanban lanes with responsive scrolling and lane-specific empty states
- extract reusable project status metadata utilities and reuse them inside the project card presentation
- adjust project fetching, filtering, and creation handling to support the new board layout and larger page size

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d13cc220908329b9f57892baaaa24e