### PR TITLE
Sync auth users to public users table

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The CRM API routes under `src/pages/api/` rely on [Supabase](https://supabase.co
 
 These API routes return JSON responses for GET, POST, PUT, and DELETE requests, so they can be consumed directly from front-end forms or integrations.
 
+When preparing CSVs for Supabase imports (for example, bulk-loading contacts or clients), set the `owner_user_id` column to a value from `public.users.id`. Leave the field blank if the record should be unassigned so the import stores a `NULL` owner.
+
 ### Galleries automation with Dropbox
 
 The galleries dashboard now includes an authenticated Dropbox workflow so asset imports are trackable end-to-end without exposing access tokens to the browser.

--- a/supabase/migrations/20250325120000_sync_auth_users_to_public_users.sql
+++ b/supabase/migrations/20250325120000_sync_auth_users_to_public_users.sql
@@ -1,0 +1,56 @@
+create extension if not exists "pgcrypto";
+
+-- Backfill public.users with any auth.users records that are missing.
+insert into public.users as u (id, email, password_hash, created_at, updated_at, email_verified_at)
+select
+    au.id,
+    au.email,
+    crypt('temporary-password-change-me', gen_salt('bf')),
+    coalesce(au.created_at, timezone('utc', now())),
+    greatest(coalesce(au.updated_at, au.created_at, timezone('utc', now())), coalesce(au.created_at, timezone('utc', now()))),
+    coalesce(au.email_confirmed_at, au.confirmed_at)
+from auth.users au
+where not exists (
+    select 1
+    from public.users pu
+    where pu.id = au.id
+);
+
+-- Keep public.users synced with auth.users going forward.
+create or replace function public.sync_public_user_from_auth()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+    now_utc timestamptz := timezone('utc', now());
+    created_ts timestamptz := coalesce(new.created_at, now_utc);
+    updated_ts timestamptz := greatest(coalesce(new.updated_at, now_utc), created_ts);
+    verified_ts timestamptz := coalesce(new.email_confirmed_at, new.confirmed_at);
+begin
+    insert into public.users as u (id, email, password_hash, created_at, updated_at, email_verified_at)
+    values (
+        new.id,
+        new.email,
+        crypt('temporary-password-change-me', gen_salt('bf')),
+        created_ts,
+        updated_ts,
+        verified_ts
+    )
+    on conflict (id) do update
+        set email = excluded.email,
+            updated_at = excluded.updated_at,
+            email_verified_at = coalesce(excluded.email_verified_at, u.email_verified_at),
+            password_hash = u.password_hash,
+            created_at = u.created_at;
+
+    return new;
+end;
+$$;
+
+drop trigger if exists sync_public_users_from_auth on auth.users;
+create trigger sync_public_users_from_auth
+    after insert or update on auth.users
+    for each row
+    execute function public.sync_public_user_from_auth();


### PR DESCRIPTION
## Summary
- backfill missing public.users rows for every auth.users account using a new Supabase migration
- add trigger-based sync so auth.users inserts and updates keep the mirrored public.users row current
- update the README import guidance to reference public.users.id when populating owner_user_id columns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d155385780832990acdd0f2e81e38c