### PR TITLE
fix hook error in settings forms and stabilize quick setup modal

### DIFF
--- a/src/components/crm/QuickSetupModal.tsx
+++ b/src/components/crm/QuickSetupModal.tsx
@@ -111,9 +111,7 @@ function buildBookingPayload(values: QuickSetupFormState): Record<string, unknow
     const status = toBookingStatus(values.status);
 
     const dateValue =
-        typeof values.shootDate === 'string' && dayjs(values.shootDate).isValid()
-            ? dayjs(values.shootDate).format('YYYY-MM-DD')
-            : dayjs().format('YYYY-MM-DD');
+        typeof values.shootDate === 'string' && dayjs(values.shootDate).isValid() ? dayjs(values.shootDate).format('YYYY-MM-DD') : dayjs().format('YYYY-MM-DD');
 
     const startTime = formatTimeLabel(values.startTime) ?? '9:00 AM';
     const endTime = values.endTime ? formatTimeLabel(values.endTime) : undefined;
@@ -242,10 +240,7 @@ export function QuickSetupModal({ open, onClose }: QuickSetupModalProps) {
                         convertWarning = payload?.error ?? 'Contact saved but conversion failed.';
                     }
                 } catch (convertError) {
-                    convertWarning =
-                        convertError instanceof Error
-                            ? convertError.message
-                            : 'Contact saved but conversion failed.';
+                    convertWarning = convertError instanceof Error ? convertError.message : 'Contact saved but conversion failed.';
                 }
             }
 
