### PR TITLE
Refactor projects board layout

### DIFF
--- a/src/components/dashboard/card.tsx
+++ b/src/components/dashboard/card.tsx
@@ -2,14 +2,19 @@ import * as React from 'react';
 
 import { cn } from '../../lib/cn';
 
-type CardProps = {
+type CardProps = React.HTMLAttributes<HTMLDivElement> & {
     children: React.ReactNode;
-    className?: string;
 };
 
-export function DashboardCard({ children, className }: CardProps) {
+export function DashboardCard({ children, className, ...props }: CardProps) {
     return (
-        <div className={cn('card card-stacked h-100', className)}>
+        <div
+            {...props}
+            className={cn(
+                'card card-stacked h-100 transition-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-400/70 focus-visible:outline-offset-2',
+                className
+            )}
+        >
             <div className="card-body">{children}</div>
         </div>
     );

--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -72,14 +72,21 @@ export function ProjectCard({ project }: ProjectCardProps) {
     const hasDateRange = project.startDate && project.endDate;
 
     return (
-        <DashboardCard>
+        <DashboardCard
+            tabIndex={0}
+            role="article"
+            aria-labelledby={`project-${project.id}-title`}
+            className="focus-visible:outline-indigo-300/80"
+        >
             <div className="flex items-start justify-between gap-6">
                 <div className="space-y-3">
                     <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${statusMeta.badgeClass}`}>
                         {statusMeta.label}
                     </span>
                     <div>
-                        <h2 className="text-xl font-semibold text-white">{project.title}</h2>
+                        <h2 id={`project-${project.id}-title`} className="text-xl font-semibold text-white">
+                            {project.title}
+                        </h2>
                         <p className="mt-1 text-sm text-slate-400">Client · {project.clientName ?? 'Unknown client'}</p>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- refactor the Projects workspace to reuse a horizontally scrolling board layout with sticky lane headers and a compact filter toolbar
- add accessibility touches, including keyboard focus outlines and semantic headings on board cards and lane counts
- enhance the shared DashboardCard so it forwards HTML attributes and renders focus-visible styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1587d85d88329ae38f22fea83063f