### PR TITLE
Fix studio calendar route and Supabase messaging

### DIFF
--- a/src/app/studio/calendars/page.tsx
+++ b/src/app/studio/calendars/page.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import { StudioCalendar } from '../../../components/calendar/StudioCalendar';
-
-export default function CalendarsPage() {
-    return <StudioCalendar />;
-}

--- a/src/pages/studio/calendars/index.tsx
+++ b/src/pages/studio/calendars/index.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+
+import { StudioCalendar } from '../../../components/calendar/StudioCalendar';
+import { CrmAuthGuard, WorkspaceLayout } from '../../../components/crm';
+
+export default function StudioCalendarsPage() {
+    return (
+        <CrmAuthGuard>
+            <WorkspaceLayout>
+                <Head>
+                    <title>Calendar · Aperture Studio CRM</title>
+                </Head>
+                <StudioCalendar />
+            </WorkspaceLayout>
+        </CrmAuthGuard>
+    );
+}


### PR DESCRIPTION
## Summary
- move the /studio/calendars route into the pages router so it inherits the CRM workspace layout
- refactor StudioCalendar to reuse a shared page shell and show a helpful message when Supabase credentials are missing

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d145fff9448329b7592da57557c91d