### PR TITLE
Guard controlled table state and throttle Supabase mutations

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -66,7 +66,9 @@ export function DataTable<TData>({
         manualPagination,
         manualSorting,
         pageCount,
-        autoResetPageIndex: !manualPagination
+        autoResetAll: false,
+        autoResetPageIndex: false,
+        autoResetExpanded: false
     });
 
     const { pageIndex, pageSize } = table.getState().pagination;

--- a/src/lib/react-table.ts
+++ b/src/lib/react-table.ts
@@ -1,0 +1,32 @@
+import type { PaginationState, SortingState } from '@tanstack/react-table';
+
+export function isSamePagination(a?: PaginationState, b?: PaginationState): boolean {
+    if (a === b) {
+        return true;
+    }
+
+    if (!a || !b) {
+        return false;
+    }
+
+    return a.pageIndex === b.pageIndex && a.pageSize === b.pageSize;
+}
+
+export function isSameSorting(a?: SortingState, b?: SortingState): boolean {
+    if (a === b) {
+        return true;
+    }
+
+    if (!a || !b) {
+        return false;
+    }
+
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    return a.every((entry, index) => {
+        const other = b[index];
+        return entry?.id === other?.id && entry?.desc === other?.desc;
+    });
+}


### PR DESCRIPTION
## Summary
- add shared helpers to compare pagination and sorting state
- guard Contacts table state setters to avoid redundant updates and disable table auto resets
- throttle Supabase project change notifications to coalesce mutate calls

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d33eb186fc8329a459872b1f627776