@@ -277,10 +272,7 @@ export function QuickSetupModal({ open, onClose }: QuickSetupModalProps) {
             setFormValues(createInitialState());
             formRef.current?.reset();
         } catch (submissionError) {
-            const message =
-                submissionError instanceof Error
-                    ? submissionError.message
-                    : 'Unable to complete quick setup. Please try again.';
+            const message = submissionError instanceof Error ? submissionError.message : 'Unable to complete quick setup. Please try again.';
             setError(message);
         } finally {
             setIsSubmitting(false);
@@ -303,308 +295,311 @@ export function QuickSetupModal({ open, onClose }: QuickSetupModalProps) {
                         </Dialog.Overlay>
                         <Dialog.Content asChild>
                             <motion.div
-                                className="fixed left-1/2 top-1/2 z-[101] w-full max-w-5xl -translate-x-1/2 -translate-y-1/2 rounded-[32px] border border-white/20 bg-white/85 p-8 shadow-2xl backdrop-blur-xl transition dark:border-slate-700/60 dark:bg-slate-950/80"
+                                className="fixed left-1/2 top-1/2 z-[101] w-full max-w-5xl -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-[32px] border border-white/20 bg-white/85 shadow-2xl backdrop-blur-xl transition dark:border-slate-700/60 dark:bg-slate-950/80"
                                 initial={{ opacity: 0, y: 32, scale: 0.98 }}
                                 animate={{ opacity: 1, y: 0, scale: 1 }}
                                 exit={{ opacity: 0, y: -24, scale: 0.98 }}
                                 transition={{ duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
                             >
-                        <Dialog.Close asChild>
-                            <button
-                                type="button"
-                                className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/60 text-slate-500 transition hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DE5FF] dark:border-slate-700/80 dark:bg-slate-900/80 dark:text-slate-300"
-                                aria-label="Close quick setup"
-                                onClick={onClose}
-                            >
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth={1.5}
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    className="h-5 w-5"
-                                >
-                                    <path d="m16 8-8 8" />
-                                    <path d="m8 8 8 8" />
-                                </svg>
-                            </button>
-                        </Dialog.Close>
-                        <form ref={formRef} onSubmit={handleSubmit} className="space-y-6" noValidate>
-                            <header className="space-y-2">
-                                <Dialog.Title className="text-2xl font-semibold text-slate-900 dark:text-white">
-                                    Quick client setup
-                                </Dialog.Title>
-                                <Dialog.Description className="text-sm text-slate-600 dark:text-slate-300">
-                                    Capture contact details and project requirements in one streamlined workflow. Ideal when a lead
-                                    calls in and you need to book the session immediately.
-                                </Dialog.Description>
-                            </header>
-                            {error ? (
-                                <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm font-medium text-rose-800 dark:border-rose-400/30 dark:bg-rose-500/10 dark:text-rose-100">
-                                    {error}
+                                <div className="max-h-[min(90vh,900px)] overflow-y-auto p-8">
+                                    <Dialog.Close asChild>
+                                        <button
+                                            type="button"
+                                            className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/60 text-slate-500 transition hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4DE5FF] dark:border-slate-700/80 dark:bg-slate-900/80 dark:text-slate-300"
+                                            aria-label="Close quick setup"
+                                            onClick={onClose}
+                                        >
+                                            <svg
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                viewBox="0 0 24 24"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                strokeWidth={1.5}
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                className="h-5 w-5"
+                                            >
+                                                <path d="m16 8-8 8" />
+                                                <path d="m8 8 8 8" />
+                                            </svg>
+                                        </button>
+                                    </Dialog.Close>
+                                    <form ref={formRef} onSubmit={handleSubmit} className="space-y-6" noValidate>
+                                        <header className="space-y-2">
+                                            <Dialog.Title className="text-2xl font-semibold text-slate-900 dark:text-white">Quick client setup</Dialog.Title>
+                                            <Dialog.Description className="text-sm text-slate-600 dark:text-slate-300">
+                                                Capture contact details and project requirements in one streamlined workflow. Ideal when a lead calls in and you
+                                                need to book the session immediately.
+                                            </Dialog.Description>
+                                        </header>
+                                        {error ? (
+                                            <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm font-medium text-rose-800 dark:border-rose-400/30 dark:bg-rose-500/10 dark:text-rose-100">
+                                                {error}
+                                            </div>
+                                        ) : null}
+                                        {success ? (
+                                            <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm font-medium text-emerald-800 dark:border-emerald-400/30 dark:bg-emerald-500/10 dark:text-emerald-100">
+                                                {success}
+                                            </div>
+                                        ) : null}
+                                        <div className="grid gap-6 lg:grid-cols-2">
+                                            <section className="space-y-5 rounded-3xl border border-white/40 bg-white/70 p-6 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/60">
+                                                <div className="space-y-1">
+                                                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Contact card</h3>
+                                                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                                                        Gather personal details so you can follow up with proposals, invoices, and delivery.
+                                                    </p>
+                                                </div>
+                                                <div className="space-y-4 text-sm">
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-contact-name" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Full name
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-contact-name"
+                                                            type="text"
+                                                            className={inputBaseStyles}
+                                                            placeholder="Jamie Rivera"
+                                                            value={formValues.contactName}
+                                                            onChange={(event) => handleFieldChange('contactName', event.target.value)}
+                                                            required
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-contact-email" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Email
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-contact-email"
+                                                            type="email"
+                                                            className={inputBaseStyles}
+                                                            placeholder="jamie@example.com"
+                                                            value={formValues.contactEmail}
+                                                            onChange={(event) => handleFieldChange('contactEmail', event.target.value)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-contact-phone" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Phone
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-contact-phone"
+                                                            type="tel"
+                                                            className={inputBaseStyles}
+                                                            placeholder="(555) 010-1234"
+                                                            value={formValues.contactPhone}
+                                                            onChange={(event) => handleFieldChange('contactPhone', event.target.value)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label
+                                                            htmlFor="quick-setup-contact-business"
+                                                            className="font-medium text-slate-700 dark:text-slate-200"
+                                                        >
+                                                            Business or organization
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-contact-business"
+                                                            type="text"
+                                                            className={inputBaseStyles}
+                                                            placeholder="Rivera Creative Studio"
+                                                            value={formValues.contactBusiness}
+                                                            onChange={(event) => handleFieldChange('contactBusiness', event.target.value)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-contact-notes" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Relationship notes
+                                                        </label>
+                                                        <textarea
+                                                            id="quick-setup-contact-notes"
+                                                            className={`${inputBaseStyles} min-h-[112px] resize-none`}
+                                                            placeholder="Referred by Alex; prefers text updates."
+                                                            value={formValues.contactNotes}
+                                                            onChange={(event) => handleFieldChange('contactNotes', event.target.value)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <label className="flex items-center gap-3 rounded-2xl border border-white/40 bg-white/60 px-4 py-3 text-sm font-medium text-slate-700 transition dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-slate-200">
+                                                        <input
+                                                            type="checkbox"
+                                                            className="h-4 w-4 rounded border border-slate-300 text-indigo-600 focus:ring-[#4DE5FF] dark:border-slate-600"
+                                                            checked={formValues.convertToClient}
+                                                            onChange={(event) => handleFieldChange('convertToClient', event.target.checked)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                        Convert to client after saving contact
+                                                    </label>
+                                                </div>
+                                            </section>
+                                            <section className="space-y-5 rounded-3xl border border-white/40 bg-white/70 p-6 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/60">
+                                                <div className="space-y-1">
+                                                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Project card</h3>
+                                                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                                                        Define the shoot logistics while you have the client on the call.
+                                                    </p>
+                                                </div>
+                                                <div className="grid gap-4 text-sm">
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-project-title" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Project title
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-project-title"
+                                                            type="text"
+                                                            className={inputBaseStyles}
+                                                            placeholder="Spring campaign"
+                                                            value={formValues.projectTitle}
+                                                            onChange={(event) => handleFieldChange('projectTitle', event.target.value)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-shoot-type" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Shoot type
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-shoot-type"
+                                                            type="text"
+                                                            className={inputBaseStyles}
+                                                            placeholder="Brand portraits"
+                                                            value={formValues.shootType}
+                                                            onChange={(event) => handleFieldChange('shootType', event.target.value)}
+                                                            required
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="grid gap-4 sm:grid-cols-2">
+                                                        <div className="space-y-1">
+                                                            <label htmlFor="quick-setup-shoot-date" className="font-medium text-slate-700 dark:text-slate-200">
+                                                                Shoot date
+                                                            </label>
+                                                            <input
+                                                                id="quick-setup-shoot-date"
+                                                                type="date"
+                                                                className={inputBaseStyles}
+                                                                value={formValues.shootDate}
+                                                                onChange={(event) => handleFieldChange('shootDate', event.target.value)}
+                                                                required
+                                                                disabled={isSubmitting}
+                                                            />
+                                                        </div>
+                                                        <div className="space-y-1">
+                                                            <label htmlFor="quick-setup-status" className="font-medium text-slate-700 dark:text-slate-200">
+                                                                Status
+                                                            </label>
+                                                            <select
+                                                                id="quick-setup-status"
+                                                                className={`${inputBaseStyles} pr-10`}
+                                                                value={formValues.status}
+                                                                onChange={(event) => handleFieldChange('status', event.target.value as BookingStatus)}
+                                                                disabled={isSubmitting}
+                                                            >
+                                                                <option value="Pending">Pending</option>
+                                                                <option value="Confirmed">Confirmed</option>
+                                                                <option value="Editing">Editing</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div className="grid gap-4 sm:grid-cols-2">
+                                                        <div className="space-y-1">
+                                                            <label htmlFor="quick-setup-start-time" className="font-medium text-slate-700 dark:text-slate-200">
+                                                                Start time
+                                                            </label>
+                                                            <input
+                                                                id="quick-setup-start-time"
+                                                                type="time"
+                                                                className={inputBaseStyles}
+                                                                value={formValues.startTime}
+                                                                onChange={(event) => handleFieldChange('startTime', event.target.value)}
+                                                                required
+                                                                disabled={isSubmitting}
+                                                            />
+                                                        </div>
+                                                        <div className="space-y-1">
+                                                            <label htmlFor="quick-setup-end-time" className="font-medium text-slate-700 dark:text-slate-200">
+                                                                End time
+                                                            </label>
+                                                            <input
+                                                                id="quick-setup-end-time"
+                                                                type="time"
+                                                                className={inputBaseStyles}
+                                                                value={formValues.endTime}
+                                                                onChange={(event) => handleFieldChange('endTime', event.target.value)}
+                                                                disabled={isSubmitting}
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-location" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Location
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-location"
+                                                            type="text"
+                                                            className={inputBaseStyles}
+                                                            placeholder="Studio or on-site address"
+                                                            value={formValues.location}
+                                                            onChange={(event) => handleFieldChange('location', event.target.value)}
+                                                            required
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-vision" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Creative vision & must-have shots
+                                                        </label>
+                                                        <textarea
+                                                            id="quick-setup-vision"
+                                                            className={`${inputBaseStyles} min-h-[112px] resize-none`}
+                                                            placeholder="Focus on natural light headshots and collaborative team imagery."
+                                                            value={formValues.creativeVision}
+                                                            onChange={(event) => handleFieldChange('creativeVision', event.target.value)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                    <div className="space-y-1">
+                                                        <label htmlFor="quick-setup-budget" className="font-medium text-slate-700 dark:text-slate-200">
+                                                            Proposed budget
+                                                        </label>
+                                                        <input
+                                                            id="quick-setup-budget"
+                                                            type="text"
+                                                            className={inputBaseStyles}
+                                                            placeholder="$2,400 retainer"
+                                                            value={formValues.budget}
+                                                            onChange={(event) => handleFieldChange('budget', event.target.value)}
+                                                            disabled={isSubmitting}
+                                                        />
+                                                    </div>
+                                                </div>
+                                            </section>
+                                        </div>
+                                        <footer className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                            <button
+                                                type="button"
+                                                onClick={onClose}
+                                                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-5 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-[#4DE5FF] dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+                                            >
+                                                {success ? 'Close' : 'Cancel'}
+                                            </button>
+                                            <button
+                                                type="submit"
+                                                disabled={isSubmitting}
+                                                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#5D3BFF] via-[#3D7CFF] to-[#4DE5FF] px-6 py-2 text-sm font-semibold text-white shadow-lg transition hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-[#4DE5FF] focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-70 dark:focus:ring-offset-slate-900"
+                                            >
+                                                {isSubmitting ? 'Saving…' : 'Start booking'}
+                                            </button>
+                                        </footer>
+                                    </form>
                                 </div>
-                            ) : null}
-                            {success ? (
-                                <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm font-medium text-emerald-800 dark:border-emerald-400/30 dark:bg-emerald-500/10 dark:text-emerald-100">
-                                    {success}
-                                </div>
-                            ) : null}
-                            <div className="grid gap-6 lg:grid-cols-2">
-                                <section className="space-y-5 rounded-3xl border border-white/40 bg-white/70 p-6 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/60">
-                                    <div className="space-y-1">
-                                        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Contact card</h3>
-                                        <p className="text-sm text-slate-600 dark:text-slate-400">
-                                            Gather personal details so you can follow up with proposals, invoices, and delivery.
-                                        </p>
-                                    </div>
-                                    <div className="space-y-4 text-sm">
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-contact-name" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Full name
-                                            </label>
-                                            <input
-                                                id="quick-setup-contact-name"
-                                                type="text"
-                                                className={inputBaseStyles}
-                                                placeholder="Jamie Rivera"
-                                                value={formValues.contactName}
-                                                onChange={(event) => handleFieldChange('contactName', event.target.value)}
-                                                required
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-contact-email" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Email
-                                            </label>
-                                            <input
-                                                id="quick-setup-contact-email"
-                                                type="email"
-                                                className={inputBaseStyles}
-                                                placeholder="jamie@example.com"
-                                                value={formValues.contactEmail}
-                                                onChange={(event) => handleFieldChange('contactEmail', event.target.value)}
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-contact-phone" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Phone
-                                            </label>
-                                            <input
-                                                id="quick-setup-contact-phone"
-                                                type="tel"
-                                                className={inputBaseStyles}
-                                                placeholder="(555) 010-1234"
-                                                value={formValues.contactPhone}
-                                                onChange={(event) => handleFieldChange('contactPhone', event.target.value)}
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-contact-business" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Business or organization
-                                            </label>
-                                            <input
-                                                id="quick-setup-contact-business"
-                                                type="text"
-                                                className={inputBaseStyles}
-                                                placeholder="Rivera Creative Studio"
-                                                value={formValues.contactBusiness}
-                                                onChange={(event) => handleFieldChange('contactBusiness', event.target.value)}
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-contact-notes" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Relationship notes
-                                            </label>
-                                            <textarea
-                                                id="quick-setup-contact-notes"
-                                                className={`${inputBaseStyles} min-h-[112px] resize-none`}
-                                                placeholder="Referred by Alex; prefers text updates."
-                                                value={formValues.contactNotes}
-                                                onChange={(event) => handleFieldChange('contactNotes', event.target.value)}
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <label className="flex items-center gap-3 rounded-2xl border border-white/40 bg-white/60 px-4 py-3 text-sm font-medium text-slate-700 transition dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-slate-200">
-                                            <input
-                                                type="checkbox"
-                                                className="h-4 w-4 rounded border border-slate-300 text-indigo-600 focus:ring-[#4DE5FF] dark:border-slate-600"
-                                                checked={formValues.convertToClient}
-                                                onChange={(event) => handleFieldChange('convertToClient', event.target.checked)}
-                                                disabled={isSubmitting}
-                                            />
-                                            Convert to client after saving contact
-                                        </label>
-                                    </div>
-                                </section>
-                                <section className="space-y-5 rounded-3xl border border-white/40 bg-white/70 p-6 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/60">
-                                    <div className="space-y-1">
-                                        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Project card</h3>
-                                        <p className="text-sm text-slate-600 dark:text-slate-400">
-                                            Define the shoot logistics while you have the client on the call.
-                                        </p>
-                                    </div>
-                                    <div className="grid gap-4 text-sm">
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-project-title" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Project title
-                                            </label>
-                                            <input
-                                                id="quick-setup-project-title"
-                                                type="text"
-                                                className={inputBaseStyles}
-                                                placeholder="Spring campaign"
-                                                value={formValues.projectTitle}
-                                                onChange={(event) => handleFieldChange('projectTitle', event.target.value)}
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-shoot-type" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Shoot type
-                                            </label>
-                                            <input
-                                                id="quick-setup-shoot-type"
-                                                type="text"
-                                                className={inputBaseStyles}
-                                                placeholder="Brand portraits"
-                                                value={formValues.shootType}
-                                                onChange={(event) => handleFieldChange('shootType', event.target.value)}
-                                                required
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="grid gap-4 sm:grid-cols-2">
-                                            <div className="space-y-1">
-                                                <label htmlFor="quick-setup-shoot-date" className="font-medium text-slate-700 dark:text-slate-200">
-                                                    Shoot date
-                                                </label>
-                                                <input
-                                                    id="quick-setup-shoot-date"
-                                                    type="date"
-                                                    className={inputBaseStyles}
-                                                    value={formValues.shootDate}
-                                                    onChange={(event) => handleFieldChange('shootDate', event.target.value)}
-                                                    required
-                                                    disabled={isSubmitting}
-                                                />
-                                            </div>
-                                            <div className="space-y-1">
-                                                <label htmlFor="quick-setup-status" className="font-medium text-slate-700 dark:text-slate-200">
-                                                    Status
-                                                </label>
-                                                <select
-                                                    id="quick-setup-status"
-                                                    className={`${inputBaseStyles} pr-10`}
-                                                    value={formValues.status}
-                                                    onChange={(event) => handleFieldChange('status', event.target.value as BookingStatus)}
-                                                    disabled={isSubmitting}
-                                                >
-                                                    <option value="Pending">Pending</option>
-                                                    <option value="Confirmed">Confirmed</option>
-                                                    <option value="Editing">Editing</option>
-                                                </select>
-                                            </div>
-                                        </div>
-                                        <div className="grid gap-4 sm:grid-cols-2">
-                                            <div className="space-y-1">
-                                                <label htmlFor="quick-setup-start-time" className="font-medium text-slate-700 dark:text-slate-200">
-                                                    Start time
-                                                </label>
-                                                <input
-                                                    id="quick-setup-start-time"
-                                                    type="time"
-                                                    className={inputBaseStyles}
-                                                    value={formValues.startTime}
-                                                    onChange={(event) => handleFieldChange('startTime', event.target.value)}
-                                                    required
-                                                    disabled={isSubmitting}
-                                                />
-                                            </div>
-                                            <div className="space-y-1">
-                                                <label htmlFor="quick-setup-end-time" className="font-medium text-slate-700 dark:text-slate-200">
-                                                    End time
-                                                </label>
-                                                <input
-                                                    id="quick-setup-end-time"
-                                                    type="time"
-                                                    className={inputBaseStyles}
-                                                    value={formValues.endTime}
-                                                    onChange={(event) => handleFieldChange('endTime', event.target.value)}
-                                                    disabled={isSubmitting}
-                                                />
-                                            </div>
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-location" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Location
-                                            </label>
-                                            <input
-                                                id="quick-setup-location"
-                                                type="text"
-                                                className={inputBaseStyles}
-                                                placeholder="Studio or on-site address"
-                                                value={formValues.location}
-                                                onChange={(event) => handleFieldChange('location', event.target.value)}
-                                                required
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-vision" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Creative vision & must-have shots
-                                            </label>
-                                            <textarea
-                                                id="quick-setup-vision"
-                                                className={`${inputBaseStyles} min-h-[112px] resize-none`}
-                                                placeholder="Focus on natural light headshots and collaborative team imagery."
-                                                value={formValues.creativeVision}
-                                                onChange={(event) => handleFieldChange('creativeVision', event.target.value)}
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                        <div className="space-y-1">
-                                            <label htmlFor="quick-setup-budget" className="font-medium text-slate-700 dark:text-slate-200">
-                                                Proposed budget
-                                            </label>
-                                            <input
-                                                id="quick-setup-budget"
-                                                type="text"
-                                                className={inputBaseStyles}
-                                                placeholder="$2,400 retainer"
-                                                value={formValues.budget}
-                                                onChange={(event) => handleFieldChange('budget', event.target.value)}
-                                                disabled={isSubmitting}
-                                            />
-                                        </div>
-                                    </div>
-                                </section>
-                            </div>
-                            <footer className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                <button
-                                    type="button"
-                                    onClick={onClose}
-                                    className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-5 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-[#4DE5FF] dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
-                                >
-                                    {success ? 'Close' : 'Cancel'}
-                                </button>
-                                <button
-                                    type="submit"
-                                    disabled={isSubmitting}
-                                    className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#5D3BFF] via-[#3D7CFF] to-[#4DE5FF] px-6 py-2 text-sm font-semibold text-white shadow-lg transition hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-[#4DE5FF] focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-70 dark:focus:ring-offset-slate-900"
-                                >
-                                    {isSubmitting ? 'Saving…' : 'Start booking'}
-                                </button>
-                            </footer>
-                        </form>
-                    </motion.div>
-                </Dialog.Content>
-            </Dialog.Portal>
+                            </motion.div>
+                        </Dialog.Content>
+                    </Dialog.Portal>
                 ) : null}
             </AnimatePresence>
         </Dialog.Root>

--- a/src/components/forms/FieldGrid.tsx
+++ b/src/components/forms/FieldGrid.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import cn from '../../lib/cn';
+
+export type FieldGridProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function FieldGrid({ className, ...props }: FieldGridProps) {
+    return <div className={cn('grid grid-cols-12 gap-4', className)} {...props} />;
+}

--- a/src/components/forms/FieldWrapper.tsx
+++ b/src/components/forms/FieldWrapper.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as React from 'react';
+import { useFormContext, type FieldError } from 'react-hook-form';
+
+import cn from '../../lib/cn';
+
+import { ErrorText, HelpText, Label } from './primitives';
+import { sizeCols, type FieldSize } from './tokens';
+
+function resolveError(errors: unknown, name: string): FieldError | undefined {
+    if (!errors || typeof errors !== 'object') {
+        return undefined;
+    }
+
+    const segments = name.split('.');
+    let current: unknown = errors;
+
+    for (const segment of segments) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+
+        current = (current as Record<string, unknown>)[segment];
+    }
+
+    return (current as FieldError) ?? undefined;
+}
+
+export type FieldWrapperProps = {
+    name: string;
+    label: string;
+    size?: FieldSize;
+    helpText?: React.ReactNode;
+    description?: React.ReactNode;
+    children: React.ReactNode;
+    className?: string;
+};
+
+export function FieldWrapper({
+    name,
+    label,
+    size = 'md',
+    helpText,
+    description,
+    children,
+    className
+}: FieldWrapperProps) {
+    const {
+        formState: { errors }
+    } = useFormContext();
+
+    const error = resolveError(errors, name);
+    const helpId = helpText ? `${name}-help` : undefined;
+    const errorId = error ? `${name}-error` : undefined;
+    const describedBy = [helpId, errorId].filter(Boolean).join(' ') || undefined;
+    const invalid = Boolean(error);
+
+    let control: React.ReactNode = children;
+
+    if (typeof children === 'function') {
+        control = (children as (context: { describedBy?: string; invalid: boolean }) => React.ReactNode)({
+            describedBy,
+            invalid
+        });
+    } else if (React.isValidElement(children)) {
+        control = React.cloneElement(children as React.ReactElement<any>, {
+            describedBy,
+            invalid,
+            name
+        });
+    }
+
+    return (
+        <div className={cn('space-y-2', sizeCols[size], className)}>
+            <div className="space-y-1">
+                <Label htmlFor={name}>{label}</Label>
+                {description ? <p className="text-sm text-slate-400">{description}</p> : null}
+                {control}
+            </div>
+            {helpText ? (
+                <HelpText id={helpId} aria-live="polite">
+                    {helpText}
+                </HelpText>
+            ) : null}
+            {error ? (
+                <ErrorText id={errorId} role="alert">
+                    {error.message}
+                </ErrorText>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/forms/SectionCard.tsx
+++ b/src/components/forms/SectionCard.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+
+import cn from '../../lib/cn';
+
+export type SectionCardProps = {
+    title: string;
+    subtitle?: string;
+    eyebrow?: string;
+    actions?: React.ReactNode;
+    stickyHeader?: boolean;
+    children: React.ReactNode;
+} & React.HTMLAttributes<HTMLElement>;
+
+export function SectionCard({
+    title,
+    subtitle,
+    eyebrow,
+    actions,
+    stickyHeader,
+    children,
+    className,
+    ...props
+}: SectionCardProps) {
+    return (
+        <section
+            className={cn('rounded-3xl border border-slate-800/80 bg-slate-950/60 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.95)]', className)}
+            {...props}
+        >
+            <header
+                className={cn(
+                    'flex flex-col gap-4 border-b border-white/5 px-6 py-4 md:flex-row md:items-center md:justify-between',
+                    stickyHeader &&
+                        'md:sticky md:top-20 md:z-20 md:border-white/5 md:bg-slate-950/80 md:shadow-[0_20px_40px_-40px_rgba(15,23,42,0.95)] md:backdrop-blur'
+                )}
+            >
+                <div className="space-y-1">
+                    {eyebrow ? (
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.48em] text-[#4DE5FF]">{eyebrow}</p>
+                    ) : null}
+                    <h2 className="text-xl font-semibold tracking-tight text-white">{title}</h2>
+                    {subtitle ? <p className="text-sm text-slate-300">{subtitle}</p> : null}
+                </div>
+                {actions ? <div className="flex flex-wrap items-center gap-2 md:justify-end">{actions}</div> : null}
+            </header>
+            <div className="px-6 py-6">{children}</div>
+        </section>
+    );
+}
+
+export type FormSectionCardProps = {
+    title: string;
+    subtitle?: string;
+    eyebrow?: string;
+    actions?: React.ReactNode;
+    stickyHeader?: boolean;
+    children: React.ReactNode;
+} & React.FormHTMLAttributes<HTMLFormElement>;
+
+export function FormSectionCard({
+    title,
+    subtitle,
+    eyebrow,
+    actions,
+    stickyHeader = true,
+    children,
+    className,
+    ...props
+}: FormSectionCardProps) {
+    return (
+        <form
+            className={cn('rounded-3xl border border-slate-800/80 bg-slate-950/60 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.95)]', className)}
+            {...props}
+        >
+            <div
+                className={cn(
+                    'flex flex-col gap-4 border-b border-white/5 px-6 py-4 md:flex-row md:items-center md:justify-between',
+                    stickyHeader &&
+                        'md:sticky md:top-24 md:z-20 md:border-white/5 md:bg-slate-950/80 md:shadow-[0_20px_40px_-40px_rgba(15,23,42,0.95)] md:backdrop-blur'
+                )}
+            >
+                <div className="space-y-1">
+                    {eyebrow ? (
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.48em] text-[#4DE5FF]">{eyebrow}</p>
+                    ) : null}
+                    <h2 className="text-xl font-semibold tracking-tight text-white">{title}</h2>
+                    {subtitle ? <p className="text-sm text-slate-300">{subtitle}</p> : null}
+                </div>
+                {actions ? <div className="flex flex-wrap items-center gap-2 md:justify-end">{actions}</div> : null}
+            </div>
+            <div className="px-6 py-6">{children}</div>
+        </form>
+    );
+}

--- a/src/components/forms/inputs.tsx
+++ b/src/components/forms/inputs.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from 'react';
+import { useFormContext, type RegisterOptions } from 'react-hook-form';
+
+import cn from '../../lib/cn';
+
+type BaseControlProps = {
+    name: string;
+    describedBy?: string;
+    invalid?: boolean;
+    className?: string;
+};
+
+type TextInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name'> &
+    BaseControlProps & {
+        registerOptions?: RegisterOptions;
+    };
+
+function baseInputClasses(invalid?: boolean) {
+    return cn(
+        'w-full rounded-2xl border px-3 py-2 text-sm text-white transition focus-visible:outline-none',
+        invalid
+            ? 'border-red-500/70 bg-red-950/30 focus-visible:border-red-400 focus-visible:ring-2 focus-visible:ring-red-500/40'
+            : 'border-slate-800/80 bg-slate-950/80 focus-visible:border-[#4DE5FF] focus-visible:ring-2 focus-visible:ring-[#4DE5FF]/50',
+        'placeholder:text-slate-500'
+    );
+}
+
+export function TextInput({
+    name,
+    describedBy,
+    invalid,
+    className,
+    type = 'text',
+    registerOptions,
+    onChange,
+    onBlur,
+    ...props
+}: TextInputProps) {
+    const { register } = useFormContext();
+    const registration = register(name, {
+        ...registerOptions,
+        onChange: (event) => {
+            registerOptions?.onChange?.(event);
+            onChange?.(event as React.ChangeEvent<HTMLInputElement>);
+        },
+        onBlur: (event) => {
+            registerOptions?.onBlur?.(event);
+            onBlur?.(event as React.FocusEvent<HTMLInputElement>);
+        }
+    });
+
+    return (
+        <input
+            id={props.id ?? name}
+            type={type}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            className={cn(baseInputClasses(invalid), className)}
+            {...props}
+            {...registration}
+        />
+    );
+}
+
+type TextareaProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'name'> &
+    BaseControlProps & {
+        registerOptions?: RegisterOptions;
+    };
+
+export function Textarea({
+    name,
+    describedBy,
+    invalid,
+    className,
+    registerOptions,
+    rows = 4,
+    onChange,
+    onBlur,
+    ...props
+}: TextareaProps) {
+    const { register } = useFormContext();
+    const registration = register(name, {
+        ...registerOptions,
+        onChange: (event) => {
+            registerOptions?.onChange?.(event);
+            onChange?.(event as React.ChangeEvent<HTMLTextAreaElement>);
+        },
+        onBlur: (event) => {
+            registerOptions?.onBlur?.(event);
+            onBlur?.(event as React.FocusEvent<HTMLTextAreaElement>);
+        }
+    });
+
+    return (
+        <textarea
+            id={props.id ?? name}
+            rows={rows}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            className={cn(baseInputClasses(invalid), 'resize-none', className)}
+            {...props}
+            {...registration}
+        />
+    );
+}
+
+type SelectOption = { label: string; value: string };
+
+type SelectProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'name'> &
+    BaseControlProps & {
+        options: SelectOption[];
+        registerOptions?: RegisterOptions;
+    };
+
+export function Select({
+    name,
+    describedBy,
+    invalid,
+    className,
+    options,
+    registerOptions,
+    onChange,
+    onBlur,
+    ...props
+}: SelectProps) {
+    const { register } = useFormContext();
+    const registration = register(name, {
+        ...registerOptions,
+        onChange: (event) => {
+            registerOptions?.onChange?.(event);
+            onChange?.(event as React.ChangeEvent<HTMLSelectElement>);
+        },
+        onBlur: (event) => {
+            registerOptions?.onBlur?.(event);
+            onBlur?.(event as React.FocusEvent<HTMLSelectElement>);
+        }
+    });
+
+    return (
+        <select
+            id={props.id ?? name}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            className={cn(baseInputClasses(invalid), 'appearance-none pr-9', className)}
+            {...props}
+            {...registration}
+        >
+            {options.map((option) => (
+                <option key={option.value} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </select>
+    );
+}

--- a/src/components/forms/primitives.tsx
+++ b/src/components/forms/primitives.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import cn from '../../lib/cn';
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export function Label({ className, ...props }: LabelProps) {
+    return (
+        <label
+            className={cn('block text-xs font-medium uppercase tracking-wide text-slate-300', className)}
+            {...props}
+        />
+    );
+}
+
+export type HelpTextProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function HelpText({ className, ...props }: HelpTextProps) {
+    return <p className={cn('text-xs text-slate-400', className)} {...props} />;
+}
+
+export type ErrorTextProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function ErrorText({ className, ...props }: ErrorTextProps) {
+    return <p className={cn('text-xs font-medium text-red-300', className)} {...props} />;
+}

--- a/src/components/forms/tokens.ts
+++ b/src/components/forms/tokens.ts
@@ -1,0 +1,9 @@
+export const sizeCols: Record<'xs' | 'sm' | 'md' | 'lg' | 'xl', string> = {
+    xs: 'col-span-12 sm:col-span-6 lg:col-span-3',
+    sm: 'col-span-12 sm:col-span-6 lg:col-span-4',
+    md: 'col-span-12 sm:col-span-6 lg:col-span-6',
+    lg: 'col-span-12 sm:col-span-8 lg:col-span-8',
+    xl: 'col-span-12'
+};
+
+export type FieldSize = keyof typeof sizeCols;


### PR DESCRIPTION
## Summary
- mark the shared form wrapper and inputs as client components so react-hook-form hooks are only run in the client bundle
- wrap the quick setup modal content in a bounded, scrollable container so the form stays usable on smaller viewports

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d184d622088329903dfaa72d7e7048