### PR TITLE
Disable client render fuse outside development

### DIFF
--- a/src/components/ClientFuse.tsx
+++ b/src/components/ClientFuse.tsx
@@ -3,8 +3,17 @@
 import { PropsWithChildren } from 'react';
 import { useRenderFuse } from '@/lib/useRenderFuse';
 
-/** Wraps children and trips if this subtree re-renders excessively. */
+/**
+ * Wraps children and trips if this subtree re-renders excessively.
+ *
+ * In production we skip the fuse entirely so runtime behaviour
+ * never changes for end users. The fuse is only meant to help
+ * developers catch feedback loops while working locally.
+ */
 export default function ClientFuse({ children }: PropsWithChildren) {
-    useRenderFuse('ClientFuse'); // name shows up in any loop error
+    if (process.env.NODE_ENV !== 'production') {
+        useRenderFuse('ClientFuse'); // name shows up in any loop error
+    }
+
     return <>{children}</>;
 }

--- a/src/lib/useRenderFuse.ts
+++ b/src/lib/useRenderFuse.ts
@@ -3,6 +3,10 @@ import { useRef } from 'react';
 
 /** Throws/logs if a component renders >limit times within windowMs. */
 export function useRenderFuse(name: string, limit = 50, windowMs = 1000) {
+    if (typeof performance === 'undefined') {
+        return;
+    }
+
     const count = useRef(0);
     const start = useRef(performance.now());
     const now = performance.now();


### PR DESCRIPTION
## Summary
- guard ClientFuse so render fuse only runs during development builds
- ensure render fuse hook safely exits when the browser performance API is unavailable

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d400174f0c832990d07e30815e85cd