### PR TITLE
Restore client directives and forwarded refs for form controls

### DIFF
--- a/src/components/forms/FieldWrapper.tsx
+++ b/src/components/forms/FieldWrapper.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from 'react';
 import { useFormContext, type FieldError } from 'react-hook-form';
 

--- a/src/components/forms/inputs.tsx
+++ b/src/components/forms/inputs.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from 'react';
 import { useFormContext, type RegisterOptions } from 'react-hook-form';
 
@@ -15,6 +17,19 @@ type TextInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name'> 
         registerOptions?: RegisterOptions;
     };
 
+type TextareaProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'name'> &
+    BaseControlProps & {
+        registerOptions?: RegisterOptions;
+    };
+
+type SelectOption = { label: string; value: string };
+
+type SelectProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'name'> &
+    BaseControlProps & {
+        options: SelectOption[];
+        registerOptions?: RegisterOptions;
+    };
+
 function baseInputClasses(invalid?: boolean) {
     return cn(
         'w-full rounded-2xl border px-3 py-2 text-sm text-white transition focus-visible:outline-none',
@@ -25,17 +40,46 @@ function baseInputClasses(invalid?: boolean) {
     );
 }
 
-export function TextInput({
-    name,
-    describedBy,
-    invalid,
-    className,
-    type = 'text',
-    registerOptions,
-    onChange,
-    onBlur,
-    ...props
-}: TextInputProps) {
+function assignRef<T>(ref: React.Ref<T> | undefined, value: T) {
+    if (typeof ref === 'function') {
+        ref(value);
+    } else if (ref != null) {
+        // eslint-disable-next-line no-param-reassign
+        (ref as React.MutableRefObject<T>).current = value;
+    }
+}
+
+function useComposedRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
+    return React.useCallback(
+        (value: T) => {
+            for (const ref of refs) {
+                assignRef(ref, value);
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        refs
+    );
+}
+
+function mergeDescribedBy(...values: Array<string | undefined>) {
+    return values.filter(Boolean).join(' ') || undefined;
+}
+
+export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(function TextInput(
+    {
+        name,
+        describedBy,
+        invalid,
+        className,
+        type = 'text',
+        registerOptions,
+        onChange,
+        onBlur,
+        'aria-describedby': ariaDescribedByProp,
+        ...props
+    },
+    forwardedRef
+) {
     const { register } = useFormContext();
     const registration = register(name, {
         ...registerOptions,
@@ -49,35 +93,59 @@ export function TextInput({
         }
     });
 
+    const { ref: registerRef, onChange: registerOnChange, onBlur: registerOnBlur, ...registrationProps } = registration;
+
+    const combinedRef = useComposedRefs<HTMLInputElement>(registerRef, forwardedRef);
+
+    const handleChange = React.useCallback(
+        (event: React.ChangeEvent<HTMLInputElement>) => {
+            registerOnChange(event);
+            onChange?.(event);
+        },
+        [onChange, registerOnChange]
+    );
+
+    const handleBlur = React.useCallback(
+        (event: React.FocusEvent<HTMLInputElement>) => {
+            registerOnBlur(event);
+            onBlur?.(event);
+        },
+        [onBlur, registerOnBlur]
+    );
+
+    const ariaDescribedBy = mergeDescribedBy(describedBy, ariaDescribedByProp);
+
     return (
         <input
             id={props.id ?? name}
             type={type}
             aria-invalid={invalid || undefined}
-            aria-describedby={describedBy}
+            aria-describedby={ariaDescribedBy}
             className={cn(baseInputClasses(invalid), className)}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            ref={combinedRef}
+            {...registrationProps}
             {...props}
-            {...registration}
         />
     );
-}
+});
 
-type TextareaProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'name'> &
-    BaseControlProps & {
-        registerOptions?: RegisterOptions;
-    };
-
-export function Textarea({
-    name,
-    describedBy,
-    invalid,
-    className,
-    registerOptions,
-    rows = 4,
-    onChange,
-    onBlur,
-    ...props
-}: TextareaProps) {
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+    {
+        name,
+        describedBy,
+        invalid,
+        className,
+        registerOptions,
+        rows = 4,
+        onChange,
+        onBlur,
+        'aria-describedby': ariaDescribedByProp,
+        ...props
+    },
+    forwardedRef
+) {
     const { register } = useFormContext();
     const registration = register(name, {
         ...registerOptions,
@@ -91,38 +159,59 @@ export function Textarea({
         }
     });
 
+    const { ref: registerRef, onChange: registerOnChange, onBlur: registerOnBlur, ...registrationProps } = registration;
+
+    const combinedRef = useComposedRefs<HTMLTextAreaElement>(registerRef, forwardedRef);
+
+    const handleChange = React.useCallback(
+        (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+            registerOnChange(event);
+            onChange?.(event);
+        },
+        [onChange, registerOnChange]
+    );
+
+    const handleBlur = React.useCallback(
+        (event: React.FocusEvent<HTMLTextAreaElement>) => {
+            registerOnBlur(event);
+            onBlur?.(event);
+        },
+        [onBlur, registerOnBlur]
+    );
+
+    const ariaDescribedBy = mergeDescribedBy(describedBy, ariaDescribedByProp);
+
     return (
         <textarea
             id={props.id ?? name}
             rows={rows}
             aria-invalid={invalid || undefined}
-            aria-describedby={describedBy}
+            aria-describedby={ariaDescribedBy}
             className={cn(baseInputClasses(invalid), 'resize-none', className)}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            ref={combinedRef}
+            {...registrationProps}
             {...props}
-            {...registration}
         />
     );
-}
+});
 
-type SelectOption = { label: string; value: string };
-
-type SelectProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'name'> &
-    BaseControlProps & {
-        options: SelectOption[];
-        registerOptions?: RegisterOptions;
-    };
-
-export function Select({
-    name,
-    describedBy,
-    invalid,
-    className,
-    options,
-    registerOptions,
-    onChange,
-    onBlur,
-    ...props
-}: SelectProps) {
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
+    {
+        name,
+        describedBy,
+        invalid,
+        className,
+        options,
+        registerOptions,
+        onChange,
+        onBlur,
+        'aria-describedby': ariaDescribedByProp,
+        ...props
+    },
+    forwardedRef
+) {
     const { register } = useFormContext();
     const registration = register(name, {
         ...registerOptions,
@@ -136,14 +225,39 @@ export function Select({
         }
     });
 
+    const { ref: registerRef, onChange: registerOnChange, onBlur: registerOnBlur, ...registrationProps } = registration;
+
+    const combinedRef = useComposedRefs<HTMLSelectElement>(registerRef, forwardedRef);
+
+    const handleChange = React.useCallback(
+        (event: React.ChangeEvent<HTMLSelectElement>) => {
+            registerOnChange(event);
+            onChange?.(event);
+        },
+        [onChange, registerOnChange]
+    );
+
+    const handleBlur = React.useCallback(
+        (event: React.FocusEvent<HTMLSelectElement>) => {
+            registerOnBlur(event);
+            onBlur?.(event);
+        },
+        [onBlur, registerOnBlur]
+    );
+
+    const ariaDescribedBy = mergeDescribedBy(describedBy, ariaDescribedByProp);
+
     return (
         <select
             id={props.id ?? name}
             aria-invalid={invalid || undefined}
-            aria-describedby={describedBy}
+            aria-describedby={ariaDescribedBy}
             className={cn(baseInputClasses(invalid), 'appearance-none pr-9', className)}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            ref={combinedRef}
+            {...registrationProps}
             {...props}
-            {...registration}
         >
             {options.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -152,4 +266,4 @@ export function Select({
             ))}
         </select>
     );
-}
+});


### PR DESCRIPTION
## Summary
- mark FieldWrapper and individual form inputs as client components
- restore the forwardRef implementations for TextInput, Textarea, and Select so refs and aria-describedby props compose correctly
- merge aria-describedby values provided by FieldWrapper with any consumer supplied IDs

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a28554e083298bcb6fdb8e4eaf6c