### PR TITLE
refactor settings forms with reusable layout

### DIFF
--- a/src/components/forms/FieldGrid.tsx
+++ b/src/components/forms/FieldGrid.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import cn from '../../lib/cn';
+
+export type FieldGridProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function FieldGrid({ className, ...props }: FieldGridProps) {
+    return <div className={cn('grid grid-cols-12 gap-4', className)} {...props} />;
+}

--- a/src/components/forms/FieldWrapper.tsx
+++ b/src/components/forms/FieldWrapper.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { useFormContext, type FieldError } from 'react-hook-form';
+
+import cn from '../../lib/cn';
+
+import { ErrorText, HelpText, Label } from './primitives';
+import { sizeCols, type FieldSize } from './tokens';
+
+function resolveError(errors: unknown, name: string): FieldError | undefined {
+    if (!errors || typeof errors !== 'object') {
+        return undefined;
+    }
+
+    const segments = name.split('.');
+    let current: unknown = errors;
+
+    for (const segment of segments) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+
+        current = (current as Record<string, unknown>)[segment];
+    }
+
+    return (current as FieldError) ?? undefined;
+}
+
+export type FieldWrapperProps = {
+    name: string;
+    label: string;
+    size?: FieldSize;
+    helpText?: React.ReactNode;
+    description?: React.ReactNode;
+    children: React.ReactNode;
+    className?: string;
+};
+
+export function FieldWrapper({
+    name,
+    label,
+    size = 'md',
+    helpText,
+    description,
+    children,
+    className
+}: FieldWrapperProps) {
+    const {
+        formState: { errors }
+    } = useFormContext();
+
+    const error = resolveError(errors, name);
+    const helpId = helpText ? `${name}-help` : undefined;
+    const errorId = error ? `${name}-error` : undefined;
+    const describedBy = [helpId, errorId].filter(Boolean).join(' ') || undefined;
+    const invalid = Boolean(error);
+
+    let control: React.ReactNode = children;
+
+    if (typeof children === 'function') {
+        control = (children as (context: { describedBy?: string; invalid: boolean }) => React.ReactNode)({
+            describedBy,
+            invalid
+        });
+    } else if (React.isValidElement(children)) {
+        control = React.cloneElement(children as React.ReactElement<any>, {
+            describedBy,
+            invalid,
+            name
+        });
+    }
+
+    return (
+        <div className={cn('space-y-2', sizeCols[size], className)}>
+            <div className="space-y-1">
+                <Label htmlFor={name}>{label}</Label>
+                {description ? <p className="text-sm text-slate-400">{description}</p> : null}
+                {control}
+            </div>
+            {helpText ? (
+                <HelpText id={helpId} aria-live="polite">
+                    {helpText}
+                </HelpText>
+            ) : null}
+            {error ? (
+                <ErrorText id={errorId} role="alert">
+                    {error.message}
+                </ErrorText>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/forms/SectionCard.tsx
+++ b/src/components/forms/SectionCard.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+
+import cn from '../../lib/cn';
+
+export type SectionCardProps = {
+    title: string;
+    subtitle?: string;
+    eyebrow?: string;
+    actions?: React.ReactNode;
+    stickyHeader?: boolean;
+    children: React.ReactNode;
+} & React.HTMLAttributes<HTMLElement>;
+
+export function SectionCard({
+    title,
+    subtitle,
+    eyebrow,
+    actions,
+    stickyHeader,
+    children,
+    className,
+    ...props
+}: SectionCardProps) {
+    return (
+        <section
+            className={cn('rounded-3xl border border-slate-800/80 bg-slate-950/60 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.95)]', className)}
+            {...props}
+        >
+            <header
+                className={cn(
+                    'flex flex-col gap-4 border-b border-white/5 px-6 py-4 md:flex-row md:items-center md:justify-between',
+                    stickyHeader &&
+                        'md:sticky md:top-20 md:z-20 md:border-white/5 md:bg-slate-950/80 md:shadow-[0_20px_40px_-40px_rgba(15,23,42,0.95)] md:backdrop-blur'
+                )}
+            >
+                <div className="space-y-1">
+                    {eyebrow ? (
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.48em] text-[#4DE5FF]">{eyebrow}</p>
+                    ) : null}
+                    <h2 className="text-xl font-semibold tracking-tight text-white">{title}</h2>
+                    {subtitle ? <p className="text-sm text-slate-300">{subtitle}</p> : null}
+                </div>
+                {actions ? <div className="flex flex-wrap items-center gap-2 md:justify-end">{actions}</div> : null}
+            </header>
+            <div className="px-6 py-6">{children}</div>
+        </section>
+    );
+}
+
+export type FormSectionCardProps = {
+    title: string;
+    subtitle?: string;
+    eyebrow?: string;
+    actions?: React.ReactNode;
+    stickyHeader?: boolean;
+    children: React.ReactNode;
+} & React.FormHTMLAttributes<HTMLFormElement>;
+
+export function FormSectionCard({
+    title,
+    subtitle,
+    eyebrow,
+    actions,
+    stickyHeader = true,
+    children,
+    className,
+    ...props
+}: FormSectionCardProps) {
+    return (
+        <form
+            className={cn('rounded-3xl border border-slate-800/80 bg-slate-950/60 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.95)]', className)}
+            {...props}
+        >
+            <div
+                className={cn(
+                    'flex flex-col gap-4 border-b border-white/5 px-6 py-4 md:flex-row md:items-center md:justify-between',
+                    stickyHeader &&
+                        'md:sticky md:top-24 md:z-20 md:border-white/5 md:bg-slate-950/80 md:shadow-[0_20px_40px_-40px_rgba(15,23,42,0.95)] md:backdrop-blur'
+                )}
+            >
+                <div className="space-y-1">
+                    {eyebrow ? (
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.48em] text-[#4DE5FF]">{eyebrow}</p>
+                    ) : null}
+                    <h2 className="text-xl font-semibold tracking-tight text-white">{title}</h2>
+                    {subtitle ? <p className="text-sm text-slate-300">{subtitle}</p> : null}
+                </div>
+                {actions ? <div className="flex flex-wrap items-center gap-2 md:justify-end">{actions}</div> : null}
+            </div>
+            <div className="px-6 py-6">{children}</div>
+        </form>
+    );
+}

--- a/src/components/forms/inputs.tsx
+++ b/src/components/forms/inputs.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { useFormContext, type RegisterOptions } from 'react-hook-form';
+
+import cn from '../../lib/cn';
+
+type BaseControlProps = {
+    name: string;
+    describedBy?: string;
+    invalid?: boolean;
+    className?: string;
+};
+
+type TextInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name'> &
+    BaseControlProps & {
+        registerOptions?: RegisterOptions;
+    };
+
+function baseInputClasses(invalid?: boolean) {
+    return cn(
+        'w-full rounded-2xl border px-3 py-2 text-sm text-white transition focus-visible:outline-none',
+        invalid
+            ? 'border-red-500/70 bg-red-950/30 focus-visible:border-red-400 focus-visible:ring-2 focus-visible:ring-red-500/40'
+            : 'border-slate-800/80 bg-slate-950/80 focus-visible:border-[#4DE5FF] focus-visible:ring-2 focus-visible:ring-[#4DE5FF]/50',
+        'placeholder:text-slate-500'
+    );
+}
+
+export function TextInput({
+    name,
+    describedBy,
+    invalid,
+    className,
+    type = 'text',
+    registerOptions,
+    onChange,
+    onBlur,
+    ...props
+}: TextInputProps) {
+    const { register } = useFormContext();
+    const registration = register(name, {
+        ...registerOptions,
+        onChange: (event) => {
+            registerOptions?.onChange?.(event);
+            onChange?.(event as React.ChangeEvent<HTMLInputElement>);
+        },
+        onBlur: (event) => {
+            registerOptions?.onBlur?.(event);
+            onBlur?.(event as React.FocusEvent<HTMLInputElement>);
+        }
+    });
+
+    return (
+        <input
+            id={props.id ?? name}
+            type={type}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            className={cn(baseInputClasses(invalid), className)}
+            {...props}
+            {...registration}
+        />
+    );
+}
+
+type TextareaProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'name'> &
+    BaseControlProps & {
+        registerOptions?: RegisterOptions;
+    };
+
+export function Textarea({
+    name,
+    describedBy,
+    invalid,
+    className,
+    registerOptions,
+    rows = 4,
+    onChange,
+    onBlur,
+    ...props
+}: TextareaProps) {
+    const { register } = useFormContext();
+    const registration = register(name, {
+        ...registerOptions,
+        onChange: (event) => {
+            registerOptions?.onChange?.(event);
+            onChange?.(event as React.ChangeEvent<HTMLTextAreaElement>);
+        },
+        onBlur: (event) => {
+            registerOptions?.onBlur?.(event);
+            onBlur?.(event as React.FocusEvent<HTMLTextAreaElement>);
+        }
+    });
+
+    return (
+        <textarea
+            id={props.id ?? name}
+            rows={rows}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            className={cn(baseInputClasses(invalid), 'resize-none', className)}
+            {...props}
+            {...registration}
+        />
+    );
+}
+
+type SelectOption = { label: string; value: string };
+
+type SelectProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'name'> &
+    BaseControlProps & {
+        options: SelectOption[];
+        registerOptions?: RegisterOptions;
+    };
+
+export function Select({
+    name,
+    describedBy,
+    invalid,
+    className,
+    options,
+    registerOptions,
+    onChange,
+    onBlur,
+    ...props
+}: SelectProps) {
+    const { register } = useFormContext();
+    const registration = register(name, {
+        ...registerOptions,
+        onChange: (event) => {
+            registerOptions?.onChange?.(event);
+            onChange?.(event as React.ChangeEvent<HTMLSelectElement>);
+        },
+        onBlur: (event) => {
+            registerOptions?.onBlur?.(event);
+            onBlur?.(event as React.FocusEvent<HTMLSelectElement>);
+        }
+    });
+
+    return (
+        <select
+            id={props.id ?? name}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            className={cn(baseInputClasses(invalid), 'appearance-none pr-9', className)}
+            {...props}
+            {...registration}
+        >
+            {options.map((option) => (
+                <option key={option.value} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </select>
+    );
+}

--- a/src/components/forms/primitives.tsx
+++ b/src/components/forms/primitives.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import cn from '../../lib/cn';
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export function Label({ className, ...props }: LabelProps) {
+    return (
+        <label
+            className={cn('block text-xs font-medium uppercase tracking-wide text-slate-300', className)}
+            {...props}
+        />
+    );
+}
+
+export type HelpTextProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function HelpText({ className, ...props }: HelpTextProps) {
+    return <p className={cn('text-xs text-slate-400', className)} {...props} />;
+}
+
+export type ErrorTextProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function ErrorText({ className, ...props }: ErrorTextProps) {
+    return <p className={cn('text-xs font-medium text-red-300', className)} {...props} />;
+}

--- a/src/components/forms/tokens.ts
+++ b/src/components/forms/tokens.ts
@@ -1,0 +1,9 @@
+export const sizeCols: Record<'xs' | 'sm' | 'md' | 'lg' | 'xl', string> = {
+    xs: 'col-span-12 sm:col-span-6 lg:col-span-3',
+    sm: 'col-span-12 sm:col-span-6 lg:col-span-4',
+    md: 'col-span-12 sm:col-span-6 lg:col-span-6',
+    lg: 'col-span-12 sm:col-span-8 lg:col-span-8',
+    xl: 'col-span-12'
+};
+
+export type FieldSize = keyof typeof sizeCols;


### PR DESCRIPTION
## Summary
- add reusable form primitives for grid sizing, labels, inputs, and section cards
- refactor the general settings workspace identity and deliverability forms to use React Hook Form + Zod with consistent layout
- introduce sticky form header actions and updated field validation for profile and SMTP settings

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d184d622088329903dfaa72d7e7048