### PR TITLE
Fix Next dev allowed origins for local development

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,13 +24,28 @@ if (supabaseAnonKey) {
     env.NEXT_PUBLIC_SUPABASE_ANON_KEY = supabaseAnonKey;
 }
 
+const defaultAllowedDevOrigins = [
+    '127.0.0.1',
+    '127.0.0.1:3000',
+    'localhost',
+    'localhost:3000',
+    '[::1]',
+    '[::1]:3000'
+];
+
 const nextConfig = {
     env,
     trailingSlash: true,
     reactStrictMode: true,
-    allowedDevOrigins: [
-        '192.168.1.84'
-    ]
+    // Allow the default local development hosts in addition to any
+    // explicitly configured LAN address so the dev server can service
+    // hot-module reloading and other /_next requests.
+    allowedDevOrigins: Array.from(
+        new Set([
+            ...defaultAllowedDevOrigins,
+            '192.168.1.84'
+        ])
+    )
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow default localhost origins so Next.js dev server can accept HMR/WebSocket requests from local development hosts
- keep the existing LAN address while de-duplicating the list of allowed origins

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40b3a984c8329badbd9240a244e6b