### PR TITLE
Add render fuse utilities and page error boundaries

### DIFF
--- a/src/app/contacts/error.tsx
+++ b/src/app/contacts/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+    return (
+        <div className="p-6">
+            <h2 className="text-lg font-semibold">Contacts crashed.</h2>
+            <p className="mt-2 text-sm opacity-75">{error.message}</p>
+            <button className="mt-4 rounded border px-3 py-2" onClick={() => reset()}>
+                Try again
+            </button>
+        </div>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import '../css/main.css';
 import type { Metadata } from 'next';
 import { Roboto } from 'next/font/google';
 
+import ClientFuse from '@/components/ClientFuse';
 import GlobalErrorBoundary from '../components/GlobalErrorBoundary';
 import { AppProviders } from './providers';
 
@@ -24,10 +25,13 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="en" className="dark">
+        <html lang="en" className="dark" suppressHydrationWarning>
             <body className={`${roboto.variable} min-h-screen bg-zinc-950 text-zinc-100 font-sans`}>
                 <GlobalErrorBoundary>
-                    <AppProviders>{children}</AppProviders>
+                    <AppProviders>
+                        {/* ⬇️ client-only wrapper so layout/provider loops are obvious */}
+                        <ClientFuse>{children}</ClientFuse>
+                    </AppProviders>
                 </GlobalErrorBoundary>
             </body>
         </html>

--- a/src/app/projects/error.tsx
+++ b/src/app/projects/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+    return (
+        <div className="p-6">
+            <h2 className="text-lg font-semibold">Projects crashed.</h2>
+            <p className="mt-2 text-sm opacity-75">{error.message}</p>
+            <button className="mt-4 rounded border px-3 py-2" onClick={() => reset()}>
+                Try again
+            </button>
+        </div>
+    );
+}

--- a/src/components/ClientFuse.tsx
+++ b/src/components/ClientFuse.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+import { useRenderFuse } from '@/lib/useRenderFuse';
+
+/** Wraps children and trips if this subtree re-renders excessively. */
+export default function ClientFuse({ children }: PropsWithChildren) {
+    useRenderFuse('ClientFuse'); // name shows up in any loop error
+    return <>{children}</>;
+}

--- a/src/lib/useRenderFuse.ts
+++ b/src/lib/useRenderFuse.ts
@@ -1,0 +1,19 @@
+'use client';
+import { useRef } from 'react';
+
+/** Throws/logs if a component renders >limit times within windowMs. */
+export function useRenderFuse(name: string, limit = 50, windowMs = 1000) {
+    const count = useRef(0);
+    const start = useRef(performance.now());
+    const now = performance.now();
+
+    if (now - start.current > windowMs) {
+        start.current = now;
+        count.current = 0;
+    }
+    if (++count.current > limit) {
+        // eslint-disable-next-line no-console
+        console.error(`[render-fuse] ${name} exceeded ${limit} renders/${windowMs}ms`);
+        throw new Error(`[render-fuse] ${name} render loop`);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable render fuse hook and ClientFuse wrapper to detect render loops
- wrap the root layout with the fuse while keeping existing providers
- introduce page-level error boundaries for the contacts and projects routes

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34fc39b54832996fd841613a5bb14