### PR TITLE
Fix gallery portal auth token loop

### DIFF
--- a/src/pages/gallery-portal/[galleryId].tsx
+++ b/src/pages/gallery-portal/[galleryId].tsx
@@ -118,17 +118,27 @@ const GalleryPortalPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>
         });
     }, [availableViews]);
 
+    const queryToken = React.useMemo(() => {
+        const rawToken = router.query.token;
+        if (Array.isArray(rawToken)) {
+            return rawToken[0] ?? null;
+        }
+
+        return typeof rawToken === 'string' ? rawToken : null;
+    }, [router.query.token]);
+
     React.useEffect(() => {
-        if (!gallery.portalSettings?.token) {
+        if (!gallery.portalSettings?.token || !queryToken) {
             return;
         }
 
-        const queryToken = Array.isArray(router.query.token) ? router.query.token[0] : router.query.token;
-        if (queryToken && safeCompare(queryToken, gallery.portalSettings.token)) {
-            setIsAuthenticated(true);
-            setErrorMessage(null);
+        if (!safeCompare(queryToken, gallery.portalSettings.token)) {
+            return;
         }
-    }, [router.query, gallery.portalSettings?.token]);
+
+        setIsAuthenticated((current) => (current ? current : true));
+        setErrorMessage((current) => (current === null ? current : null));
+    }, [gallery.portalSettings?.token, queryToken]);
 
     const handleCredentialSubmit = React.useCallback(
         (value: string) => {


### PR DESCRIPTION
## Summary
- derive the gallery portal token query parameter once and memoize it
- guard the authentication effect so it only updates state when the token truly matches
- clear any lingering error message without triggering an infinite render loop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d35e2a75ac83299a874c20ecc47a98