### PR TITLE
Resolve merge conflict in auth/public users sync migration

### DIFF
--- a/supabase/migrations/20250325120000_sync_auth_users_to_public_users.sql
+++ b/supabase/migrations/20250325120000_sync_auth_users_to_public_users.sql
@@ -1,20 +1,33 @@
 create extension if not exists "pgcrypto";
 
--- Backfill public.users with any auth.users records that are missing.
+-- Backfill public.users with auth.users rows so owner references remain valid.
+with auth_source as (
+    select
+        au.id,
+        au.email,
+        coalesce(au.created_at, timezone('utc', now())) as created_at,
+        greatest(
+            coalesce(au.updated_at, au.created_at, timezone('utc', now())),
+            coalesce(au.created_at, timezone('utc', now()))
+        ) as updated_at,
+        coalesce(au.email_confirmed_at, au.confirmed_at) as email_verified_at
+    from auth.users au
+)
 insert into public.users as u (id, email, password_hash, created_at, updated_at, email_verified_at)
 select
-    au.id,
-    au.email,
+    s.id,
+    s.email,
     crypt('temporary-password-change-me', gen_salt('bf')),
-    coalesce(au.created_at, timezone('utc', now())),
-    greatest(coalesce(au.updated_at, au.created_at, timezone('utc', now())), coalesce(au.created_at, timezone('utc', now()))),
-    coalesce(au.email_confirmed_at, au.confirmed_at)
-from auth.users au
-where not exists (
-    select 1
-    from public.users pu
-    where pu.id = au.id
-);
+    s.created_at,
+    s.updated_at,
+    s.email_verified_at
+from auth_source s
+on conflict (id) do update
+    set email = excluded.email,
+        updated_at = greatest(excluded.updated_at, u.updated_at),
+        email_verified_at = coalesce(u.email_verified_at, excluded.email_verified_at),
+        password_hash = coalesce(u.password_hash, excluded.password_hash),
+        created_at = least(u.created_at, excluded.created_at);
 
 -- Keep public.users synced with auth.users going forward.
 create or replace function public.sync_public_user_from_auth()
@@ -40,10 +53,10 @@ begin
     )
     on conflict (id) do update
         set email = excluded.email,
-            updated_at = excluded.updated_at,
+            updated_at = greatest(excluded.updated_at, u.updated_at),
             email_verified_at = coalesce(excluded.email_verified_at, u.email_verified_at),
-            password_hash = u.password_hash,
-            created_at = u.created_at;
+            password_hash = coalesce(u.password_hash, excluded.password_hash),
+            created_at = least(u.created_at, excluded.created_at);
 
     return new;
 end;


### PR DESCRIPTION
## Summary
- update the Supabase migration that syncs auth.users into public.users to use a common CTE
- ensure upserts preserve existing password hashes and favor the oldest created/newest updated timestamps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d16071447c8329a6b0f6fb18ac37f8