### PR TITLE
Add table state guards and Supabase listener fixes

### DIFF
--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -106,12 +106,11 @@ function ProjectsWorkspace() {
     });
 
     const mutateRef = React.useRef(mutateProjects);
-    const rafId = React.useRef<number | null>(null);
-
     React.useEffect(() => {
         mutateRef.current = mutateProjects;
     }, [mutateProjects]);
 
+    const rafId = React.useRef<number | null>(null);
     const requestMutate = React.useCallback(() => {
         if (typeof window === 'undefined') {
             void mutateRef.current?.();
@@ -165,13 +164,9 @@ function ProjectsWorkspace() {
             .subscribe();
 
         return () => {
-            if (typeof window !== 'undefined' && rafId.current != null) {
-                window.cancelAnimationFrame(rafId.current);
-                rafId.current = null;
-            }
             void client.removeChannel(channel);
         };
-    }, [client, requestMutate, workspaceId]);
+    }, [client, workspaceId, requestMutate]);
 
     const hasError = Boolean(error);
 

--- a/src/utils/tableEquality.ts
+++ b/src/utils/tableEquality.ts
@@ -1,0 +1,15 @@
+import type { SortingState, PaginationState, RowSelectionState } from '@tanstack/react-table';
+
+export const isSamePagination = (a: PaginationState, b: PaginationState) =>
+  a.pageIndex === b.pageIndex && a.pageSize === b.pageSize;
+
+export const isSameSorting = (a: SortingState, b: SortingState) =>
+  a.length === b.length && a.every((x, i) => x.id === b[i]?.id && x.desc === b[i]?.desc);
+
+export const isSameRowSelection = (a: RowSelectionState, b: RowSelectionState) => {
+  if (a === b) return true;
+  const ak = Object.keys(a), bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (let i = 0; i < ak.length; i++) { const k = ak[i]; if (a[k] !== b[k]) return false; }
+  return true;
+};


### PR DESCRIPTION
## Summary
- add shared table equality helpers for pagination, sorting, and row selection comparisons
- guard Contacts table state updates and clamp pagination when the available pages shrink
- coalesce Supabase change notifications on Projects to a single mutate per frame

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34a309e748329beccf0b280aa05e9