### PR TITLE
Fix studio calendar ref initialization

### DIFF
--- a/src/components/calendar/StudioCalendar.tsx
+++ b/src/components/calendar/StudioCalendar.tsx
@@ -541,12 +541,18 @@ function StudioCalendarContent() {
         openCreateDialog({ start, end, allDay: false });
     }, [currentUserId, openCreateDialog]);
 
-    const calendarApiRef = React.useCallback((instance: any) => {
-        if (instance) {
-            const api = instance.getApi();
-            handleCalendarReady(api);
-        }
-    }, [handleCalendarReady]);
+    const calendarApiRef = React.useCallback(
+        (instance: any) => {
+            if (instance) {
+                const api = typeof instance.getApi === 'function' ? instance.getApi() : instance;
+                calendarRef.current = api;
+                handleCalendarReady(api);
+            } else {
+                calendarRef.current = null;
+            }
+        },
+        [handleCalendarReady]
+    );
 
     const changeView = React.useCallback((view: typeof currentView) => {
         const calendar = calendarRef.current;


### PR DESCRIPTION
## Summary
- ensure the StudioCalendar ref always stores the FullCalendar API instance
- guard against refs that already return an API object and clear the ref when unmounting

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1718e47b08329b0685f0790a12efc